### PR TITLE
Correct the stale models.dev Upstage mapping note

### DIFF
--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -38,9 +38,16 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string | null> = {
   xai: 'xai',
   minimax: 'minimax',
   deepseek: 'deepseek',
-  // Upstage is not listed on models.dev (checked api.json — no `upstage` lab
-  // entry, only HuggingFace open-model ids). Mapping to `upstage` is harmless:
-  // the upstream lookup misses and the curated Solar entries surface anyway.
+  // models.dev has listed Upstage since 2025-07-09 (solar-pro2 + solar-mini,
+  // then solar-pro3 on 2026-01-13 and solar-pro4 on 2026-08-06), so this
+  // mapping hits rather than misses. `buildOption` prefers upstream
+  // name/reasoning/limits, so the picker can show numbers that disagree with
+  // `providers.ts`. Display-only: `customModelMetaFromOption` returns
+  // undefined for known refs, so `resolveModel` still serves the curated
+  // record — including the `thinkingLevelMap` and `compat` that Upstage's
+  // wire format depends on and models.dev has no field for. solar-open2 is
+  // partner-program only and still absent upstream, so it keeps surfacing
+  // curated.
   upstage: 'upstage',
   moonshot: 'moonshot',
   // moonshot-coding (Kimi Code subscription) is a billing surface, not a


### PR DESCRIPTION
## Background

[#1339](https://github.com/typeclaw/typeclaw/pull/1339) added `upstage/solar-pro4` to the curated catalog and noted at the time that models.dev didn't list it. models.dev does list `solar-pro4` now, which raised the reasonable question of whether the hardcoded record can be dropped and backfilled from upstream.

**It can't**, and chasing that down surfaced that the note on the `PROVIDER_TO_MODELS_DEV` mapping is asserting something false.

## Why the curated record can't be dropped

models.dev is consumed in exactly one place — `MODELS_DEV_URL` in `src/init/models-dev.ts` — and it only builds the **init/model-picker** list. The runtime resolver, `resolveModel()` in `src/config/config.ts`, reads `KNOWN_PROVIDERS` and never consults models.dev.

Deleting the entry would fail silently rather than loudly, because `upstage/solar-pro4` still passes schema validation on the known provider prefix. `resolveModel` would synthesize it from the first remaining Upstage model (`solar-open2`), and the synthesis path does not carry `thinkingLevelMap` — a field models.dev has no equivalent for. pi-ai would then pass pi levels through verbatim (`model.thinkingLevelMap?.[level] ?? level`), which reintroduces both bugs #1339 existed to fix:

- `off` omits the field, and pro4 reasons **on** by default — silent latency and billing on every non-reasoning turn.
- pi's `minimal` forwards as Upstage's `minimal`, which Upstage documents as a reasoning-**off** value, disabling reasoning on a request that asked for it.

`compat` is likewise absent upstream, and it's what pins Upstage's `max_tokens` field, no `developer` role, no `store`, no `strict`.

## What this changes

Comment only. The mapping value `upstage: 'upstage'` is correct, but its justification never was:

> Upstage is not listed on models.dev (checked api.json — no `upstage` lab entry, only HuggingFace open-model ids). Mapping to `upstage` is harmless: the upstream lookup misses and the curated Solar entries surface anyway.

models.dev has listed Upstage since **2025-07-09**. Per `sst/models.dev` history for `providers/upstage/`:

| date | commit | change |
|---|---|---|
| 2025-07-09 | `830a8b0b` | `provider.toml` + `solar-pro2` + `solar-mini` |
| 2026-01-13 | `ad0e98f7` | `solar-pro3` |
| 2026-08-06 | `f1f6a6ef` | `solar-pro4` |

So the lookup was never a miss — it was already hitting for pro2/mini when #1339 was written. `buildOption` prefers upstream `name`/`reasoning`/`limit` over the curated record, so the picker has been displaying numbers that disagree with `providers.ts`:

| model | curated (runtime) | models.dev (shown in picker) |
|---|---|---|
| solar-pro3 | 128000 / 32000 | 131072 / **8192** |
| solar-pro2 | 65000 / 16000 | 65536 / **8192** |
| solar-mini | 32000 / 8000 | 32768 / **4096** |
| solar-pro4 | 524288 / 131072 | matches |

That stays display-only — `customModelMetaFromOption` returns `undefined` for known refs, so nothing reaches `customModels` and `resolveModel` keeps serving the curated record. The replacement note leads with the 2025-07-09 listing, records that the mapping hits, why that's display-only, and that `solar-open2` is partner-program only and still absent upstream.

## What this does NOT do

- **Doesn't touch `providers.ts`.** I checked the curated Solar limits against Upstage's own docs while I was here. Upstage **does not publish a max-output-token limit** for pro3/pro2/mini at all, so neither the curated value nor models.dev's 8192/4096 is supported and there's no basis for a change. Curated pricing is the correct one (models.dev's $0.25/$0.25 for pro3/pro2 contradicts [upstage.ai/pricing/api](https://www.upstage.ai/pricing/api)). Upstage does state exact context windows of 65536 and 32768 for pro2/mini vs. the curated 65000/32000 — but those look like deliberate conservative round-downs, so I left them for a separate call rather than quietly shaving the margin.
- **Doesn't add a test.** The invariants are already pinned: curated-only survival by the `kimi-k2p6-turbo` case (`models-dev.test.ts:127`), upstream-name-wins at `:112-113`, and solar-pro4's `thinkingLevelMap`/`compat` by #1339's config and payload tests. A new test would restate coverage.

## Verification

`bun run lint` (0 errors), `bun run format:check`, and `bun run typecheck` are clean. Full suite: **12360 pass / 31 skip / 0 fail**.