### PR TITLE
Use Upstage's exact Solar context windows

### DIFF
--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -781,14 +781,20 @@ export const KNOWN_PROVIDERS = {
   // the console, the OpenAI-SDK example, and the agent docs all use bare `/v1`.
   //
   // Model lineup spans two families on the same Console API + key:
-  //   * Closed chat models. solar-pro4 (512K context / 128K output, released
-  //     2026-08-06, current flagship) is per the live model page
-  //     console.upstage.ai/docs/models/solar-pro4; the rest are from the agent
-  //     API reference (console.upstage.ai/api/docs/for-agents) as of
-  //     2026-03-23: solar-pro3 (102B MoE / 12B active, 128K), solar-pro2
-  //     (31B, 65K), solar-mini (10.7B, 32K, cheap/fast). Note that the
-  //     for-agents dump is stale (self-dated 2026-03-07) and omits pro4 — its
-  //     absence there is not evidence the model is unavailable.
+  //   * Closed chat models, per the live model pages under
+  //     console.upstage.ai/docs/models — solar-pro-4, solar-pro-3,
+  //     solar-pro-2, solar-mini (the slugs are hyphenated; the unhyphenated
+  //     form 404s): solar-pro4 (524288 context / 131072 output, released
+  //     2026-08-06, current flagship), solar-pro3 (102B MoE / 12B active,
+  //     128000), solar-pro2 (31B, 65536), solar-mini (10.7B, 32768,
+  //     cheap/fast). The contextWindow values below are those exact
+  //     documented figures. Upstage publishes NO maximum output length for
+  //     pro3/pro2/mini, so their maxTokens are deliberate conservative
+  //     choices of ours rather than sourced numbers — do not "correct" them
+  //     against a third-party catalog that states one. The older agent API
+  //     reference (console.upstage.ai/api/docs/for-agents) is stale
+  //     (self-dated 2026-03-07) and omits pro4 — its absence there is not
+  //     evidence the model is unavailable.
   //   * The open-weight Solar Open family: solar-open2 (Solar Open 2), a 102B
   //     MoE / 12B active model with a 128K context. It launched on the Console
   //     API for the Solar Agent Partner program (Stage 1, from 2026-07-17) —
@@ -965,7 +971,7 @@ export const KNOWN_PROVIDERS = {
         },
         input: ['text'],
         cost: { input: 0.15, output: 0.6, cacheRead: 0.015, cacheWrite: 0 },
-        contextWindow: 65000,
+        contextWindow: 65536,
         maxTokens: 16000,
         compat: {
           supportsStore: false,
@@ -985,7 +991,7 @@ export const KNOWN_PROVIDERS = {
         reasoning: false,
         input: ['text'],
         cost: { input: 0.15, output: 0.15, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 32000,
+        contextWindow: 32768,
         maxTokens: 8000,
         compat: {
           supportsStore: false,


### PR DESCRIPTION
## Background

Follow-up to [#1345](https://github.com/typeclaw/typeclaw/pull/1345). While establishing whether models.dev could back the curated Solar records, I checked every disputed field against Upstage's own model pages. Two context windows were rounded down, and the source note pointed at a URL that no longer exists.

## Summary

`solar-pro2` carried `65000` and `solar-mini` carried `32000`. Upstage documents **65536** and **32768**. Nothing depended on the rounding, and a context window that understates the real one only truncates history earlier than it needs to.

| model | before | after | Upstage source |
|---|---|---|---|
| solar-pro2 | 65000 | **65536** | [solar-pro-2](https://console.upstage.ai/docs/models/solar-pro-2) |
| solar-mini | 32000 | **32768** | [solar-mini](https://console.upstage.ai/docs/models/solar-mini) |

`solar-pro3` already matched Upstage's exact 128000 and is untouched.

## The source note went with them

It cited `console.upstage.ai/docs/models/solar-pro4`, which **404s** — the live slugs are hyphenated (`solar-pro-4`, `solar-pro-3`, `solar-pro-2`, `solar-mini`). It also attributed pro3/pro2/mini to the `for-agents` dump that the very same paragraph calls stale, which is where the rounded figures came from. It now cites the live per-model pages for all four.

## maxTokens is deliberately NOT changed

Worth stating plainly, because it looks like an omission: **Upstage publishes no maximum output length for pro3/pro2/mini at all.** The curated 32000/16000/8000 are our own conservative choices, not sourced numbers.

models.dev asserts 8192/8192/4096 for these three with no upstream basis I could find, and matching it would look like a correction while actually replacing our deliberate choice with an unsourced third-party guess. Pricing is the same story in reverse — models.dev says $0.25/$0.25 for pro3/pro2, contradicting [upstage.ai/pricing/api](https://www.upstage.ai/pricing/api); curated is already right.

The note now says outright not to "correct" `maxTokens` against a third-party catalog, so the next person doing this audit stops where I did.

## No test

`providers.ts` is a config catalog, and its existing Upstage tests assert invariants — every model on `openai-completions`, every model carrying `compat`, the `thinkingLevelMap` reasoning-group semantics — not raw figures. The one value assertion, `solar-open2`'s zero cost, encodes "no published price yet". A test restating `contextWindow === 65536` would just duplicate the literal, which `AGENTS.md` calls noise.

## Verification

`bun run lint` (0 errors), `bun run format:check`, `bun run typecheck` clean. `src/config/` + `src/init/` + `src/cli/model.test.ts`: 523 pass / 0 fail.

Full suite: 12437 pass / 31 skip / 1 fail. The failure is `wrapSystemTool > rejects excess queued snapshot waiters`, the 30s-timeout flake [#1339](https://github.com/typeclaw/typeclaw/pull/1339) documented as reproducing on clean `origin/main`; it passed in isolation on this machine and is unreachable from two integer literals in a model catalog.