### PR TITLE
Add Upstage Solar Pro 4 and fix Solar Open 2 reasoning

### DIFF
--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -186,7 +186,7 @@ describe('KNOWN_PROVIDERS', () => {
 
   test('upstage ships the Solar chat lineup plus the open-weight solar-open2, text-only, syn-pro omitted', () => {
     const models = KNOWN_PROVIDERS.upstage.models
-    expect(Object.keys(models)).toEqual(['solar-open2', 'solar-pro3', 'solar-pro2', 'solar-mini'])
+    expect(Object.keys(models)).toEqual(['solar-pro4', 'solar-open2', 'solar-pro3', 'solar-pro2', 'solar-mini'])
     expect(Object.keys(models)).not.toContain('syn-pro')
     for (const [modelId, model] of Object.entries(models)) {
       expect((model.input as ReadonlyArray<string>).includes('image'), `upstage/${modelId} should be text-only`).toBe(
@@ -224,7 +224,8 @@ describe('KNOWN_PROVIDERS', () => {
     const models = KNOWN_PROVIDERS.upstage.models
     const compatFor = (id: keyof typeof models) =>
       (models[id] as { compat?: { supportsReasoningEffort?: boolean } }).compat
-    // solar-pro3/pro2 and the solar-open2 template document reasoning_effort; solar-mini ignores it.
+    // solar-pro4/pro3/pro2 and the solar-open2 template document reasoning_effort; solar-mini ignores it.
+    expect(compatFor('solar-pro4')!.supportsReasoningEffort).toBe(true)
     expect(compatFor('solar-open2')!.supportsReasoningEffort).toBe(true)
     expect(compatFor('solar-pro3')!.supportsReasoningEffort).toBe(true)
     expect(compatFor('solar-pro2')!.supportsReasoningEffort).toBe(true)
@@ -232,19 +233,48 @@ describe('KNOWN_PROVIDERS', () => {
     expect(models['solar-mini']!.reasoning, 'solar-mini does not reason').toBe(false)
   })
 
-  test('reasoning upstage models clamp pi\u2019s xhigh to Upstage\u2019s documented reasoning_effort=high', () => {
+  test('the reasoning-off-by-default models clamp pi\u2019s xhigh to their documented max reasoning_effort=high', () => {
     const models = KNOWN_PROVIDERS.upstage.models
-    for (const id of ['solar-open2', 'solar-pro3', 'solar-pro2'] as const) {
+    for (const id of ['solar-pro3', 'solar-pro2'] as const) {
       const map = (models[id] as { thinkingLevelMap?: Record<string, string | null> }).thinkingLevelMap
       expect(map, `upstage/${id} missing thinkingLevelMap`).toBeDefined()
-      // Upstage documents minimal/low/medium/high only; xhigh must not leak through.
+      // These two only accept medium/high as reasoning-on; xhigh must not leak through
+      // and minimal/low would disable reasoning, so pi's enabled levels floor at medium.
       expect(map!.xhigh, `upstage/${id} must clamp xhigh -> high`).toBe('high')
       expect(map!.off, `upstage/${id} must omit reasoning_effort when off`).toBeNull()
+      expect(map!.minimal, `upstage/${id} must floor minimal at medium`).toBe('medium')
+      expect(map!.low, `upstage/${id} must floor low at medium`).toBe('medium')
     }
     expect(
       (models['solar-mini'] as { thinkingLevelMap?: unknown }).thinkingLevelMap,
       'solar-mini needs no map (never sends reasoning_effort)',
     ).toBeUndefined()
+  })
+
+  test('the reasoning-on-by-default models pass xhigh through natively instead of clamping it', () => {
+    for (const id of ['solar-pro4', 'solar-open2'] as const) {
+      const map = (KNOWN_PROVIDERS.upstage.models[id] as { thinkingLevelMap?: Record<string, string | null> })
+        .thinkingLevelMap
+      expect(map, `upstage/${id} missing thinkingLevelMap`).toBeDefined()
+      expect(map!.xhigh, `upstage/${id} documents xhigh, so it must not be clamped to high`).toBe('xhigh')
+      // Upstage's `minimal` disables reasoning, so pi's enabled `minimal` floors at `low`.
+      expect(map!.minimal, `upstage/${id} must floor minimal at the lowest reasoning-on level`).toBe('low')
+      for (const level of ['low', 'medium', 'high'] as const) {
+        expect(map![level], `upstage/${id} level ${level} must pass through unchanged`).toBe(level)
+      }
+    }
+  })
+
+  test('the reasoning-on-by-default models disable reasoning with an explicit none, not by omission', () => {
+    // Upstage documents pro4 and open2 as reasoning when reasoning_effort is
+    // omitted, with `none` as the off switch — inverted from pro3/pro2, where off
+    // is null so pi-ai omits the field. A null here would silently reason on
+    // every turn, which is a latency and billing bug rather than a hard failure.
+    for (const id of ['solar-pro4', 'solar-open2'] as const) {
+      const map = (KNOWN_PROVIDERS.upstage.models[id] as { thinkingLevelMap?: Record<string, string | null> })
+        .thinkingLevelMap
+      expect(map!.off, `upstage/${id} must send reasoning_effort=none to turn reasoning off`).toBe('none')
+    }
   })
 
   test('anthropic supports both api-key and oauth on the same provider id', () => {
@@ -551,6 +581,7 @@ describe('listKnownModelRefs', () => {
 
   test('includes upstage Solar model refs', () => {
     const refs = listKnownModelRefs()
+    expect(refs).toContain('upstage/solar-pro4')
     expect(refs).toContain('upstage/solar-open2')
     expect(refs).toContain('upstage/solar-pro3')
     expect(refs).toContain('upstage/solar-pro2')

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -781,10 +781,14 @@ export const KNOWN_PROVIDERS = {
   // the console, the OpenAI-SDK example, and the agent docs all use bare `/v1`.
   //
   // Model lineup spans two families on the same Console API + key:
-  //   * Closed chat models from the official agent API reference
-  //     (console.upstage.ai/api/docs/for-agents) as of 2026-03-23:
-  //     solar-pro3 (102B MoE / 12B active, 128K, flagship), solar-pro2
-  //     (31B, 65K), solar-mini (10.7B, 32K, cheap/fast).
+  //   * Closed chat models. solar-pro4 (512K context / 128K output, released
+  //     2026-08-06, current flagship) is per the live model page
+  //     console.upstage.ai/docs/models/solar-pro4; the rest are from the agent
+  //     API reference (console.upstage.ai/api/docs/for-agents) as of
+  //     2026-03-23: solar-pro3 (102B MoE / 12B active, 128K), solar-pro2
+  //     (31B, 65K), solar-mini (10.7B, 32K, cheap/fast). Note that the
+  //     for-agents dump is stale (self-dated 2026-03-07) and omits pro4 — its
+  //     absence there is not evidence the model is unavailable.
   //   * The open-weight Solar Open family: solar-open2 (Solar Open 2), a 102B
   //     MoE / 12B active model with a 128K context. It launched on the Console
   //     API for the Solar Agent Partner program (Stage 1, from 2026-07-17) —
@@ -799,6 +803,7 @@ export const KNOWN_PROVIDERS = {
   // versioned release.
   //
   // Costs are USD per 1M tokens from upstage.ai/pricing/api (VAT-exclusive).
+  // solar-pro4 is $0.30 in / $1.20 out with a $0.06 "Input(Cached)" rate.
   // solar-pro3/pro2 publish an "Input(Cached)" cache-read rate ($0.015); no
   // cache-write surcharge is published, so cacheWrite is 0. solar-mini
   // publishes a single flat $0.15 rate with no cache line, so cacheRead and
@@ -819,18 +824,37 @@ export const KNOWN_PROVIDERS = {
   // definitions are both undocumented, so supportsUsageInStreaming and
   // supportsStrictMode are false (both conservative — pi-ai defaults them to
   // true, and Upstage only documents `strict` inside response_format.json_schema,
-  // never on tool defs). `reasoning_effort` IS documented for solar-pro3/pro2
-  // (and the solar-open2 chat template), so supportsReasoningEffort stays true
-  // there; solar-mini ignores it, so it is false and reasoning is off.
+  // never on tool defs). `reasoning_effort` IS documented for solar-pro4,
+  // solar-open2, solar-pro3 and solar-pro2, so supportsReasoningEffort stays
+  // true there; solar-mini rejects it, so it is false and reasoning is off.
   //
-  // Upstage documents reasoning_effort values minimal/low/medium/high only. pi
-  // adds an `xhigh` level that typeclaw's attention escalation can select
-  // (src/agent/attention-escalation.ts), and pi-ai passes the pi level straight
-  // through as reasoning_effort when no map is set — which would send the
-  // unsupported `xhigh`. `thinkingLevelMap` clamps xhigh -> high (and maps off ->
-  // null so nothing is sent) on the reasoning models so every emitted
-  // reasoning_effort is a value Upstage accepts. solar-mini needs no map (it
-  // never sends reasoning_effort).
+  // Reasoning splits the lineup into two groups with OPPOSITE defaults, per
+  // Upstage's reasoning table (console.upstage.ai/docs/capabilities/generate/
+  // reasoning). pi adds an `xhigh` level that typeclaw's attention escalation
+  // can select (src/agent/attention-escalation.ts), and pi-ai passes the pi
+  // level straight through as reasoning_effort when no map is set, so each
+  // group needs a different `thinkingLevelMap`:
+  //
+  //   * solar-pro4 and solar-open2 — omitted reasoning_effort means reasoning
+  //     is ON; `none`/`minimal` turn it OFF; low/medium/high/xhigh/max turn it
+  //     on. So `off` maps to the string 'none', NOT null: pi-ai emits a string
+  //     off value verbatim and omits the field only when it is null, and
+  //     omitting it here would silently leave reasoning enabled (and billed) on
+  //     every non-reasoning turn. `xhigh` is documented, so it passes through
+  //     unclamped. Upstage's `max` sits above xhigh, but pi has no level above
+  //     xhigh to reach it, so `max` is intentionally unreachable.
+  //   * solar-pro3 and solar-pro2 — omitted means reasoning is OFF, `minimal`
+  //     and `low` ALSO turn it off, and only `medium`/`high` turn it on. So
+  //     `off` maps to null (nothing sent) and xhigh clamps to high.
+  //
+  // Note the trap in both rows: Upstage's `minimal` is an OFF value, but pi's
+  // `minimal` is an enabled level meaning "reason a little". Forwarding it
+  // verbatim would silently disable reasoning on a request that asked for it.
+  // Each group therefore floors pi's enabled levels at its own lowest
+  // reasoning-ON value — `low` for pro4/open2, `medium` for pro3/pro2 (which is
+  // why pi's `low` also maps to `medium` there). Every level pi can select thus
+  // emits a value Upstage treats as reasoning-on. solar-mini needs no map: it
+  // does not accept reasoning_effort at all (any value returns HTTP 400).
   upstage: {
     id: 'upstage',
     name: 'Upstage (Solar)',
@@ -839,6 +863,35 @@ export const KNOWN_PROVIDERS = {
     apiKeyEnv: 'UPSTAGE_API_KEY',
     oauthProviderId: null,
     models: {
+      'solar-pro4': {
+        id: 'solar-pro4',
+        name: 'Solar Pro 4',
+        api: 'openai-completions',
+        provider: 'upstage',
+        baseUrl: 'https://api.upstage.ai/v1',
+        reasoning: true,
+        // pro4 and open2 reason by DEFAULT — see the reasoning-group note above.
+        thinkingLevelMap: {
+          off: 'none',
+          minimal: 'low',
+          low: 'low',
+          medium: 'medium',
+          high: 'high',
+          xhigh: 'xhigh',
+        },
+        input: ['text'],
+        cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
+        contextWindow: 524288,
+        maxTokens: 131072,
+        compat: {
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          supportsUsageInStreaming: false,
+          supportsStrictMode: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
       'solar-open2': {
         id: 'solar-open2',
         name: 'Solar Open 2',
@@ -846,7 +899,14 @@ export const KNOWN_PROVIDERS = {
         provider: 'upstage',
         baseUrl: 'https://api.upstage.ai/v1',
         reasoning: true,
-        thinkingLevelMap: { off: null, minimal: 'minimal', low: 'low', medium: 'medium', high: 'high', xhigh: 'high' },
+        thinkingLevelMap: {
+          off: 'none',
+          minimal: 'low',
+          low: 'low',
+          medium: 'medium',
+          high: 'high',
+          xhigh: 'xhigh',
+        },
         input: ['text'],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 128000,
@@ -867,7 +927,14 @@ export const KNOWN_PROVIDERS = {
         provider: 'upstage',
         baseUrl: 'https://api.upstage.ai/v1',
         reasoning: true,
-        thinkingLevelMap: { off: null, minimal: 'minimal', low: 'low', medium: 'medium', high: 'high', xhigh: 'high' },
+        thinkingLevelMap: {
+          off: null,
+          minimal: 'medium',
+          low: 'medium',
+          medium: 'medium',
+          high: 'high',
+          xhigh: 'high',
+        },
         input: ['text'],
         cost: { input: 0.15, output: 0.6, cacheRead: 0.015, cacheWrite: 0 },
         contextWindow: 128000,
@@ -888,7 +955,14 @@ export const KNOWN_PROVIDERS = {
         provider: 'upstage',
         baseUrl: 'https://api.upstage.ai/v1',
         reasoning: true,
-        thinkingLevelMap: { off: null, minimal: 'minimal', low: 'low', medium: 'medium', high: 'high', xhigh: 'high' },
+        thinkingLevelMap: {
+          off: null,
+          minimal: 'medium',
+          low: 'medium',
+          medium: 'medium',
+          high: 'high',
+          xhigh: 'high',
+        },
         input: ['text'],
         cost: { input: 0.15, output: 0.6, cacheRead: 0.015, cacheWrite: 0 },
         contextWindow: 65000,

--- a/src/config/upstage-payload.test.ts
+++ b/src/config/upstage-payload.test.ts
@@ -52,7 +52,11 @@ async function buildUpstagePayload(
   return captured
 }
 
-const REASONING_MODEL_IDS = ['solar-open2', 'solar-pro3', 'solar-pro2'] as const
+// Upstage splits these into two groups with opposite defaults: pro4/open2 reason
+// unless sent `none`, while pro3/pro2 stay off unless asked and top out at `high`.
+const REASONS_BY_DEFAULT_MODEL_IDS = ['solar-pro4', 'solar-open2'] as const
+const XHIGH_CLAMPED_MODEL_IDS = ['solar-pro3', 'solar-pro2'] as const
+const REASONING_MODEL_IDS = [...REASONS_BY_DEFAULT_MODEL_IDS, ...XHIGH_CLAMPED_MODEL_IDS] as const
 
 describe('upstage openai-completions payload', () => {
   test('uses max_tokens (never max_completion_tokens) for every model', async () => {
@@ -90,21 +94,73 @@ describe('upstage openai-completions payload', () => {
     }
   })
 
-  test('clamps the reasoning models\u2019 xhigh level to Upstage\u2019s max reasoning_effort=high', async () => {
-    for (const modelId of REASONING_MODEL_IDS) {
+  test('clamps the pre-pro4 reasoning models\u2019 xhigh level to Upstage\u2019s max reasoning_effort=high', async () => {
+    for (const modelId of XHIGH_CLAMPED_MODEL_IDS) {
       const model = KNOWN_PROVIDERS.upstage.models[modelId] as Model<'openai-completions'>
       const payload = await buildUpstagePayload(model, 'xhigh')
       expect(payload.reasoning_effort, `upstage/${modelId} must clamp xhigh -> high`).toBe('high')
     }
   })
 
-  test('passes documented reasoning_effort levels through unchanged on reasoning models', async () => {
+  // Upstage's `minimal` (and, on pro3/pro2, `low`) are documented as values that
+  // turn reasoning OFF, while pi's `minimal`/`low` are enabled levels. Forwarding
+  // them verbatim would disable reasoning on a request that asked for it, so every
+  // level pi can select must emit a value in that model's reasoning-ON set.
+  const REASONING_ON_VALUES: Record<string, ReadonlyArray<string>> = {
+    'solar-pro4': ['low', 'medium', 'high', 'xhigh'],
+    'solar-open2': ['low', 'medium', 'high', 'xhigh'],
+    'solar-pro3': ['medium', 'high'],
+    'solar-pro2': ['medium', 'high'],
+  }
+
+  test('every pi reasoning level emits a value Upstage treats as reasoning-on', async () => {
     for (const modelId of REASONING_MODEL_IDS) {
       const model = KNOWN_PROVIDERS.upstage.models[modelId] as Model<'openai-completions'>
-      for (const level of ['minimal', 'low', 'medium', 'high'] as const) {
+      const onValues = REASONING_ON_VALUES[modelId]!
+      for (const level of ['minimal', 'low', 'medium', 'high', 'xhigh'] as const) {
         const payload = await buildUpstagePayload(model, level)
+        expect(onValues, `upstage/${modelId} level ${level} emitted ${String(payload.reasoning_effort)}`).toContain(
+          payload.reasoning_effort as string,
+        )
+      }
+    }
+  })
+
+  test('passes the levels each model documents as reasoning-on through unchanged', async () => {
+    for (const modelId of REASONING_MODEL_IDS) {
+      const model = KNOWN_PROVIDERS.upstage.models[modelId] as Model<'openai-completions'>
+      for (const level of REASONING_ON_VALUES[modelId]!) {
+        if (level === 'xhigh' || level === 'max') continue
+        const payload = await buildUpstagePayload(model, level as ThinkingLevel)
         expect(payload.reasoning_effort, `upstage/${modelId} level ${level}`).toBe(level)
       }
+    }
+  })
+
+  test('the reasoning-on-by-default models send xhigh unchanged rather than clamping it', async () => {
+    for (const modelId of REASONS_BY_DEFAULT_MODEL_IDS) {
+      const model = KNOWN_PROVIDERS.upstage.models[modelId] as Model<'openai-completions'>
+      const payload = await buildUpstagePayload(model, 'xhigh')
+      expect(payload.reasoning_effort, `upstage/${modelId} must send xhigh unclamped`).toBe('xhigh')
+    }
+  })
+
+  test('the reasoning-on-by-default models emit an explicit reasoning_effort=none when reasoning is off', async () => {
+    // pi expresses "off" by omitting `reasoning`, and these models reason unless
+    // told otherwise — so an omitted reasoning_effort would silently leave
+    // reasoning on. pro3/pro2 omit the field to disable it instead.
+    for (const modelId of REASONS_BY_DEFAULT_MODEL_IDS) {
+      const model = KNOWN_PROVIDERS.upstage.models[modelId] as Model<'openai-completions'>
+      const payload = await buildUpstagePayload(model, undefined)
+      expect(payload.reasoning_effort, `upstage/${modelId} must send none to disable reasoning`).toBe('none')
+    }
+  })
+
+  test('the reasoning-off-by-default models omit reasoning_effort entirely when reasoning is off', async () => {
+    for (const modelId of XHIGH_CLAMPED_MODEL_IDS) {
+      const model = KNOWN_PROVIDERS.upstage.models[modelId] as Model<'openai-completions'>
+      const payload = await buildUpstagePayload(model, undefined)
+      expect(payload.reasoning_effort, `upstage/${modelId} must omit reasoning_effort when off`).toBeUndefined()
     }
   })
 


### PR DESCRIPTION
## Background

Upstage shipped Solar Pro 4 on 2026-08-06 as their new flagship, but the
`upstage.models` catalog only went up to solar-pro3. The block was originally
written from the agent API reference (`console.upstage.ai/api/docs/for-agents`),
which is self-dated 2026-03-07 and simply predates pro4, so its absence there
isn't evidence the model doesn't exist. This entry is sourced instead from the
live model page (`console.upstage.ai/docs/models/solar-pro4`), the reasoning
table (`console.upstage.ai/docs/capabilities/generate/reasoning`), and the
pricing card (`upstage.ai/pricing/api`). models.dev still doesn't list pro4
(only `solar-mini`, `solar-pro2`, `solar-pro3`), so nothing backfills it.

## Summary

Adds `solar-pro4`: 524288 context window, 131072 max output tokens, $0.30
input / $1.20 output / $0.06 cache-read per 1M tokens, text-only, function
calling supported.

Chasing pro4's reasoning semantics surfaced that Upstage's reasoning table
splits the lineup into **two groups with opposite defaults**, and this provider
block had `solar-open2` in the wrong one:

| Model | Omitted | Turns off | Turns on |
|---|---|---|---|
| `solar-pro4` | ✅ ON | `none`, `minimal` | `low`, `medium`, `high`, `xhigh`, `max` |
| `solar-open2` | ✅ ON | `none`, `minimal` | `low`, `medium`, `high`, `xhigh`, `max` |
| `solar-pro3` | ❌ OFF | `minimal`, `low` | `medium`, `high` |
| `solar-pro2` | ❌ OFF | `minimal`, `low` | `medium`, `high` |

`solar-open2` was mapped as if it were in the second group — `off: null` and
`xhigh` clamped to `high`.

**The open2 bug is pre-existing and silent.** pi-ai only omits
`reasoning_effort` when the `off` value is `null` (the `!options?.reasoningEffort`
branch in `providers/openai-completions.js`). Because open2 reasons when the
field is omitted, every turn TypeClaw asked to disable reasoning left it
**enabled** — extra latency and billing, never a 4xx, so nothing surfaced it.
The clamp separately discarded `xhigh`, a level open2 documents.

`max` sits above `xhigh` for both on-by-default models, but pi has no thinking
level above `xhigh`, so `max` is intentionally unreachable.

## What this does NOT do

- Doesn't touch the docs site. It never enumerates individual Solar model ids
  (only the `upstage` provider id), so adding a model has no docs touch-point.
- Doesn't change `solar-pro3`/`solar-pro2`/`solar-mini` behavior. Their `minimal`
  and `low` levels are documented as reasoning-*off* values, which the current
  mapping passes through as-is; that's pre-existing and left alone as out of
  scope here.

## Review notes

The load-bearing lines are the `thinkingLevelMap`s. `solar-pro4` and
`solar-open2` use `off: 'none'` + `xhigh: 'xhigh'`; `solar-pro3`/`solar-pro2`
use `off: null` + `xhigh: 'high'`. The two groups look inconsistent side by
side and a reviewer's instinct may be to unify them — that's exactly the bug
this PR fixes. Flipping either value back fails both the config test and the
payload test.

## Verification

`bun run lint`, `bun run format:check`, and `bun run typecheck` are clean.
Full suite: 12328 pass / 31 skip / 1 fail — the single failure is
`plugin-tools.test.ts > rejects excess queued snapshot waiters`, a 30s-timeout
flake that reproduces identically on clean `origin/main` with these three files
reverted, and which passed CI on the previous push.

The grouping is pinned end-to-end in `src/config/upstage-payload.test.ts`,
which drives pi-ai's real openai-completions adapter and asserts on the actual
wire payload rather than the model record. Both inversions were mutation-tested
by hand: reverting `off: 'none'`→`null` or `xhigh: 'xhigh'`→`'high'` on either
model fails at both layers.
