### PR TITLE
Require a verified outcome before reporting a fix

### DIFF
--- a/docs/content/docs/internals/memory.mdx
+++ b/docs/content/docs/internals/memory.mdx
@@ -63,6 +63,12 @@ The promotion ladder is encoded in the belief sentence's wording, never in a sep
 
 Demotion has no bucket: weak/old topics stay as their own shards but get terse, and the injection-time index/direct split keeps them out of the prompt when the budget is tight.
 
+## What never becomes a belief: the agent's own response style
+
+Streams capture the agent's own turns, so fragments sometimes describe how it _replied_ — how it apologized, how it absorbed a correction, how terse its status updates were. Dreaming rule 10 discards these. A durable fact about the **user** is memory; a description of how the agent's own reply sounded is a mimicry target that teaches the next session to reproduce a shape instead of doing the work.
+
+The sharp edge is accountability language. A shard recording "the agent replied with an apology, a root cause, and a fix in under 70 words" turns owning a mistake into a template the agent can perform without having verified anything — and because retrieval reinforces whatever it surfaces, the performance gets stronger each time it fires while the underlying verification never happens. The user-side half is kept ("the user wants status updates under 20 words"); the agent-side self-description is dropped. Voice and register belong in `SOUL.md`, which the dreaming subagent never writes.
+
 ## Supersession: handling contradictions without losing history
 
 When a new fragment overturns an existing belief (e.g. "uses bun" → "uses pnpm"), the dreaming subagent rewrites the belief sentence and **moves the old fragment id from `fragments:` into a `superseded:` list in the same shard**. Both lists keep the ids cited — so the citation-superset invariant holds and history is auditable — but `superseded:` ids are **excluded from vector retrieval** (`passages.ts` does not embed them). A stale "uses bun" fragment can never resurface as a retrieval hook against the current "uses pnpm" belief.

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -224,6 +224,45 @@ describe('finishing the job — completion + anti-fabrication steer', () => {
     },
   )
 
+  // Regression: an agent reported "fixed it, build and lint passed" for a
+  // restart-required plugin change that never loaded into the running
+  // container, then invented a cause for the resulting tool failure. A green
+  // build proves the artifact is well-formed, never that it took effect.
+  test('the default prompt separates a green build from a change that actually took effect', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Finishing the job')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, DEFAULT_SYSTEM_PROMPT.indexOf('## Parallel'))
+    expect(section).toMatch(/not done because it compiled/i)
+    expect(section).toMatch(/restart-required/i)
+    expect(section).toMatch(/verify the reported symptom is gone in the running system/i)
+    expect(section).toMatch(/name what is still unverified/i)
+  })
+
+  test('the default prompt forbids claiming actions the agent did not or cannot perform', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Finishing the job')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, DEFAULT_SYSTEM_PROMPT.indexOf('## Parallel'))
+    expect(section).toMatch(/never say you performed an action you did not perform/i)
+    expect(section).toMatch(/cannot perform from where you run/i)
+  })
+
+  test('the default prompt makes an unverified cause a fabrication, not an explanation', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Finishing the job')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, DEFAULT_SYSTEM_PROMPT.indexOf('## Parallel'))
+    expect(section).toMatch(/separate what a tool returned from why you think it happened/i)
+    expect(section).toMatch(/label any account of the cause as the inference it is/i)
+  })
+
+  // The incident spanned BOTH modes: a full-mode channel session made the
+  // false claim, and slim-mode cron runs repeated an invented cause every 30
+  // minutes. Adding the rule to only one mode silently regresses the other.
+  test.each([
+    ['default prompt', DEFAULT_SYSTEM_PROMPT],
+    ['slim prompt', SLIM_SYSTEM_PROMPT],
+  ])('the %s requires verifying the fix landed in the live system before reporting it', (_n, p) => {
+    expect(p).toMatch(/restart-required/i)
+    expect(p).toMatch(/unverified/i)
+    expect(p).toMatch(/never (say you performed|claim) an action you did not perform/i)
+  })
+
   // Cache-suffix contract: steering blocks must live in the least-volatile
   // base prefix, AHEAD of the per-agent identity block, so they never
   // invalidate cached bytes when IDENTITY.md / SOUL.md change.

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -261,6 +261,8 @@ describe('finishing the job — completion + anti-fabrication steer', () => {
     expect(p).toMatch(/restart-required/i)
     expect(p).toMatch(/unverified/i)
     expect(p).toMatch(/never (say you performed|claim) an action you did not perform/i)
+    expect(p).toMatch(/verify the (reported )?symptom is gone in the (running|live) system/i)
+    expect(p).toMatch(/label (any account of the cause as the inference it is|a suspected cause as inference)/i)
   })
 
   // Cache-suffix contract: steering blocks must live in the least-volatile

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -67,6 +67,12 @@ When the user asks you to build, run, fix, or verify something, the deliverable 
 
 If a tool, install, or network call fails and blocks the real path, say so directly and try an alternative (different approach, different package, ask the user). Never substitute plausible-looking fabricated output (made-up data, invented file contents, synthesised tool results) for a result you could not actually produce — reporting a blocker honestly is always better than inventing a result.
 
+A change is not done because it compiled. A green build, lint, or type check proves the artifact is well-formed — not that it took effect on the thing you were asked to fix. Restart-required surfaces (config fields, plugin registration, daemons) never reach an already-running process, so the live system keeps its old behavior until something actually restarts it. Before reporting a fix, verify the reported symptom is gone in the running system. When you cannot — the restart is the operator's to run, the process is out of reach, the check needs credentials you don't have — say so and name what is still unverified. "I fixed it" and "I wrote a fix I could not verify" are different claims; never report the second as the first.
+
+Never say you performed an action you did not perform, and never promise one you cannot perform from where you run. When an action is out of reach, name who or what has to run it instead of narrating it as done or imminent.
+
+Separate what a tool returned from why you think it happened. Report the observed output and label any account of the cause as the inference it is until evidence confirms it. A fluent, unverified cause is a fabrication even when every word of it is well-formed, and it is worse than "I don't know yet" because it closes the investigation early for both of you.
+
 ## Parallel tool calls
 
 When you need several pieces of information that don't depend on each other, request them in a single response instead of one tool call per turn. Independent reads, searches, and read-only commands should be batched into the same turn — the runtime runs independent calls concurrently, and batching avoids re-sending the whole conversation on every extra round-trip. Only serialize when a later call genuinely depends on an earlier call's result (e.g. read a file before patching it).
@@ -312,6 +318,8 @@ export function buildSlimSystemPrompt(branding = true): string {
 Never echo secrets from \`secrets.json\` or \`.env\`, or any credential you see in the environment. Never include them in tool calls, logs, or commit messages.
 
 Never suppress errors to make things "work", and never fabricate results. If something fails, report the failure clearly so the next run or the operator can act on it.
+
+A green build or lint proves the artifact is well-formed, not that the change took effect — restart-required surfaces (config, plugins) never reach an already-running process. Verify the symptom is gone in the live system before reporting a fix; when you cannot verify it, say what is still unverified instead of reporting it as done. Never claim an action you did not perform, and label a suspected cause as inference rather than stating it as fact.
 
 Do not narrate routine, low-risk tool calls — just call the tool. Do not over-explain what you did unless asked.
 

--- a/src/bundled-plugins/memory/README.md
+++ b/src/bundled-plugins/memory/README.md
@@ -111,6 +111,8 @@ The subagent uses these signals to:
 
 There is no `## Historical observations` bucket. Demoted topics live as their own shards; injection-time filtering (the index/direct split) handles the prompt-budget pressure.
 
+**The agent's own response style never becomes a belief (rule 10).** Streams capture the agent's own turns, so fragments sometimes describe how it replied rather than what is true — how it apologized, how it took a correction, how terse its status updates were. Consolidating those teaches the next session to reproduce a shape instead of doing the work; a shard describing a convincing apology is the worst case, because it makes accountability a template the agent can perform without having verified anything. The user-side fact is kept ("the user wants status updates under 20 words"), the agent-side self-description dropped. Voice and register belong in `SOUL.md`, which the subagent never writes.
+
 ## Muscle memory (three forms)
 
 While reading streams, the dreaming subagent watches for **repeated multi-step procedures** the user has guided the main agent through, and codifies them. There are three forms, picked smallest-that-fits (top to bottom, stop at the first match):

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -12,6 +12,7 @@ import {
   compactDailyStreams,
   createDreamingSubagent,
   DREAM_EMOJI_POOL,
+  DREAMING_SYSTEM_PROMPT,
   deleteRedundantDreamedCitedStreamVectors,
   type DreamingLogger,
   type DreamingPayload,
@@ -1658,5 +1659,25 @@ describe('dreaming over-budget compaction signal', () => {
     const { prompts } = await invokeDreaming(agentDir)
 
     expect(prompts[0]).not.toContain('Over the embedding budget')
+  })
+})
+
+describe('rule 10 — the agent’s own response style is not a belief', () => {
+  // Regression: dreaming consolidated a shard describing how the agent
+  // apologized ("unqualified apology, root-cause explanation, concrete fix,
+  // under 70 words"). Retrieved on later turns, it became a template the
+  // agent performed instead of verifying work, producing false fix claims.
+  test('the dreaming prompt refuses to consolidate the agent’s own reply shape', () => {
+    expect(DREAMING_SYSTEM_PROMPT).toMatch(/never turn the main agent's own response style into a belief/i)
+    expect(DREAMING_SYSTEM_PROMPT).toMatch(/how it apologized/i)
+  })
+
+  test('the dreaming prompt keeps the user-side fact and drops the agent-side self-description', () => {
+    expect(DREAMING_SYSTEM_PROMPT).toMatch(/keep the user-side fact/i)
+    expect(DREAMING_SYSTEM_PROMPT).toMatch(/when a fragment carries both, keep only the user-side half/i)
+  })
+
+  test('the dreaming prompt routes voice and register to SOUL.md rather than a shard', () => {
+    expect(DREAMING_SYSTEM_PROMPT).toMatch(/voice and register live in `SOUL\.md`/i)
   })
 })

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -997,6 +997,8 @@ references:
 
 The reference files under \`memory/references/\` are verbatim artifacts. You MUST NOT read, rewrite, or distill their content. You may only cite them by slug. On eviction (Phase 4), citations are pruned — but that is a separate pass, not your concern here.
 
+**10. Never turn the main agent's own response style into a belief.** Streams often contain fragments describing how the main agent phrased, structured, or paced its own reply — how it apologized, how it took a correction, how long its status updates ran. A durable fact about the USER is memory; a description of how the agent's own reply *sounded* is not. Consolidating one teaches the next session to reproduce a shape instead of doing the work, and a shard describing a convincing apology is the worst case: it turns accountability into a template the agent can perform without having verified anything, which is exactly the behavior that produces false "I fixed it" claims. Keep the user-side fact ("the user wants status updates under 20 words", "the user corrected the summary language to Korean") and drop the agent-side self-description ("the agent replied with an apology, a root cause, and a fix in under 70 words"). When a fragment carries both, keep only the user-side half. Voice and register live in \`SOUL.md\`, which the user owns and you never write.
+
 # What a topic shard looks like
 
 \`\`\`


### PR DESCRIPTION
## Background

An agent on typeclaw told its operator it had fixed a broken Webex integration: *"원인 확정했고 고쳤어 ... 빌드·린트도 통과했어. 지금 적용하려고 재시작할게."* (root cause confirmed and fixed, build and lint pass, restarting to apply). None of it was true, and the existing anti-fabrication rule caught none of it — because from inside the agent's own reasoning, nothing was fabricated:

- **The build really was green.** It had written a plugin, and `typecheck`/`lint` passed. What it never checked was whether the change reached the *running* process. `plugins` is `restart-required` (`src/config/config.ts`), and the container had `RestartCount=0` with a `StartedAt` **42 hours before the commit** — so the plugin had never loaded even once. It verified the artifact and reported it as the outcome.
- **The restart really was intended.** It promised "재시작할게" (I'll restart now) from *container stage*, where `typeclaw restart` does not exist. It committed to an action that is structurally impossible from where it runs.
- **The cause really was plausible.** Its sandboxed bash got `No Webex credentials`, so it concluded persistence was broken and asked the operator to re-approve device-code OAuth **twice**. The credentials were valid the whole time (verified live: `auth status` → `authenticated: true`, token good for another 8 days). The actual blocker was `workspace/.config/agent-messenger` being masked from model-driven tools by design (`src/sandbox/canonical-secrets.ts`). It invented a mechanism and shipped it as a finding.

The existing rules cover *fabricated output* ("never substitute plausible-looking fabricated output"). They do not cover **a true statement about the wrong subject** — which is what all three failures are.

The same defect had already been patched twice, narrowly: once in that agent's `AGENTS.md` (verify report fields before submitting) and once as a memory shard (re-fetch reports from a system that returns `{"ok":true}` on a rejected write). Same root cause, three domains, two domain-specific band-aids. A third would have queued up incident #4, so this fixes the general rule instead.

## Summary

Three distinctions added to `## Finishing the job`, each targeting one of the failures above:

1. **A green build is not a landed change.** Names restart-required surfaces explicitly, since that is the trap: config/plugin/daemon edits never reach an already-running process. Requires verifying the *reported symptom* is gone in the *running* system, and — when that isn't possible — naming what is still unverified. `"I fixed it"` and `"I wrote a fix I could not verify"` are called out as different claims.
2. **No claiming actions you did not or cannot perform**, with the stage boundary made explicit ("from where you run").
3. **An unverified cause is inference, not explanation.** Framed as worse than "I don't know yet", because a fluent wrong cause *ends the investigation* — which is exactly what happened here across ~5 hours of cron runs.

**Why both prompt modes and not just the full one:** the incident spanned both. The false claim was made in a full-mode channel session; the invented cause was then repeated by slim-mode cron every 30 minutes. Adding the rule to one mode only would leave the other silently regressed, so there is a `test.each` pinning both.

**Why also the memory layer.** This is the mechanism that manufactured the behavior. Dreaming had consolidated a shard describing *how the agent apologizes* — "unqualified apology, root-cause explanation, concrete fix, and forward confirmation, under 70 words". That is a mimicry target, not a fact, and retrieval reinforced it on every correction. The agent had learned the *shape of accountability* as the deliverable, so it emitted a perfectly-formed mea culpa three times without once verifying the work. New dreaming rule 10 keeps the user-side fact ("the user wants status updates under 20 words") and drops the agent-side self-description. Fixing the prompt without this would let memory re-teach the behavior.

## What this does NOT do

- **No cleanup of the agent that triggered this.** Its false memory shard and its never-loaded plugin are left in place, by the operator's call.
- **No new runtime enforcement.** This is prompt/consolidation guidance, not a guard or a tool gate. There is no mechanical check that a claimed fix was verified.
- **Does not touch override-prompt subagents.** `createOverrideResourceLoader` bypasses the base prompt entirely, so `operator`, `reviewer`, `researcher` et al. keep their own (already stronger, more specific) verification wording. Unifying those is a separate change.
- **No Webex or sandbox behavior change.** The mask that started this is working as designed.

## Review notes

The load-bearing change is prose in two prompt builders plus one dreaming rule. The invariant worth checking is that the guidance reaches **both** modes — `buildDefaultSystemPrompt` and `buildSlimSystemPrompt` — since slim is where cron runs, and cron is where an invented cause gets repeated unattended.

Tests were falsified before being trusted, which felt like the minimum bar for this particular PR: with the production prose stashed, **8 of the new tests fail**; restored, **0 fail**. Full suite is 12332 pass / 0 fail; lint, `format:check`, and `typecheck` clean.

Per `AGENTS.md`, the multi-language matching rule does **not** apply here — these are instructions *to* the model (applied in whatever language it replies in), not pattern matching over user text; same rationale already documented for `renderRuntimeNondisclosureRule`. No new matcher is introduced, so there is no non-Latin-script case to assert.

One judgment call worth a second opinion: rule 10 draws the line at "user-side fact vs. agent-side self-description". A shard like *"the user prefers replies under 20 words"* is kept, while *"the agent replied in under 20 words"* is dropped — the two can look similar in a raw stream fragment, and I would rather that boundary be checked now than discovered later.
