### PR TITLE
Land a promised continuation instead of going silent

### DIFF
--- a/src/channels/adapters/discord-bot-reactions.test.ts
+++ b/src/channels/adapters/discord-bot-reactions.test.ts
@@ -68,6 +68,15 @@ describe('createDiscordReactionCallback', () => {
     expect(calls[0]!.emoji).toBe('👍')
   })
 
+  it('maps the continuation hourglass name to unicode', async () => {
+    const calls: AddCall[] = []
+    const cb = createDiscordReactionCallback({
+      client: { addReaction: async (channel, message, emoji) => void calls.push({ channel, message, emoji }) },
+    })
+    await cb(addReq('hourglass_flowing_sand'))
+    expect(calls[0]!.emoji).toBe('⏳')
+  })
+
   it('rejects an unmapped emoji name as unsupported without calling the SDK', async () => {
     let called = false
     const cb = createDiscordReactionCallback({

--- a/src/channels/adapters/discord-bot-reactions.ts
+++ b/src/channels/adapters/discord-bot-reactions.ts
@@ -78,6 +78,7 @@ const EMOJI_UNICODE: Record<string, string> = {
   eye: '👁️',
   raised_hands: '🙌',
   zipper_mouth_face: '🤐',
+  hourglass_flowing_sand: '⏳',
 }
 
 function resolveEmoji(emoji: string): string | null {

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -30,6 +30,7 @@ import {
   DISCORD_HISTORY_LIMIT_MAX,
   DISCORD_SLASH_COMMAND_NAMES,
 } from './discord-bot'
+import { encodeDiscordReactionRef } from './discord-bot-reactions'
 import { DISCORD_SLASH_COMMAND_TYPE_CHAT_INPUT } from './discord-bot-slash-commands'
 
 const provenanceConfig: ChannelAdapterConfig = {
@@ -1708,7 +1709,12 @@ describe('discord-bot createOutboundCallback', () => {
     // when
     const result = await cb(makeMsg({ text: 'hello' }))
     // then
-    expect(result).toEqual({ ok: true, messageId: 'm1', messageIds: ['m1'] })
+    expect(result).toEqual({
+      ok: true,
+      messageId: 'm1',
+      messageIds: ['m1'],
+      reactionRef: encodeDiscordReactionRef({ channel: 'c1', message: 'm1' }),
+    })
     expect(uploads).toHaveLength(0)
     expect(sends).toEqual([{ chat: 'c1', content: 'hello', options: undefined }])
   })

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -60,7 +60,11 @@ import {
 } from './discord-bot-classify'
 import { createDiscordEditMessageCallback } from './discord-bot-edit'
 import { convertDiscordTables } from './discord-bot-format'
-import { createDiscordReactionCallback, createDiscordRemoveReactionCallback } from './discord-bot-reactions'
+import {
+  createDiscordReactionCallback,
+  createDiscordRemoveReactionCallback,
+  encodeDiscordReactionRef,
+} from './discord-bot-reactions'
 import { enrichDiscordMessageReferences } from './discord-bot-reference'
 import {
   ackInteraction,
@@ -840,7 +844,12 @@ export function createOutboundCallback(deps: {
         Object.keys(sendOptions).length > 0 ? sendOptions : undefined,
       )
       logger.info(`[discord-bot] sent id=${sent.id} ${tag}`)
-      return { ok: true, messageId: sent.id, messageIds: [sent.id] }
+      return {
+        ok: true,
+        messageId: sent.id,
+        messageIds: [sent.id],
+        reactionRef: encodeDiscordReactionRef({ channel: msg.chat, message: sent.id }),
+      }
     } catch (err) {
       const message = describeError(err)
       logger.error(`[discord-bot] sendMessage failed: ${message}`)

--- a/src/channels/adapters/discord-reactions.ts
+++ b/src/channels/adapters/discord-reactions.ts
@@ -61,6 +61,7 @@ const EMOJI_UNICODE: Record<string, string> = {
   eye: '👁️',
   raised_hands: '🙌',
   zipper_mouth_face: '🤐',
+  hourglass_flowing_sand: '⏳',
 }
 
 function resolveEmoji(emoji: string): string | null {

--- a/src/channels/adapters/discord.ts
+++ b/src/channels/adapters/discord.ts
@@ -108,6 +108,7 @@ export function createDiscordOutboundCallback(deps: {
           await deps.client.sendMessage(msg.chat, chunk, replyOption(index === 0 ? replyTo : undefined))
         }
       }
+      // The user-account SDK send APIs return no posted-message id, so no reaction target ref is available.
       return { ok: true }
     } catch (err) {
       const message = describeError(err)

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -24,6 +24,7 @@ import {
 } from './slack-bot'
 import { classifyInbound, type SlackInboundAppMentionEvent } from './slack-bot-classify'
 import { createSlackDedupe } from './slack-bot-dedupe'
+import { encodeSlackReactionRef } from './slack-bot-reactions'
 
 describe('slack-bot createTypingCallback', () => {
   type SetStatusCall = { channel: string; threadTs: string; status: string }
@@ -1686,7 +1687,12 @@ describe('slack-bot createOutboundCallback', () => {
     // when
     const result = await cb(makeMsg({ text: 'hello' }))
     // then
-    expect(result).toEqual({ ok: true, messageId: 'ts1', messageIds: ['ts1'] })
+    expect(result).toEqual({
+      ok: true,
+      messageId: 'ts1',
+      messageIds: ['ts1'],
+      reactionRef: encodeSlackReactionRef({ channel: 'C0', ts: 'ts1' }),
+    })
     expect(uploads).toHaveLength(0)
     expect(posts).toEqual([
       {

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -56,7 +56,11 @@ import {
 } from './slack-bot-classify'
 import { createSlackDedupe } from './slack-bot-dedupe'
 import { createSlackEditMessageCallback } from './slack-bot-edit'
-import { createSlackReactionCallback, createSlackRemoveReactionCallback } from './slack-bot-reactions'
+import {
+  createSlackReactionCallback,
+  createSlackRemoveReactionCallback,
+  encodeSlackReactionRef,
+} from './slack-bot-reactions'
 import { enrichSlackReferenceContext } from './slack-bot-reference'
 import {
   buildSlashAckPayload,
@@ -1006,7 +1010,12 @@ export function createOutboundCallback(deps: {
           if (threadTs === null && chunks.length > 1) threadTs = sent.ts
         }
         if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.typingThread ?? msg.thread)
-        return { ok: true, messageId: sentTs[0], messageIds: sentTs }
+        return {
+          ok: true,
+          messageId: sentTs[0],
+          messageIds: sentTs,
+          reactionRef: encodeSlackReactionRef({ channel: msg.chat, ts: sentTs[0]! }),
+        }
       } catch (err) {
         const message = describeError(err)
         logger.error(`[slack-bot] postMessage failed: ${message}`)

--- a/src/channels/adapters/slack.ts
+++ b/src/channels/adapters/slack.ts
@@ -106,6 +106,7 @@ export function createSlackOutboundCallback(deps: {
         const filename = attachment.filename ?? basename(path)
         await deps.client.uploadFile([msg.chat], buffer, filename)
       }
+      // The user-account SDK send APIs return no posted-message id, so no reaction target ref is available.
       return { ok: true }
     } catch (err) {
       const message = describeError(err)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -28,6 +28,7 @@ import type { CreateChannelRouterOptions } from './router'
 import {
   CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS,
   CHANNEL_MAX_OUTPUT_TOKENS,
+  CONTINUATION_REACTION_EMOJI,
   createChannelRouter,
   disengageReactionEmojiFor,
   DUPLICATE_SEND_ERROR,
@@ -13681,22 +13682,23 @@ describe('ChannelRouter continuation willingness nudge', () => {
     session.setAssistantMidTurn(replyText, 'aborted')
   }
 
-  test('queues a nudge when a terminal reply promises to continue without more_work_this_turn:true', async () => {
+  test('posts a fallback when the willingness nudge ends in explicit NO_REPLY', async () => {
     const dir = await tempDir()
+    const logs: string[] = []
     const sent: string[] = []
-    const { router, sessions } = makeRouter(dir)
+    const { router, sessions } = makeRouter(dir, { logs })
     router.registerOutbound('discord-bot', async (msg) => {
       sent.push(msg.text ?? '')
       return { ok: true }
     })
 
-    await router.route(inbound({ text: '다시 확인해봐' }))
+    await router.route(inbound({ text: 'check it again' }))
     let attempt = 0
     sessions[0]!.onPrompt = async (text) => {
       attempt++
       // given: first turn replies with a continuation promise (no more_work_this_turn:true)
       if (attempt === 1) {
-        await replyTurn(sessions[0]!, router, '바로 계속 확인하겠습니다')
+        await replyTurn(sessions[0]!, router, "I'll keep checking on that now.")
         return
       }
       // then: the nudge arrives as a reminder-only re-prompt; now do the work
@@ -13706,6 +13708,51 @@ describe('ChannelRouter continuation willingness nudge', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent).toEqual(["I'll keep checking on that now.", EMPTY_TURN_FALLBACK_TEXT])
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=no_reply_after_willingness_nudge'))).toBe(true)
+  })
+
+  test('does not post a fallback for NO_REPLY from a later unrelated reminder after the promised result', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const laterReminder = '<system-reminder>Perform unrelated turn cleanup.</system-reminder>'
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'check it again' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      attempt++
+      if (attempt === 1) {
+        await replyTurn(sessions[0]!, router, "I'll keep checking on that now.")
+        return
+      }
+      if (attempt === 2) {
+        expect(text).toContain(WILLINGNESS_NUDGE)
+        sessions[0]!.setAssistantText('SENT')
+        await router.send({
+          adapter: 'discord-bot',
+          workspace: 'g1',
+          chat: 'c1',
+          text: 'The cause was a permission setting.',
+        })
+        router.__testing!.injectContinuationReminder(KEY, laterReminder)
+        return
+      }
+      expect(text).toContain(laterReminder)
+      expect(text).not.toContain(WILLINGNESS_NUDGE)
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(3)
+    expect(sent).toEqual(["I'll keep checking on that now.", 'The cause was a permission setting.'])
+    expect(sent).not.toContain(EMPTY_TURN_FALLBACK_TEXT)
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=no_reply_after_willingness_nudge'))).toBe(false)
   })
 
   test('does NOT queue a nudge for a final reply with no continuation intent', async () => {
@@ -13737,6 +13784,274 @@ describe('ChannelRouter continuation willingness nudge', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(sessions[0]!.prompts).toHaveLength(2)
+  })
+})
+
+describe('ChannelRouter continuation willingness reaction', () => {
+  const WILLINGNESS_REPLY = "I'll check the exact failure message and work out what was blocked."
+  const TARGET_REF: ReactionRef = { adapter: 'discord-bot', value: 'outbound-target' }
+  const INSTANCE_REF: ReactionRef = { adapter: 'discord-bot', value: 'continuation-instance' }
+
+  function terminalReplyContext(replyText: string): AfterToolCallContext {
+    return {
+      assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
+      toolCall: {
+        type: 'toolCall',
+        id: 'tc-continuation',
+        name: 'channel_reply',
+        arguments: { text: replyText },
+      } as AfterToolCallContext['toolCall'],
+      args: { text: replyText },
+      result: {
+        content: [{ type: 'text' as const, text: 'ignored' }],
+        details: { ok: true },
+      } as AfterToolCallContext['result'],
+      isError: false,
+      context: { systemPrompt: '', messages: [], tools: [] },
+    }
+  }
+
+  async function sendTerminalWillingness(
+    session: FakeSession,
+    router: ChannelRouter,
+    text: string = WILLINGNESS_REPLY,
+  ): Promise<void> {
+    await session.agent.afterToolCall!(terminalReplyContext(text))
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text })
+    session.setAssistantMidTurn(text, 'aborted')
+  }
+
+  test('adds an hourglass to the agent own willingness message', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const added: ReactionRequest[] = []
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async () => ({ ok: true, reactionRef: TARGET_REF }))
+    router.registerReaction('discord-bot', async (req) => {
+      added.push(req)
+      return { ok: true, reactionRef: INSTANCE_REF }
+    })
+
+    await router.route(inbound({ text: 'look at it again' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: WILLINGNESS_REPLY })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => added.length === 1)
+    expect(added[0]).toMatchObject({
+      adapter: 'discord-bot',
+      chat: 'c1',
+      emoji: CONTINUATION_REACTION_EMOJI,
+      reactionRef: TARGET_REF,
+    })
+  })
+
+  test('retires the hourglass when a substantive follow-up lands', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const removed: ReactionRef[] = []
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async () => ({ ok: true, reactionRef: TARGET_REF }))
+    router.registerReaction('discord-bot', async () => ({ ok: true, reactionRef: INSTANCE_REF }))
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'tell me the result too' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: WILLINGNESS_REPLY })
+      await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'The block came from a missing permission.',
+      })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => removed.length === 1)
+    expect(removed).toEqual([INSTANCE_REF])
+  })
+
+  test('retires the hourglass when the promised turn falls back', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const removed: ReactionRef[] = []
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async (msg) =>
+      msg.text === EMPTY_TURN_FALLBACK_TEXT
+        ? { ok: false, error: 'fallback delivery failed' }
+        : { ok: true, reactionRef: TARGET_REF },
+    )
+    router.registerReaction('discord-bot', async () => ({ ok: true, reactionRef: INSTANCE_REF }))
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'please check' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      if (attempt === 1) {
+        await sendTerminalWillingness(sessions[0]!, router)
+        return
+      }
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => removed.length === 1)
+    expect(removed).toEqual([INSTANCE_REF])
+  })
+
+  test('retires the hourglass on a final NO_REPLY', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const removed: ReactionRef[] = []
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async () => ({ ok: true, reactionRef: TARGET_REF }))
+    router.registerReaction('discord-bot', async () => ({ ok: true, reactionRef: INSTANCE_REF }))
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'please check' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: WILLINGNESS_REPLY })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => removed.length === 1)
+    expect(removed).toEqual([INSTANCE_REF])
+  })
+
+  test('does not react when the send result omits a reaction target ref', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const added: ReactionRequest[] = []
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    router.registerReaction('discord-bot', async (req) => {
+      added.push(req)
+      return { ok: true, reactionRef: INSTANCE_REF }
+    })
+
+    await router.route(inbound({ text: 'please check' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: WILLINGNESS_REPLY })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(added).toHaveLength(0)
+  })
+
+  test('stays a no-op when the adapter has no reaction callback', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const removed: ReactionRef[] = []
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async () => ({ ok: true, reactionRef: TARGET_REF }))
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'please check' }))
+    sessions[0]!.onPrompt = async () => {
+      const status = await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: WILLINGNESS_REPLY,
+      })
+      const answer = await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'It turned out to be a permissions problem.',
+      })
+      expect(status.ok).toBe(true)
+      expect(answer.ok).toBe(true)
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(removed).toHaveLength(0)
+  })
+
+  test('cleanup waits for an unresolved hourglass add before removing it', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const removed: ReactionRef[] = []
+    let releaseAdd: (() => void) | undefined
+    const addGate = new Promise<void>((resolve) => {
+      releaseAdd = resolve
+    })
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async () => ({ ok: true, reactionRef: TARGET_REF }))
+    router.registerReaction('discord-bot', async () => {
+      await addGate
+      return { ok: true, reactionRef: INSTANCE_REF }
+    })
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'please check' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: WILLINGNESS_REPLY })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'That check is done.' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(removed).toHaveLength(0)
+
+    releaseAdd!()
+    await waitFor(() => removed.length === 1)
+    expect(removed).toEqual([INSTANCE_REF])
+  })
+
+  test('one substantive result retires every pending willingness status', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const removed: ReactionRef[] = []
+    let outboundCount = 0
+    router.setTypingCapability('discord-bot', true)
+    router.registerOutbound('discord-bot', async () => {
+      outboundCount++
+      return {
+        ok: true,
+        reactionRef: { adapter: 'discord-bot', value: `outbound-${outboundCount}` },
+      }
+    })
+    router.registerReaction('discord-bot', async (req) => ({
+      ok: true,
+      reactionRef: { adapter: 'discord-bot', value: `instance-${req.reactionRef.value}` },
+    }))
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'keep me posted' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: WILLINGNESS_REPLY })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: "I'll check the logs too." })
+      await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'Both logs showed the same permission error.',
+      })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => removed.length === 2)
+    expect(removed.map((ref) => ref.value).sort()).toEqual(['instance-outbound-1', 'instance-outbound-2'])
   })
 })
 
@@ -13860,7 +14175,7 @@ describe('ChannelRouter channel_send willingness nudge', () => {
       return { ok: true }
     })
 
-    await router.route(inbound({ text: '확인해줘' }))
+    await router.route(inbound({ text: 'please check' }))
     let attempt = 0
     sessions[0]!.onPrompt = async () => {
       attempt++
@@ -14006,7 +14321,7 @@ describe('ChannelRouter more_work_this_turn:true empty-stop recovery (phrase-ind
       return { ok: true }
     })
 
-    await router.route(inbound({ text: '확인해줘' }))
+    await router.route(inbound({ text: 'please check' }))
     let attempt = 0
     sessions[0]!.onPrompt = async () => {
       attempt++
@@ -14099,7 +14414,7 @@ describe('ChannelRouter more_work_this_turn:true empty-stop recovery (phrase-ind
       return { ok: true }
     })
 
-    await router.route(inbound({ text: '확인해줘' }))
+    await router.route(inbound({ text: 'please check' }))
     let attempt = 0
     sessions[0]!.onPrompt = async () => {
       attempt++
@@ -14127,7 +14442,7 @@ describe('ChannelRouter more_work_this_turn:true empty-stop recovery (phrase-ind
       return { ok: true }
     })
 
-    await router.route(inbound({ text: '확인해줘' }))
+    await router.route(inbound({ text: 'please check' }))
     let attempt = 0
     sessions[0]!.onPrompt = async () => {
       attempt++

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -196,6 +196,7 @@ export const SESSION_GC_INTERVAL_MS = 60 * 1000
 // recovery paths (`source: 'system'`) bypass.
 export const MAX_CHANNEL_SENDS_PER_TURN = 10
 export const ENGAGE_REACTION_EMOJI = 'eyes'
+export const CONTINUATION_REACTION_EMOJI = 'hourglass_flowing_sand'
 // Best-effort "zipping it / going quiet" ack dropped on the triggering message
 // when the model disengages (channel_disengage); fire-and-forget like engage :eyes:.
 export const DISENGAGE_REACTION_EMOJI = 'zipper_mouth_face'
@@ -456,20 +457,31 @@ export const MAX_WILLINGNESS_NUDGES = 1
 // Injected when a reply that ended the turn (terminal-reply abort) promised to
 // keep working but omitted `more_work_this_turn: true`. Reminder-only, SYSTEM MESSAGE
 // framing so persona-rich models do not reply to the notice itself.
+// Leads with the DELIVERY imperative, mirroring SEND_WILLINGNESS_NUDGE below. An
+// earlier revision closed on a bare "If there is nothing left to do, reply with
+// `NO_REPLY`" and production models took that door after doing the promised work:
+// "nothing left to DO" reads as satisfied the moment the investigation finishes,
+// so the turn exited silent while still holding the answer. Splitting "no work
+// left" from "nothing to report", and scoping NO_REPLY to already-delivered, is
+// the load-bearing part of this wording — do not collapse it back.
 export const WILLINGNESS_NUDGE = [
   '---',
   '**[SYSTEM MESSAGE — not from a human]**',
   '',
-  'Your last reply said you would keep working this turn, but it ended right',
-  'after sending — a successful channel reply ends the turn unless you set',
+  'Your last reply promised the human you would keep working, but the turn ended',
+  'right after sending — a successful channel reply ends the turn unless you set',
   '`more_work_this_turn: true` on it. This is an automated signal from the channel',
   'router, not a message from anyone in the chat. **Do not acknowledge or reply to',
   'this notice itself.**',
   '',
-  'If you still have work to do (fetch data, run a tool, spawn a subagent, then',
-  'reply with the result), do it now — and on the status reply that precedes more',
-  'work this turn, set `more_work_this_turn: true`. If there is nothing left to do,',
-  'reply with `NO_REPLY`.',
+  'Someone is waiting on the result you just promised. Do the work now (fetch data,',
+  'run a tool, spawn a subagent) and post what you find — and on any further status',
+  'reply that precedes more work this turn, set `more_work_this_turn: true`. If you',
+  'already did the work, post the conclusion you reached: having no work left is NOT',
+  'the same as having nothing to report, and a promise that never lands reads to the',
+  'human as being ignored.',
+  '',
+  '`NO_REPLY` is correct ONLY if the result you promised is already in the channel.',
   '',
   '---',
 ].join('\n')
@@ -480,6 +492,10 @@ export const WILLINGNESS_NUDGE = [
 // needs `more_work_this_turn: true`; this path is a `channel_send` (which never ends the
 // turn) whose follow-up degenerated, so the model just needs to emit the reply it
 // already worked out. Shares MAX_WILLINGNESS_NUDGES so a turn can't double-nudge.
+// Scopes NO_REPLY the same way WILLINGNESS_NUDGE does, and for the same reason:
+// both nudges share `willingnessNudges`, so both are covered by the
+// `no_reply_after_willingness_nudge` fallback. A nudge that still advertised
+// NO_REPLY as an ordinary exit would contradict the guard that answers it.
 export const SEND_WILLINGNESS_NUDGE = [
   '---',
   '**[SYSTEM MESSAGE — not from a human]**',
@@ -489,8 +505,12 @@ export const SEND_WILLINGNESS_NUDGE = [
   'message. This is an automated signal from the channel router, not a message',
   'from anyone in the chat. **Do not acknowledge or reply to this notice itself.**',
   '',
-  'Send the answer you just worked out now via your channel send tool. If you',
-  'genuinely have nothing to report, reply with `NO_REPLY`.',
+  'Send the answer you just worked out now via your channel send tool. Post what',
+  'you found even if the finding is "no change" or "it failed" — someone is waiting',
+  'on the result you promised, and having no work left is not the same as having',
+  'nothing to report.',
+  '',
+  '`NO_REPLY` is correct ONLY if the result you promised is already in the channel.',
   '',
   '---',
 ].join('\n')
@@ -906,6 +926,12 @@ type LiveSession = {
   // legitimately keeps its "seen, not replying" ack, unlike the transient
   // engage :eyes: which teardown must strip.
   activeSilentAckReactions: Array<Promise<ReactionRef | null>>
+  // One add promise per willingness status posted by the agent, resolving to
+  // the removable reaction-instance ref. Cross-turn state on purpose: the
+  // hourglass stays visible until a substantive result, fallback, explicit
+  // silence, stop, or teardown retires every outstanding promise. Storing the
+  // promise synchronously prevents cleanup racing a slow reaction add.
+  activeContinuationReactions: Array<Promise<ReactionRef | null>>
   lastTurnAuthorIds: Set<string>
   // Mirror of currentTurnAuthorId at end-of-turn (the LAST speaker of the
   // prior batch), preserved across the drain finally-block which resets
@@ -931,6 +957,11 @@ type LiveSession = {
   // the drain loop's run condition checks BOTH queues so a system
   // reminder alone is enough to trigger a turn.
   pendingSystemReminders: string[]
+  // True only for the reminder-only iteration that consumed a willingness
+  // nudge. `willingnessNudges` persists across the logical turn, so it remains
+  // nonzero after a substantive result and would misclassify NO_REPLY from a
+  // later unrelated reminder as another dropped promise.
+  willingnessReminderIteration: boolean
   consecutiveSends: Map<string, number>
   // Per-(chat:thread) text of the last reserved bot send. Set
   // SYNCHRONOUSLY inside router.send before the outbound callback awaits,
@@ -2238,6 +2269,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         originRef,
         promptQueue: [],
         pendingSystemReminders: [],
+        willingnessReminderIteration: false,
         contextBuffer: [],
         currentTurnAttachments: [],
         historyTimedAttachments: [],
@@ -2263,6 +2295,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         pendingTurnReactions: [],
         silentAckTurn: null,
         activeSilentAckReactions: [],
+        activeContinuationReactions: [],
         // `lastTurnAuthorId` (string, used for `lastInboundAuthorId` in
         // origin) and `lastTurnAuthorIds` (Set, used by
         // `grantStickyForReplyTargets` as the fallback when
@@ -2829,18 +2862,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const postEmptyTurnFallback = async (live: LiveSession, cause: string): Promise<void> => {
     logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)
     live.emptyTurnFallbackTurn = live.turnSeq
-    const result = await send(
-      {
-        adapter: live.key.adapter,
-        workspace: live.key.workspace,
-        chat: live.key.chat,
-        thread: live.key.thread,
-        text: EMPTY_TURN_FALLBACK_TEXT,
-      },
-      { source: 'system', outputKind: 'meta' },
-    )
-    if (!result.ok) {
-      logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
+    try {
+      const result = await send(
+        {
+          adapter: live.key.adapter,
+          workspace: live.key.workspace,
+          chat: live.key.chat,
+          thread: live.key.thread,
+          text: EMPTY_TURN_FALLBACK_TEXT,
+        },
+        { source: 'system', outputKind: 'meta' },
+      )
+      if (!result.ok) {
+        logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
+      }
+    } finally {
+      void dropContinuationReactions(live)
     }
   }
 
@@ -2969,6 +3006,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.promptQueue.length = 0
     live.pendingSystemReminders.length = 0
     live.continueReplyTurn = null
+    void dropContinuationReactions(live)
     await stopTypingHeartbeat(live)
     try {
       await live.session.abort()
@@ -3089,6 +3127,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const observed = live.contextBuffer.splice(0, live.contextBuffer.length)
         const reminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
         live.currentTurnAttachments = collectTurnAttachments(observed, batch)
+        live.willingnessReminderIteration =
+          batch.length === 0 && reminders.some((r) => r === WILLINGNESS_NUDGE || r === SEND_WILLINGNESS_NUDGE)
 
         if (batch.length > 0) {
           // A fresh user batch starts a NEW logical turn. Drop any provider
@@ -4491,8 +4531,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.pendingQuoteCandidate = null
     }
     const text = normalizeSendText(msg.text)
-    const outputKind =
-      opts?.outputKind ?? (text !== undefined && detectContinuationWillingness(text) ? 'status' : 'substantive')
+    const continuationWillingness = text !== undefined && detectContinuationWillingness(text)
+    const outputKind = opts?.outputKind ?? (continuationWillingness ? 'status' : 'substantive')
 
     // Central enforcement. Tool-initiated sends are subject to two policies:
     // a per-turn count cap (kills runaway loops regardless of content) and
@@ -4586,6 +4626,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     let delivered = false
     let messageId: string | undefined
     let messageIds: readonly string[] | undefined
+    let reactionRef: ReactionRef | undefined
     try {
       for (const cb of snapshot) {
         const result = await cb(msg)
@@ -4593,6 +4634,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           delivered = true
           messageId = result.messageId
           messageIds = result.messageIds
+          reactionRef = result.reactionRef
           break
         }
         lastError = result.error
@@ -4621,6 +4663,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         else live.lastSentText.set(sendKey, priorLastSentText)
       }
       return { ok: false, error: lastError ?? 'no callback accepted the outbound', code: 'callback-rejected' }
+    }
+
+    if (live && continuationWillingness && reactionRef !== undefined) {
+      reactOnContinuationWillingness(live, reactionRef)
+    } else if (live && !continuationWillingness && outputKind === 'substantive') {
+      void dropContinuationReactions(live)
     }
 
     if (live) {
@@ -4687,6 +4735,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       ok: true,
       ...(messageId !== undefined ? { messageId } : {}),
       ...(messageIds !== undefined ? { messageIds } : {}),
+      ...(reactionRef !== undefined ? { reactionRef } : {}),
     }
   }
 
@@ -4729,6 +4778,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.skippedTurn = null
       logger.info(`[channels] ${live.keyId} skipped_by_tool reason=${JSON.stringify(reason)}`)
       armSilentTurnAck(live, 'skip_response')
+      void dropContinuationReactions(live)
       return
     }
     if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq) {
@@ -5092,9 +5142,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         await postEmptyTurnFallback(live, 'empty_stop_after_tool_work_retries_exhausted')
         return
       }
+      // Explicit NO_REPLY normally records a deliberate choice to stay silent.
+      // Only the reminder iteration that consumed a willingness nudge is different:
+      // the turn-persistent nudge budget remains nonzero after a substantive result,
+      // so using it here would post a bogus fallback on a later unrelated reminder.
+      if (
+        isNoReplySignal(assistantText) &&
+        live.willingnessReminderIteration &&
+        live.successfulChannelSends === successfulSendsBeforePrompt &&
+        live.promptQueue.length === 0
+      ) {
+        await postEmptyTurnFallback(live, 'no_reply_after_willingness_nudge')
+        return
+      }
       const leakedReasoning = !isNoReplySignal(assistantText)
       logger.info(`[channels] ${live.keyId} no_reply${leakedReasoning ? ' (with_leaked_reasoning)' : ''}`)
       armSilentTurnAck(live, 'no_reply')
+      void dropContinuationReactions(live)
       return
     }
 
@@ -5322,6 +5386,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     clearQueuedEngageReactions(live)
     dropEngageReactions(live, live.currentTurnEngageReactions)
     live.currentTurnEngageReactions = []
+    void dropContinuationReactions(live)
     if (live.debounceTimer) clearTimeout(live.debounceTimer)
     live.debounceTimer = null
     live.unsubProviderErrors?.()
@@ -6003,6 +6068,66 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           .catch((err) => {
             logger.info(
               `[channels] silent-ack-unreact threw adapter=${live.key.adapter} chat=${live.key.chat}: ${describeError(err)}`,
+            )
+          }),
+      ),
+    ).then(() => undefined)
+  }
+
+  const reactOnContinuationWillingness = (live: LiveSession, reactionRef: ReactionRef): void => {
+    const addResult = react({
+      adapter: live.key.adapter,
+      workspace: live.key.workspace,
+      chat: live.key.chat,
+      thread: live.key.thread,
+      reactionRef,
+      emoji: CONTINUATION_REACTION_EMOJI,
+    })
+    void addResult
+      .then((result) => {
+        if (!result.ok && result.code !== 'unsupported') {
+          logger.info(
+            `[channels] continuation-react failed adapter=${live.key.adapter} chat=${live.key.chat}: ${result.error}`,
+          )
+        }
+      })
+      .catch((err) => {
+        logger.info(
+          `[channels] continuation-react threw adapter=${live.key.adapter} chat=${live.key.chat}: ${describeError(err)}`,
+        )
+      })
+    live.activeContinuationReactions.push(
+      addResult.then((result) => (result.ok ? (result.reactionRef ?? null) : null)).catch(() => null),
+    )
+  }
+
+  const dropContinuationReactions = (live: LiveSession): Promise<void> => {
+    const addPromises = live.activeContinuationReactions
+    if (addPromises.length === 0) return Promise.resolve()
+    live.activeContinuationReactions = []
+    return Promise.all(
+      addPromises.map((addPromise) =>
+        addPromise
+          .then((reactionRef) => {
+            if (reactionRef === null) return undefined
+            return removeReaction({
+              adapter: live.key.adapter,
+              workspace: live.key.workspace,
+              chat: live.key.chat,
+              thread: live.key.thread,
+              reactionRef,
+            })
+          })
+          .then((result) => {
+            if (result && !result.ok && result.code !== 'unsupported' && result.code !== 'not-found') {
+              logger.info(
+                `[channels] continuation-unreact failed adapter=${live.key.adapter} chat=${live.key.chat}: ${result.error}`,
+              )
+            }
+          })
+          .catch((err) => {
+            logger.info(
+              `[channels] continuation-unreact threw adapter=${live.key.adapter} chat=${live.key.chat}: ${describeError(err)}`,
             )
           }),
       ),

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -273,8 +273,11 @@ export type SendErrorCode =
 // Optional throughout: an adapter whose SDK does not hand back an id (legacy
 // slack/discord user-account adapters) omits both, and callers must treat a
 // missing id as "not available", never as an error.
+// `reactionRef` is the outbound message's adapter-owned TARGET ref — the entity
+// a later ReactionRequest reacts to. It is explicitly NOT the per-reaction
+// removal-instance ref returned by `ReactionResult.reactionRef` after an add.
 export type SendResult =
-  | { ok: true; messageId?: string; messageIds?: readonly string[] }
+  | { ok: true; messageId?: string; messageIds?: readonly string[]; reactionRef?: ReactionRef }
   | { ok: false; error: string; code?: SendErrorCode }
 
 export type OutboundCallback = (msg: OutboundMessage) => Promise<SendResult>


### PR DESCRIPTION
## Background

A deployed agent was asked why a Webex call had failed. It replied, in substance, *"I'll re-check the exact block/failure message and work out what was blocked"* — and then went silent. The human got nothing: no result, no error, no follow-up. Ever.

Container logs show the continuation machinery worked perfectly right up to the last step:

```
send source=tool turn=1 rate=1/5000ms text_len=139   ← the promise posted
terminal_after_channel_reply                          ← terminal reply aborted
willingness_nudge attempt=1/1                         ← detector fired
prompting batch=0 text_len=716                        ← reminder-only re-prompt
no_reply                                              ← agent answered NO_REPLY
```

`detectContinuationWillingness()` matched correctly. The session transcript shows the agent then *did the promised work* — it read the `agent-webex` skill and reasoned to a conclusion ("identifying permission conflict in skill bridge") — and emitted `NO_REPLY` while still holding the answer.

**Root cause is the nudge text itself.** `WILLINGNESS_NUDGE` closed on:

> "If there is nothing left to do, reply with `NO_REPLY`."

The model was being compliant. It had no *work* left, so it took the exit. But "nothing left to **do**" and "nothing left to **say**" are not the same thing, and the nudge conflated them. Its sibling `SEND_WILLINGNESS_NUDGE` never had this problem because it leads with "Send the answer you just worked out now" — the asymmetry between the two was the bug.

**Nothing caught it.** Both degenerate-turn guards (`router.ts` empty-stop paths) are gated on `assistantText.trim() === ''`. An explicit `NO_REPLY` is non-empty, so it escapes both — deliberately, per the comment there. That is correct for ordinary silence, but there was no case for a `NO_REPLY` arriving on a reminder-only iteration that exists *only because the agent promised a human something*. With `MAX_WILLINGNESS_NUDGES = 1` already spent, the promise died with no telemetry beyond a routine `no_reply` line.

Across that agent's full session history, 17 turns reached the willingness nudge and only 9 posted a follow-up.

## Summary

**Reword both nudges.** Lead with the delivery imperative and scope `NO_REPLY` to "the result you promised is already in the channel", explicitly splitting "no work left" from "nothing to report".

Both nudges were reworded, not just the broken one — they share the `willingnessNudges` budget, so the new guard covers both paths. Leaving `SEND_WILLINGNESS_NUDGE` advertising `NO_REPLY` as an ordinary exit while a guard punished it would have desynced the prompt from the runtime.

**Add a guard as the safety net.** A `NO_REPLY` on the reminder iteration that consumed a willingness nudge, which sent nothing of its own, now posts `EMPTY_TURN_FALLBACK_TEXT` rather than dropping the promise. Prompt wording alone is not a guarantee; this is the fail-closed half.

**Show the wait with an hourglass.** ⏳ goes on the promise message and is retired once the promise lands.

*Why a new `SendResult` field and not the alternatives.* Reacting to the agent's own message needs a target ref the router cannot build: `ReactionRef.value` is adapter-private and every ref so far originated from an **inbound**. Considered and rejected:

- **A `registerSelfReactionRef` capability** — adds another public router registry plus adapter start/stop wiring and one more entry on the adapter checklist, and separates target construction from the send path where the platform actually knows the id.
- **Correlating the bot's own message when it loops back as an inbound** — genuinely observable in production, but delivery is platform-dependent, may be filtered, can land either side of the send completing, and needs a second correlation state machine. A fast follow-up could finish before the loopback ever supplies the target.

Returning adapter-owned metadata from the operation that created the target keeps the opacity invariant intact and touches the fewest enumeration sites.

## What this does NOT do

- **No new detection.** `detectContinuationWillingness()` is untouched; it was never the problem, and its existing multi-language coverage is unchanged.
- **No GitHub support.** Its reaction vocabulary is fixed and has no ⏳, so it stays a silent `unsupported` no-op. Telegram, Webex, Teams, Instagram, LINE and KakaoTalk register no reaction callback at all and are likewise unaffected.
- **No nudge-budget change.** `MAX_WILLINGNESS_NUDGES` is still 1.
- **No persisted reaction ledger.** A hard container crash can strand an ⏳. Accepted: this is a best-effort UI side effect, and a startup-replay ledger is disproportionate. Graceful teardown, `/stop`, and idle GC all clean up.
- **No user-account adapter refs** where the SDK does not surface the posted id — those keep omitting the field, exactly as they already omit `messageId`.

## Review notes

The load-bearing change is the guard in `router.ts`:

```ts
isNoReplySignal(assistantText) &&
live.willingnessReminderIteration &&
live.successfulChannelSends === successfulSendsBeforePrompt &&
live.promptQueue.length === 0
```

`willingnessReminderIteration` is set from the reminders spliced for the current drain:

```ts
live.willingnessReminderIteration =
  batch.length === 0 && reminders.some((r) => r === WILLINGNESS_NUDGE || r === SEND_WILLINGNESS_NUDGE)
```

**Invariant to verify:** this must *not* swallow ordinary deliberate silence, and it must *not* fire after the promise was already kept. The turn-persistent `willingnessNudges` counter cannot express that — it stays nonzero for the rest of the logical turn, so a later unrelated reminder answering `NO_REPLY` would have posted a bogus failure notice. The per-iteration marker is what confines the fallback to the prompt that actually consumed the nudge. (Caught in review; regression test added.)

Reaction cleanup follows the `activeSilentAckReactions` discipline exactly — store the **add promise**, never its resolved ref, and snapshot-and-clear synchronously before awaiting — so a fast follow-up cannot race a slow add. There is a test for precisely that race.

All new code paths are mutation-verified: removing the guard turns the positive test red, reverting the marker to the old counter turns the regression test red, and disabling the ⏳ hook turns all six reaction tests red.
