### PR TITLE
Render the live runtime paths in the system prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ bun run debug:prompt --origin cron         # just one
 bun run debug:prompt --origin channel --no-git-nudge
 ```
 
-`composeSystemPrompt` (`src/agent/index.ts`) is the right entry point if you're adding a new section. The cache-suffix contract (least-volatile first → identity → runtime → origin+role → git → memory → now) is enforced by both the helper and `scripts/dump-system-prompt.test.ts`. Reorder one without the other and CI fails. The trailing `## Now` block is pinned last to keep the cache prefix stable across sessions — don't move it.
+`composeSystemPrompt` (`src/agent/index.ts`) is the right entry point if you're adding a new section. The cache-suffix contract (least-volatile first → identity → runtime → runtime paths → origin+role → git → memory → now) is enforced by both the helper and `scripts/dump-system-prompt.test.ts`. Reorder one without the other and CI fails. The trailing `## Now` block is pinned last to keep the cache prefix stable across sessions — don't move it.
 
 Memory is injected per turn into the user prompt; the system prompt never contains long-term memory; vector memory is always on. The memory plugin's `session.turn.start` hook renders de-duplicated direct shards (under budget) or top-K hybrid-search results (over budget) into `event.retrievalContext.results`, which the four turn-drivers (server TUI, channel router, cron consumer, subagent runner) append to the user text.
 

--- a/scripts/dump-system-prompt.test.ts
+++ b/scripts/dump-system-prompt.test.ts
@@ -19,6 +19,7 @@ describe('dumpSystemPrompt', () => {
       expect(out).toContain('# Identity')
       expect(out).toContain('## Runtime')
       expect(out).toContain('TypeClaw runtime version: 1.2.3-debug.')
+      expect(out).toContain('## Runtime paths')
       expect(out).toContain('## Session origin')
       expect(out).toContain('## Your role in this session')
       expect(out).not.toContain('# Memory')
@@ -32,6 +33,7 @@ describe('dumpSystemPrompt', () => {
     const out = dumpSystemPrompt('subagent')
 
     expect(out).toContain('## Runtime')
+    expect(out).toContain('## Runtime paths')
     expect(out).toContain('## Session origin')
     expect(out).toContain('## Your role in this session')
     expect(out).not.toContain('## Now')
@@ -176,6 +178,7 @@ describe('dumpSystemPrompt', () => {
       'DEFAULT_SYSTEM_PROMPT (base)',
       'Identity (IDENTITY.md + SOUL.md)',
       'Runtime block',
+      'Runtime paths',
       'Session origin',
       'Role context',
       'Git nudge',
@@ -188,6 +191,7 @@ describe('dumpSystemPrompt', () => {
       'SLIM_SYSTEM_PROMPT (base)',
       'Identity (IDENTITY.md + SOUL.md)',
       'Runtime block',
+      'Runtime paths',
       'Session origin',
       'Role context',
     ])
@@ -195,7 +199,7 @@ describe('dumpSystemPrompt', () => {
 
   test('subagent breakdown reflects production override path: override + runtime + origin/role', () => {
     const names = dumpSystemPromptWithBreakdown('subagent').sections.map((s) => s.name)
-    expect(names).toEqual(['Subagent override prompt', 'Runtime block', 'Session origin + role'])
+    expect(names).toEqual(['Subagent override prompt', 'Runtime block', 'Runtime paths', 'Session origin + role'])
     expect(names).not.toContain('SLIM_SYSTEM_PROMPT (base)')
     expect(names).not.toContain('DEFAULT_SYSTEM_PROMPT (base)')
     expect(names).not.toContain('Identity (IDENTITY.md + SOUL.md)')
@@ -231,7 +235,8 @@ describe('dumpSystemPrompt', () => {
     const idx = (needle: string) => out.indexOf(needle)
 
     expect(idx('## IDENTITY.md')).toBeLessThan(idx('TypeClaw runtime version:'))
-    expect(idx('TypeClaw runtime version:')).toBeLessThan(idx('## Session origin'))
+    expect(idx('TypeClaw runtime version:')).toBeLessThan(idx('## Runtime paths'))
+    expect(idx('## Runtime paths')).toBeLessThan(idx('## Session origin'))
     expect(idx('## Session origin')).toBeLessThan(idx('## Your role in this session'))
     expect(idx('## Your role in this session')).toBeLessThan(idx('git reports 2 uncommitted files'))
   })
@@ -241,7 +246,8 @@ describe('dumpSystemPrompt', () => {
     const idx = (needle: string) => out.indexOf(needle)
 
     expect(idx('## IDENTITY.md')).toBeLessThan(idx('TypeClaw runtime version:'))
-    expect(idx('TypeClaw runtime version:')).toBeLessThan(idx('You are running an unattended cron job.'))
+    expect(idx('TypeClaw runtime version:')).toBeLessThan(idx('## Runtime paths'))
+    expect(idx('## Runtime paths')).toBeLessThan(idx('You are running an unattended cron job.'))
     expect(idx('You are running an unattended cron job.')).toBeLessThan(idx('## Your role in this session'))
   })
 

--- a/scripts/dump-system-prompt.ts
+++ b/scripts/dump-system-prompt.ts
@@ -4,11 +4,17 @@ import { parseArgs } from 'node:util'
 
 import { composeSystemPrompt, deriveSystemPromptMode, renderTurnTimeAnchor, type SystemPromptMode } from '@/agent'
 import type { SessionOrigin, SessionRoleContext } from '@/agent/session-origin'
+import { renderRuntimePathsBlock, type RuntimePaths } from '@/agent/system-prompt'
 
 type OriginKind = 'tui' | 'cron' | 'channel' | 'subagent'
 const ALL_KINDS: readonly OriginKind[] = ['tui', 'cron', 'channel', 'subagent'] as const
 
 const PLACEHOLDER_RUNTIME_VERSION = '1.2.3-debug'
+const PLACEHOLDER_RUNTIME_PATHS: RuntimePaths = {
+  agentDir: '/agent',
+  homeDir: '/home/agent',
+  agentMessengerConfigDir: '/agent/workspace/.config/agent-messenger',
+}
 
 // Fixed wall-clock for the per-turn `<current-time>` anchor. The dumper
 // needs a deterministic timestamp so successive runs produce byte-identical
@@ -188,7 +194,7 @@ export function dumpSystemPromptWithBreakdown(
 // (and the plugin-subagent path in run/index.ts), both of which set
 // `systemPromptOverride: subagent.systemPrompt`. That routes through
 // `createOverrideResourceLoader`, which emits only:
-//   <override string> + runtime block + origin (with role)
+//   <override string> + runtime block + runtime paths + origin (with role)
 // No DEFAULT/SLIM base, no IDENTITY/SOUL, no git-nudge.
 //
 // Without this branch, the dumper would report a misleadingly large slim
@@ -197,12 +203,14 @@ export function dumpSystemPromptWithBreakdown(
 function dumpSubagentOverridePrompt(): DumpResult {
   const fixture = buildFixture('subagent')
   const runtimeBlock = `## Runtime\n\nTypeClaw runtime version: ${PLACEHOLDER_RUNTIME_VERSION}.`
+  const runtimePathsBlock = renderRuntimePathsBlock(PLACEHOLDER_RUNTIME_PATHS)
   const originBlock = `## Session origin\n\nYou are a \`${(fixture.origin as { subagent: string }).subagent}\` subagent spawned by parent session\n\`${(fixture.origin as { parentSessionId: string }).parentSessionId}\`. Stay narrowly within the task you were given.\nReturn cleanly when done; do not sprawl into unrelated work.\n\n## Your role in this session\n\nRole: \`${fixture.roleContext.role}\`. Permissions: ${fixture.roleContext.permissions.map((p) => `\`${p}\``).join(', ')}.\n\nThis is the role the runtime resolved at session creation. Tool calls\nand channel admission are gated by these permissions; a \`blocked:\` or\n"denied by permissions" message means the current actor lacks the\npermission the guard was looking for. See the \`typeclaw-permissions\`\nskill for what each role can do and how to grant access.`
 
-  const prompt = `${PLACEHOLDER_SUBAGENT_OVERRIDE}\n\n${runtimeBlock}\n\n${originBlock}`
+  const prompt = `${PLACEHOLDER_SUBAGENT_OVERRIDE}\n\n${runtimeBlock}\n\n${runtimePathsBlock}\n\n${originBlock}`
   const sections: SectionBreakdown[] = [
     mkSection('Subagent override prompt', PLACEHOLDER_SUBAGENT_OVERRIDE),
     mkSection('Runtime block', runtimeBlock),
+    mkSection('Runtime paths', runtimePathsBlock),
     mkSection('Session origin + role', originBlock),
   ]
   return {
@@ -222,6 +230,7 @@ function dumpDefaultLoaderPrompt(kind: Exclude<OriginKind, 'subagent'>, options:
     mode,
     self: PLACEHOLDER_SELF,
     runtimeVersion: PLACEHOLDER_RUNTIME_VERSION,
+    runtimePaths: PLACEHOLDER_RUNTIME_PATHS,
     origin: fixture.origin,
     roleContext: fixture.roleContext,
     gitNudge: wantGitNudge ? PLACEHOLDER_GIT_NUDGE : '',
@@ -236,6 +245,7 @@ function dumpDefaultLoaderPrompt(kind: Exclude<OriginKind, 'subagent'>, options:
     mkSection(baseLabel, base),
     mkSection('Identity (IDENTITY.md + SOUL.md)', parts.self),
     mkSection('Runtime block', `## Runtime\n\nTypeClaw runtime version: ${parts.runtimeVersion}.`),
+    mkSection('Runtime paths', renderRuntimePathsBlock(parts.runtimePaths)),
     mkSection('Session origin', extractSection(prompt, '## Session origin', '## Your role in this session')),
     mkSection(
       'Role context',

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 
 import { defineTool as definePiTool, SessionManager } from '@mariozechner/pi-coding-agent'
 import { Type } from 'typebox'
@@ -68,12 +68,16 @@ function silentLogger() {
 }
 
 let agentDir: string
+let savedAgentMessengerConfigDir: string | undefined
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-agent-'))
+  savedAgentMessengerConfigDir = process.env.AGENT_MESSENGER_CONFIG_DIR
 })
 
 afterEach(async () => {
+  if (savedAgentMessengerConfigDir === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+  else process.env.AGENT_MESSENGER_CONFIG_DIR = savedAgentMessengerConfigDir
   await rm(agentDir, { recursive: true, force: true })
 })
 
@@ -247,8 +251,9 @@ describe('createResourceLoader', () => {
 
     // then
     const prompt = loader.getSystemPrompt() ?? ''
-    expect(prompt).not.toContain('## Runtime')
+    expect(prompt).not.toContain('## Runtime\n')
     expect(prompt).not.toContain('TypeClaw runtime version')
+    expect(prompt).toContain('## Runtime paths')
   })
 
   test('renders the runtime block under "## Runtime" when runtimeVersion is provided', async () => {
@@ -278,6 +283,50 @@ describe('createResourceLoader', () => {
     expect(runtimeIdx).toBeGreaterThan(-1)
     expect(originIdx).toBeGreaterThan(-1)
     expect(runtimeIdx).toBeLessThan(originIdx)
+  })
+
+  test('honors the live AGENT_MESSENGER_CONFIG_DIR override', async () => {
+    // given
+    process.env.AGENT_MESSENGER_CONFIG_DIR = '/runtime/config/agent-messenger'
+
+    // when
+    const loader = await createResourceLoader({ agentDir })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain(`- Agent folder: \`${agentDir}\``)
+    expect(prompt).toContain('- `AGENT_MESSENGER_CONFIG_DIR`: `/runtime/config/agent-messenger`')
+  })
+
+  test.each([
+    ['absent', undefined],
+    ['empty', ''],
+  ] as const)('falls back to HOME when AGENT_MESSENGER_CONFIG_DIR is %s', async (_name, value) => {
+    // given
+    if (value === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+    else process.env.AGENT_MESSENGER_CONFIG_DIR = value
+
+    // when
+    const loader = await createResourceLoader({ agentDir })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain(`- Runtime process \`HOME\`: \`${homedir()}\` (tool sandboxes may differ)`)
+    expect(prompt).toContain(`- \`AGENT_MESSENGER_CONFIG_DIR\`: \`${join(homedir(), '.config', 'agent-messenger')}\``)
+  })
+
+  test('normalizes a relative AGENT_MESSENGER_CONFIG_DIR against the process cwd', async () => {
+    // given
+    process.env.AGENT_MESSENGER_CONFIG_DIR = 'workspace/.config/agent-messenger'
+
+    // when
+    const loader = await createResourceLoader({ agentDir })
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain(
+      `- \`AGENT_MESSENGER_CONFIG_DIR\`: \`${resolve(process.cwd(), 'workspace/.config/agent-messenger')}\``,
+    )
   })
 
   test('full cache-suffix ordering: role block < gitNudge', async () => {
@@ -1029,6 +1078,24 @@ describe('composeSystemPrompt slim mode', () => {
 })
 
 describe('composeSystemPrompt branding', () => {
+  test.each([true, false])('includes runtime paths when branding is %s', (branding) => {
+    // given / when
+    const prompt = composeSystemPrompt({
+      branding,
+      self: '# Identity\n\nfoo',
+      runtimePaths: {
+        agentDir: '/agent',
+        homeDir: '/home/agent',
+        agentMessengerConfigDir: '/agent/workspace/.config/agent-messenger',
+      },
+      gitNudge: '',
+    })
+
+    // then
+    expect(prompt).toContain('## Runtime paths')
+    expect(prompt).toContain('- Agent folder: `/agent`')
+  })
+
   test('branding off drops the runtime block and every TypeClaw clue (full mode)', () => {
     const prompt = composeSystemPrompt({
       branding: false,
@@ -1115,6 +1182,20 @@ describe('createOverrideResourceLoader', () => {
     const prompt = loader.getSystemPrompt() ?? ''
     expect(prompt).toContain('## Runtime')
     expect(prompt).toContain('TypeClaw runtime version: 9.9.9.')
+  })
+
+  test('appends runtime paths to the production subagent override prompt', async () => {
+    // given
+    process.env.AGENT_MESSENGER_CONFIG_DIR = '/agent/workspace/.config/agent-messenger'
+
+    // when
+    const loader = await createOverrideResourceLoader('SUBAGENT PROMPT')
+
+    // then
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).toContain('## Runtime paths')
+    expect(prompt).toContain(`- Agent folder: \`${process.cwd()}\``)
+    expect(prompt).toContain('- `AGENT_MESSENGER_CONFIG_DIR`: `/agent/workspace/.config/agent-messenger`')
   })
 })
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import {
@@ -67,7 +68,9 @@ import {
   DEFAULT_SUBAGENT_ROSTER,
   renderRuntimeBlock,
   renderRuntimeNondisclosureRule,
+  renderRuntimePathsBlock,
   stripRuntimeIdentityProse,
+  type RuntimePaths,
 } from './system-prompt'
 import { attachToolNotFoundNudge } from './tool-not-found-nudge'
 import { createBudgetState, type ToolResultBudget, wrapToolDefinitionWithBudget } from './tool-result-budget'
@@ -986,7 +989,8 @@ export async function createOverrideResourceLoader(
       ? `${systemPrompt}\n\n${renderRuntimeBlock(runtimeVersion)}`
       : systemPrompt
     : `${stripRuntimeIdentityProse(systemPrompt)}\n\n${renderRuntimeNondisclosureRule()}`
-  const finalPrompt = withOrigin(withRuntime, origin, permissions)
+  const withRuntimePaths = `${withRuntime}\n\n${renderRuntimePathsBlock(resolveRuntimePaths(process.cwd()))}`
+  const finalPrompt = withOrigin(withRuntimePaths, origin, permissions)
   const loader = new DefaultResourceLoader({
     cwd: process.cwd(),
     agentDir: process.cwd(),
@@ -1080,6 +1084,7 @@ export type SystemPromptComposition = {
   // Falls back to `DEFAULT_SUBAGENT_ROSTER` when omitted.
   subagentRoster?: string
   runtimeVersion?: string
+  runtimePaths?: RuntimePaths
   origin?: SessionOrigin
   roleContext?: SessionRoleContext
   mcpCatalog?: string
@@ -1096,11 +1101,12 @@ export type SystemPromptComposition = {
 // that differs).
 //
 // 0. runtime block — most stable: only changes on typeclaw releases (rare).
-// 1. origin block — stable across all sessions of the same kind.
-// 2. gitNudge — rare changes; agent folders force-commit sessions/ and
+// 1. runtime paths — stable for the current container boot.
+// 2. origin block — stable across all sessions of the same kind.
+// 3. gitNudge — rare changes; agent folders force-commit sessions/ and
 //    memory/ after every turn, so the dirty-files list is empty most of
 //    the time.
-// 3. proactive next-step nudge — deterministic per model family.
+// 4. proactive next-step nudge — deterministic per model family.
 //
 // The wall-clock anchor that used to live here as `## Now` moved out
 // entirely. It is now injected into the user turn at each `session.prompt`
@@ -1121,6 +1127,9 @@ export function composeSystemPrompt(parts: SystemPromptComposition): string {
   }
   if (!branding) {
     prompt = `${prompt}\n\n${renderRuntimeNondisclosureRule()}`
+  }
+  if (parts.runtimePaths !== undefined) {
+    prompt = `${prompt}\n\n${renderRuntimePathsBlock(parts.runtimePaths)}`
   }
   if (parts.origin !== undefined) {
     prompt = `${prompt}\n\n${renderSessionOrigin(parts.origin, Date.now(), parts.roleContext)}`
@@ -1223,6 +1232,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
     self,
     subagentRoster,
     ...(options.runtimeVersion !== undefined ? { runtimeVersion: options.runtimeVersion } : {}),
+    runtimePaths: resolveRuntimePaths(agentDir),
     ...(options.origin !== undefined ? { origin: options.origin } : {}),
     ...(roleContext !== undefined ? { roleContext } : {}),
     ...(mcpCatalog !== undefined ? { mcpCatalog } : {}),
@@ -1268,6 +1278,18 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   })
   await loader.reload()
   return loader
+}
+
+function resolveRuntimePaths(agentDir: string): RuntimePaths {
+  const homeDir = homedir()
+  const configuredAgentMessengerDir = process.env.AGENT_MESSENGER_CONFIG_DIR
+  const agentMessengerConfigDir =
+    configuredAgentMessengerDir !== undefined && configuredAgentMessengerDir !== ''
+      ? isAbsolute(configuredAgentMessengerDir)
+        ? configuredAgentMessengerDir
+        : resolve(process.cwd(), configuredAgentMessengerDir)
+      : join(homeDir, '.config', 'agent-messenger')
+  return { agentDir, homeDir, agentMessengerConfigDir }
 }
 
 function withOrigin(

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -8,11 +8,34 @@ import {
   DEFAULT_SUBAGENT_ROSTER,
   DEFAULT_SYSTEM_PROMPT,
   renderRuntimeNondisclosureRule,
+  renderRuntimePathsBlock,
   renderTurnRoleAnchor,
   renderTurnTimeAnchor,
   SLIM_SYSTEM_PROMPT,
   stripRuntimeIdentityProse,
 } from './system-prompt'
+
+describe('renderRuntimePathsBlock', () => {
+  test('renders the three live runtime paths as inline code', () => {
+    // given
+    const paths = {
+      agentDir: '/agent',
+      homeDir: '/home/agent',
+      agentMessengerConfigDir: '/agent/workspace/.config/agent-messenger',
+    }
+
+    // when
+    const block = renderRuntimePathsBlock(paths)
+
+    // then
+    expect(block).toBe(`## Runtime paths
+
+Current for this container boot; prefer these over remembered paths:
+- Agent folder: \`/agent\`
+- Runtime process \`HOME\`: \`/home/agent\` (tool sandboxes may differ)
+- \`AGENT_MESSENGER_CONFIG_DIR\`: \`/agent/workspace/.config/agent-messenger\``)
+  })
+})
 
 describe('subagent orchestration — explicit research routing', () => {
   // Guards the regression where an explicit "do a research" directive was answered

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -184,6 +184,27 @@ export function renderRuntimeBlock(version: string): string {
 TypeClaw runtime version: ${version}.`
 }
 
+export type RuntimePaths = {
+  agentDir: string
+  homeDir: string
+  agentMessengerConfigDir: string
+}
+
+// These values must come from the running process on every boot, not from
+// intended container constants. A memory shard retained
+// `/root/.config/agent-messenger/MEMORY.md` across the 0.46.2/0.47.0 HOME and
+// config-directory moves, then outranked the changed infrastructure because it
+// was never re-observed. The regenerated system prompt gives the model an
+// authoritative source that stays fresh when runtime wiring changes again.
+export function renderRuntimePathsBlock(paths: RuntimePaths): string {
+  return `## Runtime paths
+
+Current for this container boot; prefer these over remembered paths:
+- Agent folder: \`${paths.agentDir}\`
+- Runtime process \`HOME\`: \`${paths.homeDir}\` (tool sandboxes may differ)
+- \`AGENT_MESSENGER_CONFIG_DIR\`: \`${paths.agentMessengerConfigDir}\``
+}
+
 // Appended to the system prompt ONLY when `config.branding` is false. Branding
 // off rephrases the opening and drops the version block, but the literal
 // "typeclaw" still reaches the model through functional tokens it can't lose


### PR DESCRIPTION
## Background

An agent in production memorized the absolute path `/root/.config/agent-messenger/MEMORY.md`. That was **correct** when it learned it. Releases 0.46.2/0.47.0 moved the runtime `HOME` to `/home/agent` and the agent-messenger config to `workspace/.config/agent-messenger`, and the memorized value silently rotted.

The memory shard was last reinforced five days *before* that move, with 17 citations. It was never re-observed afterwards, because the job that would have exercised it early-exits on most runs. So a belief that was true 17 times decayed into a high-confidence falsehood — and the strength model reads those citations as authority, not staleness.

The consequence was not academic. The agent produced a wrong self-diagnosis from that shard (blaming credential masking in a subprocess that is not masked) and posted a degraded message to a user-facing channel.

The structural gap: **the model has no authoritative, always-fresh source for these paths**, so it memorizes resolved absolute values, which rot on every infra change. The system prompt is recomposed every turn, so putting the live values there deterministically outranks a stale shard.

## Summary

One new `## Runtime paths` block, ~64 tokens, three values:

```
## Runtime paths

Current for this container boot; prefer these over remembered paths:
- Agent folder: `/agent`
- Runtime process `HOME`: `/home/agent` (tool sandboxes may differ)
- `AGENT_MESSENGER_CONFIG_DIR`: `/agent/workspace/.config/agent-messenger`
```

**Why live values and not the container constants.** A prompt that states a path with authority has to be right. An operator can override `AGENT_MESSENGER_CONFIG_DIR`, and startup wiring can regress. Rendering `CONTAINER_RUNTIME_HOME` would mean confidently printing the *intended* path rather than the real one — which is precisely the failure mode this PR exists to prevent. So the block reports `os.homedir()` and the live env var, with relative values normalized against cwd and a documented fallback.

**Why branding-independent.** `renderRuntimeBlock` is gated on `branding: true`. Gating paths the same way would deny them to exactly the agents that still need them for real work. A filesystem path is an operational fact, not agent identity, and the existing nondisclosure rule already tells the model that config filenames and CLI names are implementation details to use but not surface as identity. So this is a separate block, emitted in both modes.

**Why slim/cron and subagent too.** The confirmed failure happened on a **cron** turn, which takes the slim path. Excluding slim to save ~64 tokens would preserve the exact bug class this fixes. Cron stays at ~771 tokens, subagent ~340 — both well inside the existing guards.

**Placement.** These values are boot-stable, so the block sits in the cacheable prefix — after the branding-dependent runtime/disclosure block, before session origin. `AGENTS.md` and `scripts/dump-system-prompt.test.ts` are updated together, since the contract only holds if both move.

## What this does NOT do

- Does not add per-tool config dirs (OPENSOMA, GWS, …), credential file paths, host paths, or an env dump. The bar for a permanent per-turn slot: runtime-owned, boot-stable, routinely needed, and not reliably inferable from inside a tool sandbox. Exactly three values clear it. Tool-specific paths belong in that tool's skill.
- Does not restate the `workspace/` / `public/` write-zone guidance — the prompt already says it.
- Does not touch the trailing `## Now` pinning or reorder any other section.
- Does not attempt to invalidate stale memory shards. That is a much larger problem (classifying arbitrary prose as environment-dependent) and this block sidesteps it by making the authoritative value always present.

## Review notes

The load-bearing decision is **live resolution over constants** (`resolveRuntimePaths` in `src/agent/index.ts`). If a future change swaps in `CONTAINER_RUNTIME_HOME` "for consistency", the block starts asserting a path that may not exist in the running process, and a wrong authoritative path is worse than none.

Second: the block is branding-independent *on purpose*. It is not an oversight that it sits outside the `branding` conditional.

Worth verifying: tests cover the env override, the empty-env fallback, relative-path normalization, both branding modes, and presence in cron + subagent prompts — so it proves "live effective value" rather than just today's canonical deployment.

Design reviewed against the alternatives (a resolver tool the model calls on demand; memory-shard invalidation; fixing one agent's `AGENTS.md`). The prompt block is the only one that is global, deterministic, and does not depend on the model choosing to distrust its own memory first.