### PR TITLE
Block unsupported completion claims in replies

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -16,6 +16,7 @@ function fakeRouter(
   handler: (msg: OutboundMessage) => Promise<SendResult>,
   options: {
     consecutiveCount?: number
+    qualifyingWorkObserved?: boolean
     resolveReviewThread?: ChannelRouter['resolveReviewThread']
     getReviewState?: ChannelRouter['getReviewState']
   } = {},
@@ -23,6 +24,7 @@ function fakeRouter(
   return {
     route: async () => {},
     send: handler,
+    hasQualifyingWorkThisLogicalTurn: () => options.qualifyingWorkObserved ?? false,
     getConsecutiveSendCount: () => options.consecutiveCount ?? 0,
     getSendRate: () => ({ count: 0, windowMs: 5_000 }),
     registerOutbound: () => {},
@@ -130,6 +132,42 @@ async function runTool(
 }
 
 describe('createChannelReplyTool', () => {
+  test('denies an unsupported completion claim before posting it', async () => {
+    let sent = 0
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => {
+        sent++
+        return { ok: true }
+      }),
+      origin: slackThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: '반영했어' })
+
+    expect(sent).toBe(0)
+    expect(result.details).toMatchObject({ ok: false })
+    expect((result.content[0] as { text: string }).text).toContain('perform the work')
+  })
+
+  test('allows a completion claim after qualifying work was observed', async () => {
+    let sent = 0
+    const tool = createChannelReplyTool({
+      router: fakeRouter(
+        async () => {
+          sent++
+          return { ok: true }
+        },
+        { qualifyingWorkObserved: true },
+      ),
+      origin: slackThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: 'I saved it' })
+
+    expect(sent).toBe(1)
+    expect(result.details).toMatchObject({ ok: true })
+  })
+
   test('addresses the message from the origin and forwards text to router.send', async () => {
     const calls: OutboundMessage[] = []
     const tool = createChannelReplyTool({

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -1,6 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { checkCompletionClaim } from '@/channels/completion-claim'
 import { checkFalseReceipt } from '@/channels/github-false-receipt'
 import { evaluateRereviewGuard } from '@/channels/github-rereview-guard'
 import {
@@ -197,6 +198,19 @@ export function createChannelReplyTool({
       }
       const falseReceiptNotice = falseReceipt.kind === 'warn' ? falseReceipt.notice : null
 
+      const completionClaim = checkCompletionClaim({
+        text,
+        qualifyingWorkObserved: router.hasQualifyingWorkThisLogicalTurn?.(origin) === true,
+      })
+      if (completionClaim.kind === 'block') {
+        logger.warn(formatChannelToolFailure('channel_reply', completionClaim.reason))
+        return {
+          content: [{ type: 'text' as const, text: `channel_reply denied: ${completionClaim.reason}` }],
+          details: { ok: false, error: completionClaim.reason },
+        }
+      }
+      const completionClaimNotice = completionClaim.kind === 'warn' ? completionClaim.notice : null
+
       // Re-review stranding guard: block a thread close-out / verdict ack while
       // the bot still holds its own CHANGES_REQUESTED on this PR, so it can't
       // silently leave the PR blocked (PR #644). Runs before the resolve so a
@@ -307,7 +321,10 @@ export function createChannelReplyTool({
         // TOOL_RESULT_PREFIX to match the denial branch below. The prefix is
         // intentionally weaker and is safe ONLY because denials carry no echoed
         // prose; the success result does, and the weak prefix let Kimi loop.
-        const warnNote = falseReceiptNotice !== null ? fenceRuntimeNotice(falseReceiptNotice) : ''
+        const warnings = [falseReceiptNotice, completionClaimNotice].filter(
+          (notice): notice is string => notice !== null,
+        )
+        const warnNote = warnings.length > 0 ? fenceRuntimeNotice(warnings.join('\n\n')) : ''
         const missNote = resolveMissNotice ?? ''
         return {
           content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hint}${warnNote}${missNote}` }],

--- a/src/channels/completion-claim.test.ts
+++ b/src/channels/completion-claim.test.ts
@@ -72,6 +72,7 @@ describe('checkCompletionClaim', () => {
 
   test.each([
     'The warning "I fixed it" is inaccurate.',
+    "The warning 'I fixed it' is inaccurate.",
     'The warning “I fixed it” is inaccurate.',
     'The warning 「I fixed it」 is inaccurate.',
     'The warning 『I fixed it』 is inaccurate.',
@@ -80,6 +81,20 @@ describe('checkCompletionClaim', () => {
   ])('allows completion-shaped text inside quotation or code spans: %s', (text) => {
     expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('allow')
   })
+
+  test.each(["I've fixed it", "je l'ai enregistré", "l'ho salvato"])(
+    'does not mistake a contraction apostrophe for a quotation span: %s',
+    (text) => {
+      expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('block')
+    },
+  )
+
+  test.each(['상류 시스템이 끝냈어. 반영했어', '상류 시스템이 끝냈어。반영했어', '상류 시스템이 끝냈어\n반영했어'])(
+    'does not carry a Korean third-person subject across a sentence boundary: %s',
+    (text) => {
+      expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('block')
+    },
+  )
 })
 
 describe('isQualifyingWorkResult', () => {

--- a/src/channels/completion-claim.test.ts
+++ b/src/channels/completion-claim.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test'
+
+import { checkCompletionClaim, isQualifyingWorkResult } from './completion-claim'
+
+describe('checkCompletionClaim', () => {
+  test.each(['I saved it', "I've updated it", 'I fixed it', 'I committed it', 'I updated the file', 'I fixed the bug'])(
+    'blocks unsupported English completion claim: %s',
+    (text) => {
+      expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('block')
+    },
+  )
+
+  test.each(['반영했어', '저장했어요', '수정했어', '커밋했어요'])(
+    'blocks unsupported Korean completion claim: %s',
+    (text) => {
+      expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('block')
+    },
+  )
+
+  test('allows the identical claim after qualifying work', () => {
+    expect(checkCompletionClaim({ text: '반영했어', qualifyingWorkObserved: true }).kind).toBe('allow')
+    expect(checkCompletionClaim({ text: 'I saved it', qualifyingWorkObserved: true }).kind).toBe('allow')
+  })
+
+  test.each([
+    'the upstream fixed it',
+    'A teammate already updated it',
+    '상류 시스템이 반영했어',
+    '반영했어?',
+    'I did not save it',
+    'Yesterday I saved it for another project',
+    'A teammate said: I saved it',
+    'I thought I saved it, but the write failed',
+    '어제 반영했어',
+    '상류 시스템이 이미 반영했어',
+  ])('allows descriptive, third-party, question, or negated prose: %s', (text) => {
+    expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('allow')
+  })
+
+  test('warns rather than blocks on an unanchored completion-shaped phrase', () => {
+    expect(checkCompletionClaim({ text: 'updated and ready', qualifyingWorkObserved: false }).kind).toBe('warn')
+  })
+
+  test('does not let a later question hide a declarative completion claim', () => {
+    expect(checkCompletionClaim({ text: 'I saved it. Anything else?', qualifyingWorkObserved: false }).kind).toBe(
+      'block',
+    )
+    expect(checkCompletionClaim({ text: 'I saved it\nAnything else?', qualifyingWorkObserved: false }).kind).toBe(
+      'block',
+    )
+  })
+
+  test('recognizes non-ASCII question punctuation without hiding an earlier assertion', () => {
+    expect(checkCompletionClaim({ text: '私は保存しておきました？', qualifyingWorkObserved: false }).kind).toBe('allow')
+    expect(
+      checkCompletionClaim({ text: '私は保存しておきました。ほかにありますか？', qualifyingWorkObserved: false }).kind,
+    ).toBe('block')
+  })
+
+  test.each([
+    '昨天没有操作。现在我已经保存了',
+    '昨天没有操作！现在我已经保存了',
+    '昨天有操作吗？现在我已经保存了',
+    '昨天没有操作\n现在我已经保存了',
+    '昨日は操作していません。今、私は保存しておきました',
+    '昨日は操作していません！今、私は保存しておきました',
+    '昨日は操作しましたか？今、私は保存しておきました',
+    '昨日は操作していません\n今、私は保存しておきました',
+  ])('does not carry historical context across a CJK sentence boundary: %s', (text) => {
+    expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('block')
+  })
+
+  test.each([
+    'The warning "I fixed it" is inaccurate.',
+    'The warning “I fixed it” is inaccurate.',
+    'The warning 「I fixed it」 is inaccurate.',
+    'The warning 『I fixed it』 is inaccurate.',
+    '警告「我已经修好了」は不正確です。',
+    'The warning `I fixed it` is inaccurate.',
+  ])('allows completion-shaped text inside quotation or code spans: %s', (text) => {
+    expect(checkCompletionClaim({ text, qualifyingWorkObserved: false }).kind).toBe('allow')
+  })
+})
+
+describe('isQualifyingWorkResult', () => {
+  test.each(['read', 'write', 'edit', 'bash'])('counts a successful %s result as qualifying work', (toolName) => {
+    expect(isQualifyingWorkResult({ toolName, isError: false, details: { ok: true } })).toBe(true)
+  })
+
+  test.each(['channel_reply', 'channel_send', 'channel_react', 'todo_write', 'skip_response'])(
+    'does not count successful communication/control tool %s',
+    (toolName) => {
+      expect(isQualifyingWorkResult({ toolName, isError: false, details: { ok: true } })).toBe(false)
+    },
+  )
+
+  test('requires success and completed subagent work', () => {
+    expect(isQualifyingWorkResult({ toolName: 'write', isError: true, details: { ok: true } })).toBe(false)
+    expect(isQualifyingWorkResult({ toolName: 'write', isError: false, details: { ok: false } })).toBe(false)
+    expect(
+      isQualifyingWorkResult({ toolName: 'spawn_subagent', isError: false, details: { mode: 'background' } }),
+    ).toBe(false)
+    expect(isQualifyingWorkResult({ toolName: 'spawn_subagent', isError: false, details: { mode: 'sync' } })).toBe(true)
+    expect(
+      isQualifyingWorkResult({ toolName: 'subagent_output', isError: false, details: { status: 'completed' } }),
+    ).toBe(true)
+  })
+
+  test.each(['web_fetch', 'web_search'])('does not count a normally returned %s failure', (toolName) => {
+    expect(isQualifyingWorkResult({ toolName, isError: false, details: { error: true } })).toBe(false)
+  })
+})

--- a/src/channels/completion-claim.ts
+++ b/src/channels/completion-claim.ts
@@ -66,7 +66,7 @@ function matchesKoreanClaim(text: string): boolean {
   for (const phrase of KO_PHRASES) {
     for (const index of phraseIndexes(text, phrase)) {
       if (claimIsQuestion(text, index) || claimHasPastOrAttributedContext(text, index)) continue
-      const prefix = text.slice(Math.max(0, index - 24), index)
+      const prefix = text.slice(Math.max(latestSentenceBoundary(text, index) + 1, index - 24), index)
       if (KOREAN_OTHER_SUBJECT.test(prefix) && !KOREAN_FIRST_PERSON_SUBJECT.test(prefix)) continue
       return true
     }
@@ -108,9 +108,13 @@ function earliestIndex(text: string, needles: readonly string[], offset: number)
 }
 
 function claimHasPastOrAttributedContext(text: string, claimIndex: number): boolean {
-  const sentenceStart = Math.max(...SENTENCE_TERMINATORS.map((terminator) => text.lastIndexOf(terminator, claimIndex)))
+  const sentenceStart = latestSentenceBoundary(text, claimIndex)
   const prefix = text.slice(sentenceStart + 1, claimIndex)
   return HISTORICAL_MARKERS.some((marker) => prefix.includes(marker)) || ATTRIBUTION_END.test(prefix)
+}
+
+function latestSentenceBoundary(text: string, offset: number): number {
+  return Math.max(...SENTENCE_TERMINATORS.map((terminator) => text.lastIndexOf(terminator, offset)))
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -252,6 +256,7 @@ const NON_ASSERTED_SPAN_PATTERNS: readonly RegExp[] = [
   /```[\s\S]*?```/gu,
   /`[^`\r\n]*`/gu,
   /"[^"\r\n]*"/gu,
+  /(?<![\p{L}\p{N}])'[^'\r\n]+'(?![\p{L}\p{N}])/gu,
   /“[^”\r\n]*”/gu,
   /‘[^’\r\n]*’/gu,
   /「[^」\r\n]*」/gu,

--- a/src/channels/completion-claim.ts
+++ b/src/channels/completion-claim.ts
@@ -1,0 +1,302 @@
+export type CompletionClaimDecision =
+  | { kind: 'allow' }
+  | { kind: 'block'; reason: string }
+  | { kind: 'warn'; notice: string }
+
+export type CompletionClaimInput = {
+  text: string | undefined
+  qualifyingWorkObserved: boolean
+}
+
+export type ToolResultEvidenceInput = {
+  toolName: string
+  isError: boolean
+  details: unknown
+}
+
+export function checkCompletionClaim(input: CompletionClaimInput): CompletionClaimDecision {
+  if (input.qualifyingWorkObserved) return { kind: 'allow' }
+  const text = normalize(input.text ?? '')
+  if (text === '') return { kind: 'allow' }
+
+  if (matchesKoreanClaim(text) || hasAssertivePhrase(text, ALL_FIRST_PERSON_PHRASES)) {
+    return { kind: 'block', reason: UNSUPPORTED_COMPLETION_REASON }
+  }
+  if (SOFT_PHRASES.some((phrase) => text.includes(phrase))) {
+    return { kind: 'warn', notice: SOFT_NOTICE }
+  }
+  return { kind: 'allow' }
+}
+
+export function isQualifyingWorkResult(input: ToolResultEvidenceInput): boolean {
+  if (input.isError) return false
+  const details = isRecord(input.details) ? input.details : undefined
+  if (details?.ok === false || details?.error === true) return false
+  if (
+    NON_WORK_TOOLS.has(input.toolName) ||
+    input.toolName.startsWith('channel_') ||
+    input.toolName.startsWith('todo_')
+  ) {
+    return false
+  }
+  if (input.toolName === 'spawn_subagent') return details?.mode === 'sync'
+  if (input.toolName === 'subagent_output') return details?.status === 'completed'
+  return true
+}
+
+function normalize(text: string): string {
+  return maskQuotedAndCodeSpans(text)
+    .toLocaleLowerCase()
+    .replace(/[*_~]/gu, ' ')
+    .replace(/\r\n?/gu, '\n')
+    .replace(/[^\S\n]+/gu, ' ')
+    .replace(/ *\n */gu, '\n')
+    .replace(/\n+/gu, '\n')
+    .trim()
+}
+
+function maskQuotedAndCodeSpans(text: string): string {
+  return NON_ASSERTED_SPAN_PATTERNS.reduce(
+    (masked, pattern) => masked.replace(pattern, (span) => span.replace(/[^\r\n]/gu, ' ')),
+    text,
+  )
+}
+
+function matchesKoreanClaim(text: string): boolean {
+  for (const phrase of KO_PHRASES) {
+    for (const index of phraseIndexes(text, phrase)) {
+      if (claimIsQuestion(text, index) || claimHasPastOrAttributedContext(text, index)) continue
+      const prefix = text.slice(Math.max(0, index - 24), index)
+      if (KOREAN_OTHER_SUBJECT.test(prefix) && !KOREAN_FIRST_PERSON_SUBJECT.test(prefix)) continue
+      return true
+    }
+  }
+  return false
+}
+
+function hasAssertivePhrase(text: string, phrases: readonly string[]): boolean {
+  return phrases.some((phrase) => {
+    return phraseIndexes(text, phrase).some(
+      (index) => !claimIsQuestion(text, index) && !claimHasPastOrAttributedContext(text, index),
+    )
+  })
+}
+
+function phraseIndexes(text: string, phrase: string): number[] {
+  const indexes: number[] = []
+  let offset = 0
+  while (offset < text.length) {
+    const index = text.indexOf(phrase, offset)
+    if (index < 0) break
+    indexes.push(index)
+    offset = index + phrase.length
+  }
+  return indexes
+}
+
+function claimIsQuestion(text: string, claimIndex: number): boolean {
+  const nextQuestion = earliestIndex(text, QUESTION_TERMINATORS, claimIndex)
+  if (nextQuestion < 0) return false
+  const nextStatementEnd = earliestIndex(text, DECLARATIVE_TERMINATORS, claimIndex)
+  if (nextStatementEnd < 0) return true
+  return nextQuestion < nextStatementEnd
+}
+
+function earliestIndex(text: string, needles: readonly string[], offset: number): number {
+  const indexes = needles.map((needle) => text.indexOf(needle, offset)).filter((index) => index >= 0)
+  return indexes.length === 0 ? -1 : Math.min(...indexes)
+}
+
+function claimHasPastOrAttributedContext(text: string, claimIndex: number): boolean {
+  const sentenceStart = Math.max(...SENTENCE_TERMINATORS.map((terminator) => text.lastIndexOf(terminator, claimIndex)))
+  const prefix = text.slice(sentenceStart + 1, claimIndex)
+  return HISTORICAL_MARKERS.some((marker) => prefix.includes(marker)) || ATTRIBUTION_END.test(prefix)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+// Every block phrase is first-person and perfective. Bare verbs stay in the
+// warning tier so descriptions of another actor are never hard-denied.
+const EN_PHRASES: readonly string[] = [
+  'i saved it',
+  "i've saved it",
+  'i have saved it',
+  'i wrote it',
+  "i've written it",
+  'i recorded it',
+  'i applied it',
+  'i updated it',
+  "i've updated it",
+  'i fixed it',
+  "i've fixed it",
+  'i deployed it',
+  'i committed it',
+  'i removed it',
+  'i deleted it',
+  'i saved the ',
+  "i've saved the ",
+  'i wrote the ',
+  "i've written the ",
+  'i recorded the ',
+  'i applied the ',
+  'i updated the ',
+  "i've updated the ",
+  'i fixed the ',
+  "i've fixed the ",
+  'i deployed the ',
+  'i committed the ',
+  'i removed the ',
+  'i deleted the ',
+  'i saved your ',
+  'i updated your ',
+  'i fixed your ',
+]
+
+// Korean commonly drops the subject. The perfective endings below are safe for
+// a bare assistant ack; an explicit nearby third-person 은/는/이/가 subject
+// demotes the match, while 내가/제가 keeps the first-person reading.
+const KO_PHRASES: readonly string[] = [
+  '저장했어',
+  '저장했습니다',
+  '기록했어',
+  '기록했습니다',
+  '반영했어',
+  '반영했습니다',
+  '고쳤어',
+  '고쳤습니다',
+  '수정했어',
+  '수정했습니다',
+  '커밋했어',
+  '커밋했습니다',
+  '삭제했어',
+  '삭제했습니다',
+]
+
+const ES_PHRASES: readonly string[] = ['lo guardé', 'lo escribí', 'lo actualicé', 'lo corregí', 'lo eliminé']
+const FR_PHRASES: readonly string[] = [
+  "je l'ai enregistré",
+  "je l'ai écrit",
+  "je l'ai mis à jour",
+  "je l'ai corrigé",
+  "je l'ai supprimé",
+]
+const IT_PHRASES: readonly string[] = [
+  "l'ho salvato",
+  "l'ho scritto",
+  "l'ho aggiornato",
+  "l'ho corretto",
+  "l'ho eliminato",
+]
+const PT_PHRASES: readonly string[] = ['eu salvei', 'eu escrevi', 'eu atualizei', 'eu corrigi', 'eu removi']
+const DE_PHRASES: readonly string[] = [
+  'ich habe es gespeichert',
+  'ich habe es geschrieben',
+  'ich habe es aktualisiert',
+  'ich habe es korrigiert',
+  'ich habe es gelöscht',
+]
+const RU_PHRASES: readonly string[] = ['я сохранил', 'я записал', 'я обновил', 'я исправил', 'я удалил']
+const ZH_PHRASES: readonly string[] = ['我已经保存了', '我已经写好了', '我已经更新了', '我已经修好了', '我已经删除了']
+const JA_PHRASES: readonly string[] = [
+  '私は保存しておきました',
+  '私は書いておきました',
+  '私は更新しておきました',
+  '私は修正しておきました',
+  '私は削除しておきました',
+]
+const AR_PHRASES: readonly string[] = ['أنا حفظته', 'أنا كتبته', 'أنا حدّثته', 'أنا أصلحته', 'أنا حذفته']
+const HI_PHRASES: readonly string[] = [
+  'मैंने इसे सहेज दिया',
+  'मैंने इसे लिख दिया',
+  'मैंने इसे अपडेट कर दिया',
+  'मैंने इसे ठीक कर दिया',
+  'मैंने इसे हटा दिया',
+]
+const TR_PHRASES: readonly string[] = ['kaydettim', 'yazdım', 'güncelledim', 'düzelttim', 'sildim']
+const VI_PHRASES: readonly string[] = ['tôi đã lưu', 'tôi đã viết', 'tôi đã cập nhật', 'tôi đã sửa', 'tôi đã xóa']
+const ID_PHRASES: readonly string[] = [
+  'saya sudah menyimpan',
+  'saya sudah menulis',
+  'saya sudah memperbarui',
+  'saya sudah memperbaiki',
+  'saya sudah menghapus',
+]
+
+const ALL_FIRST_PERSON_PHRASES: readonly string[] = [
+  ...EN_PHRASES,
+  ...ES_PHRASES,
+  ...FR_PHRASES,
+  ...IT_PHRASES,
+  ...PT_PHRASES,
+  ...DE_PHRASES,
+  ...RU_PHRASES,
+  ...ZH_PHRASES,
+  ...JA_PHRASES,
+  ...AR_PHRASES,
+  ...HI_PHRASES,
+  ...TR_PHRASES,
+  ...VI_PHRASES,
+  ...ID_PHRASES,
+]
+
+const KOREAN_OTHER_SUBJECT = /(?:^|[\s,])[^\s,]{1,16}(?:은|는|이|가)(?:\s+\S+){0,3}\s*$/u
+const KOREAN_FIRST_PERSON_SUBJECT = /(?:내가|제가|나는|저는)(?:\s+\S+){0,3}\s*$/u
+const ATTRIBUTION_END =
+  /(?:said|wrote|reported|dijo|a dit|ha detto|disse|sagte|сказал[аи]?|说|言いました|قال|कहा|dedi|nói|berkata|말했어|말했습니다|썼어|썼습니다)\s*[:"“']?\s*$/u
+const QUESTION_TERMINATORS: readonly string[] = ['?', '？', '﹖']
+const DECLARATIVE_TERMINATORS: readonly string[] = ['.', '!', '。', '！', '｡', '．', '﹒', '﹗', '\n']
+const SENTENCE_TERMINATORS: readonly string[] = [...QUESTION_TERMINATORS, ...DECLARATIVE_TERMINATORS]
+const NON_ASSERTED_SPAN_PATTERNS: readonly RegExp[] = [
+  /```[\s\S]*?```/gu,
+  /`[^`\r\n]*`/gu,
+  /"[^"\r\n]*"/gu,
+  /“[^”\r\n]*”/gu,
+  /‘[^’\r\n]*’/gu,
+  /「[^」\r\n]*」/gu,
+  /『[^』\r\n]*』/gu,
+]
+const HISTORICAL_MARKERS: readonly string[] = [
+  'yesterday',
+  'earlier',
+  'previously',
+  'i thought',
+  'i think',
+  'last week',
+  'last month',
+  'for another project',
+  'ayer',
+  'hier',
+  'ieri',
+  'ontem',
+  'gestern',
+  'вчера',
+  '昨天',
+  '昨日',
+  'أمس',
+  'कल',
+  'dün',
+  'hôm qua',
+  'kemarin',
+  '어제',
+  '라고',
+  '줄 알았',
+  '전에',
+  '이전에',
+  '지난주',
+  '지난달',
+]
+
+const SOFT_PHRASES: readonly string[] = ['saved and ready', 'updated and ready', '반영 완료', '수정 완료']
+
+const NON_WORK_TOOLS = new Set(['skip_response', 'restart', 'grant_role', 'subagent_cancel'])
+
+const UNSUPPORTED_COMPLETION_REASON =
+  'This reply claims you already completed durable work, but this logical turn has no successful non-communication work result to support it. ' +
+  'Actually perform the work with the appropriate tool, confirm that it succeeds, and then reply with the completion claim. ' +
+  'If no durable change was intended, reword the reply without claiming it was saved, applied, updated, fixed, or otherwise completed.'
+
+const SOFT_NOTICE =
+  'This reply sounds completion-shaped, but no successful non-communication work was observed this turn. ' +
+  'Only claim a durable result after the relevant tool succeeds; otherwise describe what remains to be done.'

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -20,6 +20,7 @@ import { readContinuationState } from '@/agent/todo/continuation-state'
 import { recordTurnOutcome } from '@/agent/todo/continuation-wiring'
 import { resolveTodoScope } from '@/agent/todo/scope'
 import { writeTodos } from '@/agent/todo/store'
+import { createChannelReplyTool } from '@/agent/tools/channel-reply'
 import type { PermissionService } from '@/permissions'
 import type { HookBus, SessionIdleEvent } from '@/plugin'
 import { waitFor } from '@/test-helpers/wait-for'
@@ -13772,7 +13773,7 @@ describe('ChannelRouter per-turn live role anchor', () => {
 describe('ChannelRouter post-tool follow-up suppression', () => {
   function afterToolContext(
     toolName: string,
-    result: { ok: boolean; more_work_this_turn?: boolean },
+    result: Record<string, unknown>,
     isError: boolean,
     replyText?: string,
   ): AfterToolCallContext {
@@ -13839,6 +13840,82 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     await agent.afterToolCall!(afterToolContext('channel_send', { ok: true }, false))
     expect(agent.signal.aborted).toBe(false)
   })
+
+  test('records only successful non-communication, non-control work as completion evidence', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+    const agent = sessions[0]!.agent
+    let sent = 0
+    router.registerOutbound('discord-bot', async () => {
+      sent++
+      return { ok: true }
+    })
+    const reply = createChannelReplyTool({ router, origin: KEY })
+    const executeReply = (text: string) =>
+      reply.execute(
+        'reply-call',
+        { text, more_work_this_turn: false },
+        undefined,
+        undefined,
+        {} as Parameters<typeof reply.execute>[4],
+      )
+
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true, more_work_this_turn: true }, false))
+    await agent.afterToolCall!(afterToolContext('todo_write', { ok: true }, false))
+    expect(router.hasQualifyingWorkThisLogicalTurn!(KEY)).toBe(false)
+    expect((await executeReply('반영했어')).details).toMatchObject({ ok: false })
+    expect(sent).toBe(0)
+
+    await agent.afterToolCall!(afterToolContext('write', { ok: false }, true))
+    expect(router.hasQualifyingWorkThisLogicalTurn!(KEY)).toBe(false)
+    expect((await executeReply('반영했어')).details).toMatchObject({ ok: false })
+    expect(sent).toBe(0)
+
+    await agent.afterToolCall!(afterToolContext('edit', { ok: true }, false))
+    expect(router.hasQualifyingWorkThisLogicalTurn!(KEY)).toBe(true)
+    expect((await executeReply('반영했어')).details).toMatchObject({ ok: true })
+    expect(sent).toBe(1)
+
+    router.__testing!.injectContinuationReminder(KEY, 'continue the current logical turn')
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.hasQualifyingWorkThisLogicalTurn!(KEY)).toBe(true)
+
+    await router.route(inbound({ externalMessageId: 'next-real-turn', text: 'new task' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.hasQualifyingWorkThisLogicalTurn!(KEY)).toBe(false)
+  })
+
+  test.each(['web_fetch', 'web_search'])(
+    'does not accept a claim after a normally returned %s failure',
+    async (toolName) => {
+      const dir = await tempDir()
+      const { router, sessions } = makeRouter(dir)
+      await router.route(inbound())
+      await router.__testing!.flushDebounce(KEY)
+      const agent = sessions[0]!.agent
+      let sent = 0
+      router.registerOutbound('discord-bot', async () => {
+        sent++
+        return { ok: true }
+      })
+      const reply = createChannelReplyTool({ router, origin: KEY })
+
+      await agent.afterToolCall!(afterToolContext(toolName, { error: true, message: 'request failed' }, false))
+      const result = await reply.execute(
+        'reply-call',
+        { text: 'I saved it', more_work_this_turn: false },
+        undefined,
+        undefined,
+        {} as Parameters<typeof reply.execute>[4],
+      )
+
+      expect(router.hasQualifyingWorkThisLogicalTurn!(KEY)).toBe(false)
+      expect(result.details).toMatchObject({ ok: false })
+      expect(sent).toBe(0)
+    },
+  )
 
   test('stashes the reply text on a terminal channel_reply so the willingness nudge can read it', async () => {
     const agent = await liveAgentAfterRoute(await tempDir())

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5526,12 +5526,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (live.draining) continue
       if (live.promptQueue.length > 0) continue
       // pendingSystemReminders is checked alongside promptQueue because both
-      // represent pending work that drain() will process. Today's only
-      // populator (injectSubagentCompletionReminder) also fires drain()
-      // synchronously, which sets draining=true and shadows this guard via
-      // the line above — but the guard exists to keep the invariant honest
-      // for any future caller that queues a reminder without immediately
-      // waking the drain loop.
+      // represent pending work that drain() will process. Reminder injection
+      // wakes an idle session immediately, but deliberately leaves a pending
+      // inbound debounce in charge so both queues coalesce into one turn.
       if (live.pendingSystemReminders.length > 0) continue
       if (t - live.lastInboundAt <= SESSION_IDLE_MS) continue
       if (isPinnedByRunningChild(live.sessionId, live.keyId, 'idle_gc evicting')) continue
@@ -5927,17 +5924,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // hard-block that legitimate fetch.
     forgetSharedLoopGuardTool(live.sessionId, SUBAGENT_OUTPUT_TOOL_NAME)
     logger.info(`[channels] ${live.keyId}: subagent-completion reminder queued task=${args.taskId} ok=${args.ok}`)
-    // Wake the drain loop. If a turn is already in flight, the wakeup is
-    // a no-op because drain() will pick up the reminder on its next
-    // iteration (it now gates on promptQueue OR pendingSystemReminders).
-    // If the session is idle, fire drain() immediately rather than going
-    // through the debounce path — the reminder is not a user inbound,
-    // so the "coalesce nearby inbounds" rationale for debouncing does
-    // not apply. Mirrors the TUI path's `idle ? 'interrupt' : 'queue'`
-    // semantics: the channel router doesn't have a `delivery: interrupt`
-    // mechanism (no in-flight abort during a turn), but firing drain()
-    // immediately is the equivalent for an idle session.
-    if (!live.draining) {
+    // Wake an idle session immediately, but leave an already-scheduled inbound
+    // debounce in charge. Starting a fire-and-forget drain here would splice
+    // both queues before the debounce owner can await that drain, making the
+    // caller observe an in-progress turn and defeating deterministic coalescing.
+    // An in-flight drain picks up the reminder on its next iteration.
+    if (!live.draining && live.debounceTimer === null) {
       void drain(live)
     }
     return { kind: 'delivered', keyId: live.keyId }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -39,6 +39,7 @@ import type { Stream } from '@/stream'
 
 import { extractMentionedUserIds } from './adapters/mention-hints'
 import { formatChannelCommandHelp } from './commands'
+import { isQualifyingWorkResult } from './completion-claim'
 import { detectContinuationWillingness } from './continuation-willingness'
 import { describeError } from './describe-error'
 import {
@@ -1168,6 +1169,10 @@ type LiveSession = {
   // retry iterations that end the turn. Reset ONLY on a real user batch,
   // beside `githubReviewOutputTurn`.
   toolExecutionThisLogicalTurn: boolean
+  // Successful, non-communication, non-control tool output observed during
+  // this logical turn. Unlike toolExecutionThisLogicalTurn, channel_reply and
+  // todo/control calls cannot satisfy a later durable completion claim.
+  qualifyingWorkThisLogicalTurn: boolean
   // True while a successful `channel_reply({ more_work_this_turn: true })`
   // promise remains unfulfilled in this LOGICAL turn. Unlike the per-iteration
   // `continueReplyTurn` stamp used by retry authorization and empty-stop
@@ -1310,6 +1315,7 @@ export type ChannelRouter = {
     chat: string
     thread?: string | null
   }) => number
+  hasQualifyingWorkThisLogicalTurn?: (target: ChannelKey) => boolean
   getSendRate: (target: {
     adapter: ChannelKey['adapter']
     workspace: string
@@ -2345,6 +2351,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         stagedFallbackCause: null,
         githubReviewOutputTurn: null,
         toolExecutionThisLogicalTurn: false,
+        qualifyingWorkThisLogicalTurn: false,
         promisedWorkOutstandingThisLogicalTurn: false,
         pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
@@ -2738,6 +2745,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     agent.afterToolCall = async (context, signal) => {
       const result = prior ? await prior(context, signal) : undefined
       const details = context.result.details as { ok?: unknown; more_work_this_turn?: unknown } | undefined
+      if (
+        isQualifyingWorkResult({
+          toolName: context.toolCall.name,
+          isError: context.isError,
+          details: context.result.details,
+        })
+      ) {
+        live.qualifyingWorkThisLogicalTurn = true
+      }
       const succeeded = context.toolCall.name === 'channel_reply' && !context.isError && details?.ok === true
       const keepTurnAlive = details?.more_work_this_turn === true
       if (succeeded) {
@@ -3255,6 +3271,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // empty-turn fallback across the reminder-only retry iterations.
           live.githubReviewOutputTurn = null
           live.toolExecutionThisLogicalTurn = false
+          live.qualifyingWorkThisLogicalTurn = false
           live.promisedWorkOutstandingThisLogicalTurn = false
         } else if (live.lastTurnAuthorId !== null) {
           live.currentTurnEngageReactions = []
@@ -5435,6 +5452,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return live.consecutiveSends.get(consecutiveSendKey(target.chat, target.thread)) ?? 0
   }
 
+  const hasQualifyingWorkThisLogicalTurn = (target: ChannelKey): boolean => {
+    return liveSessions.get(channelKeyId(target))?.qualifyingWorkThisLogicalTurn === true
+  }
+
   const getSendRate = (target: {
     adapter: ChannelKey['adapter']
     workspace: string
@@ -6219,6 +6240,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     route,
     send,
     getConsecutiveSendCount,
+    hasQualifyingWorkThisLogicalTurn,
     getSendRate,
     registerOutbound,
     unregisterOutbound,


### PR DESCRIPTION
## Background

A channel agent told its operator that context had been saved — a persisted annotation on the conversation's context — when the only thing that logical turn actually did was reply. No read, write, edit, or delegation had run. Challenged on it, the agent repeated the same completion claim before eventually admitting nothing had been persisted.

Nothing in the existing guards catches this. `detectContinuationWillingness()` only scores whether the model intends to *keep working*; it says nothing about whether a claim of already-finished work is backed by anything that actually ran. A reply is free to say "done" regardless of what happened this turn.

## Summary

`detectContinuationWillingness()` stays untouched and out of scope here by design: it covers *future* intent ("I'll check that next") to decide whether a turn should continue. This adds a separate check for *past/perfective* claims already sitting in the outgoing reply — "I saved it", "저장했습니다" — evaluated against what the turn actually did, not what it says it will do. The two signals never share phrase content and are wired independently.

The new piece is `checkCompletionClaim()`, a precision-first, 15-language phrase classifier (EN, KO, ES, FR, IT, PT, DE, RU, ZH, JA, AR, HI, TR, VI, ID) built on Unicode-aware sentence/question boundaries — ASCII, CJK, and fullwidth terminators (`.`, `!`, `?`, `。`, `！`, `？`, `｡`, `．`, `﹒`, `﹗`) plus line breaks — rather than ASCII-only splitting. Before classification, matched double-quote (`"…"`, `"…"`), balanced single-quote (`'…'`), and CJK quotation spans (`「…」`, `『…』`), plus backtick code spans (inline and fenced), are masked out, so a completion-shaped phrase sitting inside a quote or a code block is never treated as the model's own assertion. The single-quote span is bounded with Unicode letter/number lookaround so a contraction apostrophe — `I've`, `je l'ai`, `l'ho` — is never mistaken for an opening or closing quote and stays classifiable:

- **Hard block** only first-person, current-task, perfective claims. Questions, historical/attributed prose ("yesterday I...", "she said she fixed it"), and Korean sentences carrying an explicit third-person subject *within the same sentence* are excluded from the block tier by construction, not by afterthought — a description of someone else's work, or your own past work, is never hard-denied, and a third-person subject from a prior sentence can no longer suppress a completion claim in the next one.
- **Soft warn** for completion-shaped-but-ambiguous phrasing ("saved and ready", "반영 완료") — flagged, not blocked.

The claim is only evaluated against a new `qualifyingWorkThisLogicalTurn` signal on the router's live session, set from `afterToolCall`. A tool result counts only if it is not a communication or control call and carries no explicit failure marker — `isError`, `details.ok === false`, and `details.error === true` all disqualify it, the last of which catches first-party tools like `web_fetch`/`web_search` that report failure in their own payload without throwing. Reads, writes, edits, bash, and a *completed* synchronous subagent delegation (`spawn_subagent` with `mode: 'sync'`, or `subagent_output` with `status: 'completed'`) all count when they succeed. Channel sends and reactions, `todo_*` calls, `skip_response`/`restart`/`grant_role`/`subagent_cancel`, and any failed or normally-returned-as-failed tool call do not. The flag resets at the start of each new logical turn alongside the existing `toolExecutionThisLogicalTurn` marker.

`channel_reply` runs the check before sending: a block denies the send (same failure-formatting path other pre-send guards use) and tells the agent to either do the work first or reword the reply without the completion claim; a warn is folded into the existing multi-notice fencing alongside the false-receipt notice.

## What this does NOT do

- No change to `detectContinuationWillingness()` or the willingness-nudge machinery — future-intent detection is untouched.
- No promise ledger, protected-todos tracking, or terminal-abort provenance. This checks the current reply against the current logical turn's tool results only; it does not track claims across turns.
- No session-origin-specific guidance and no prompt-copy changes for any origin.
- No version bump.

## Testing

- `bun run typecheck` — clean.
- `bun run lint` — 0 errors (69 pre-existing warnings, unrelated to this change).
- `bun run format` — clean, no changes.
- Targeted suite (`completion-claim.test.ts`, `channel-reply.test.ts`, `router.test.ts`, `continuation-willingness.test.ts`): 1021 pass, 0 fail.
- Regression coverage added for: a normally-returned `web_fetch`/`web_search` failure (`details.error === true`, nothing thrown) not counting as qualifying work; Chinese and Japanese sentence-boundary cases where an earlier historical or negated clause must not leak past a CJK terminator into a later completion claim; completion-shaped text sitting inside straight/curly/CJK quotation marks and backtick spans; newline-only boundaries, which cannot be used to launder a declarative completion claim past a trailing question; English, French, and Italian contraction apostrophes (`I've fixed it`, `je l'ai enregistré`, `l'ho salvato`) that must stay classifiable rather than being masked as a quotation span; and Korean third-person-subject exemptions bounded to the current sentence across period, ideographic full stop, and newline boundaries.

## Review notes

The precision-first split lives in `completion-claim.ts`: the question check, the historical/attributed-context check, and the Korean first-person-vs-third-person subject regexes are what keep the block tier from over-firing. Removing any one of them turns an otherwise-safe sentence (a question, a quote, someone else's past action) into a hard block — verify against the false-positive cases in the test file before loosening the phrase tables.

The other invariant worth checking is the `afterToolCall` wiring in `router.ts`: `qualifyingWorkThisLogicalTurn` must reset on a new logical turn before it's read again, and a successful `channel_reply` call must never count as qualifying work for itself — the check runs before the send completes, not after.