### PR TITLE
Stop models.dev metadata overriding curated records

### DIFF
--- a/src/init/models-dev.test.ts
+++ b/src/init/models-dev.test.ts
@@ -68,7 +68,7 @@ describe('fetchModelOptions', () => {
   })
 
   test('merges live data with curated entries when fetch succeeds', async () => {
-    // given: a stub response with a richer name for one curated model and a new upstream model.
+    // given: a stub response with a rival name for one curated model and a new upstream model.
     const stub = {
       openai: {
         id: 'openai',
@@ -110,7 +110,7 @@ describe('fetchModelOptions', () => {
 
     expect(result.source).toBe('models.dev')
     const nano = result.options.find((o) => o.ref === 'openai/gpt-5.4-nano')
-    expect(nano?.modelName).toBe('GPT-5.4 nano (live)')
+    expect(nano?.modelName).toBe('GPT-5.4 nano')
     const live = result.options.find((o) => o.ref === 'openai/gpt-6-live')
     expect(live).toMatchObject({
       modelName: 'GPT-6 Live',
@@ -125,6 +125,82 @@ describe('fetchModelOptions', () => {
     expect(result.options.some((o) => o.modelName === 'Invalid')).toBe(false)
     // kimi-k2p6-turbo is curated-only; must still appear even though models.dev didn't list it.
     expect(result.options.some((o) => o.modelId === 'accounts/fireworks/routers/kimi-k2p6-turbo')).toBe(true)
+  })
+
+  test('a curated record outranks contradicting models.dev metadata on every field', async () => {
+    // The picker has to describe what `resolveModel` will actually serve, and
+    // that is always the curated record for a known ref. Upstream disagreeing
+    // is the normal case, not an anomaly: models.dev names solar-pro3 with its
+    // bare id and caps its output at 8192, where providers.ts says "Solar Pro
+    // 3" and 32000.
+    const fetchImpl = routedFetch({
+      [MODELS_DEV_URL]: {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'gpt-5.4-nano': {
+              id: 'gpt-5.4-nano',
+              name: 'GPT-5.4 nano (live)',
+              reasoning: false,
+              modalities: { input: ['text'], output: ['text'] },
+              limit: { context: 111111, output: 2222 },
+              cost: { input: 9.99, output: 9.99, cache_read: 9.99, cache_write: 9.99 },
+            },
+          },
+        },
+      },
+      [OPENGATEWAY_CATALOG_URL]: new Error('gateway catalog down'),
+      [OPENGATEWAY_PRICES_URL]: new Error('gateway prices down'),
+    })
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.options.find((o) => o.ref === 'openai/gpt-5.4-nano')).toMatchObject({
+      modelName: 'GPT-5.4 nano',
+      reasoning: true,
+      supportsVision: true,
+      contextWindow: 400000,
+      maxTokens: 128000,
+      cost: { input: 0.2, output: 1.25, cacheRead: 0.02, cacheWrite: 0 },
+    })
+  })
+
+  test('upstream still supplies every field for a ref we do not curate', async () => {
+    // The flip to curated-first must not starve uncurated models, which have no
+    // curated record to read and would otherwise lose their metadata entirely.
+    const fetchImpl = routedFetch({
+      [MODELS_DEV_URL]: {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'gpt-6-live': {
+              id: 'gpt-6-live',
+              name: 'GPT-6 Live',
+              reasoning: true,
+              modalities: { input: ['text', 'image'], output: ['text'] },
+              limit: { context: 500000, output: 64000 },
+              cost: { input: 1, output: 2, cache_read: 0.1, cache_write: 0.2 },
+            },
+          },
+        },
+      },
+      [OPENGATEWAY_CATALOG_URL]: new Error('gateway catalog down'),
+      [OPENGATEWAY_PRICES_URL]: new Error('gateway prices down'),
+    })
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.options.find((o) => o.ref === 'openai/gpt-6-live')).toMatchObject({
+      modelName: 'GPT-6 Live',
+      curated: false,
+      reasoning: true,
+      supportsVision: true,
+      contextWindow: 500000,
+      maxTokens: 64000,
+      cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },
+    })
   })
 
   test('never synthesizes bare models.dev ids onto opengateway, which requires a creator prefix', async () => {

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -40,14 +40,10 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string | null> = {
   deepseek: 'deepseek',
   // models.dev has listed Upstage since 2025-07-09 (solar-pro2 + solar-mini,
   // then solar-pro3 on 2026-01-13 and solar-pro4 on 2026-08-06), so this
-  // mapping hits rather than misses. `buildOption` prefers upstream
-  // name/reasoning/limits, so the picker can show numbers that disagree with
-  // `providers.ts`. Display-only: `customModelMetaFromOption` returns
-  // undefined for known refs, so `resolveModel` still serves the curated
-  // record — including the `thinkingLevelMap` and `compat` that Upstage's
-  // wire format depends on and models.dev has no field for. solar-open2 is
-  // partner-program only and still absent upstream, so it keeps surfacing
-  // curated.
+  // mapping hits rather than misses — harmless either way, since `buildOption`
+  // lets upstream fill gaps but never override the curated Solar records, and
+  // those specify every field. solar-open2 is partner-program only and still
+  // absent upstream, so it surfaces curated.
   upstage: 'upstage',
   moonshot: 'moonshot',
   // moonshot-coding (Kimi Code subscription) is a billing surface, not a
@@ -310,6 +306,19 @@ type BuildOptionOpts = {
   upstream?: ModelsDevModel
 }
 
+// The curated record wins every field it specifies; upstream only fills gaps.
+// A known ref always resolves to the curated record at runtime — `resolveModel`
+// reads `KNOWN_PROVIDERS`, never models.dev, and `customModelMetaFromOption`
+// declines to persist metadata for known refs — so letting upstream win here
+// only desynchronized the picker from the model it was describing. It showed in
+// what `formatModelLabel`/`formatModelHint` render (name, context, reasoning):
+// models.dev names solar-pro3/pro2/mini with their bare ids, so the picker
+// offered "solar-pro3" where the curated record says "Solar Pro 3". maxTokens
+// and cost reach no surface today, so aligning them is consistency within the
+// record, not a visible fix. `supportsVision` already resolved this way (see
+// `resolveInput`, and the note on `ModelOption.supportsVision`); this extends
+// the rule to the rest. Refs we do not curate still take everything from
+// upstream, which is the whole point of merging it in.
 function buildOption(ref: ModelRef | string, opts: BuildOptionOpts): ModelOption {
   const providerId = providerForModelRef(ref)
   const modelId = ref.slice(providerId.length + 1)
@@ -323,6 +332,7 @@ function buildOption(ref: ModelRef | string, opts: BuildOptionOpts): ModelOption
         maxTokens?: number
         reasoning?: boolean
         input?: ReadonlyArray<string>
+        cost?: ModelOptionCost
       }
     >
   )[modelId]
@@ -332,11 +342,11 @@ function buildOption(ref: ModelRef | string, opts: BuildOptionOpts): ModelOption
     providerId,
     providerName: provider.name,
     modelId,
-    modelName: opts.upstream?.name ?? curatedModel?.name ?? modelId,
-    reasoning: opts.upstream?.reasoning ?? curatedModel?.reasoning ?? false,
-    contextWindow: opts.upstream?.limit?.context ?? curatedModel?.contextWindow ?? null,
-    maxTokens: opts.upstream?.limit?.output ?? curatedModel?.maxTokens ?? null,
-    cost: resolveCost(opts.upstream?.cost),
+    modelName: curatedModel?.name ?? opts.upstream?.name ?? modelId,
+    reasoning: curatedModel?.reasoning ?? opts.upstream?.reasoning ?? false,
+    contextWindow: curatedModel?.contextWindow ?? opts.upstream?.limit?.context ?? null,
+    maxTokens: curatedModel?.maxTokens ?? opts.upstream?.limit?.output ?? null,
+    cost: curatedModel?.cost ?? resolveCost(opts.upstream?.cost),
     curated: opts.curated,
     supportsVision: input.includes('image'),
   }


### PR DESCRIPTION
Follow-up to [#1345](https://github.com/typeclaw/typeclaw/pull/1345), which established that models.dev never reaches the runtime catalog. This fixes the divergence that fact created.

## The bug

`buildOption` preferred models.dev over the curated record on `name`, `reasoning`, `contextWindow` and `maxTokens`, and read `cost` from upstream **only** — a curated price never reached the picker at all:

```ts
modelName: opts.upstream?.name ?? curatedModel?.name ?? modelId,
contextWindow: opts.upstream?.limit?.context ?? curatedModel?.contextWindow ?? null,
maxTokens: opts.upstream?.limit?.output ?? curatedModel?.maxTokens ?? null,
cost: resolveCost(opts.upstream?.cost),
```

So the init picker described a different model than the one it was about to select.

**What the user actually saw.** `formatModelLabel` (`src/cli/init.ts:2088`) is just `modelName`, and `formatModelHint` (`:2098`) emits `NNK ctx` plus `reasoning`. Upstage makes the name case stark — models.dev's `name` for three of the four Solar models is the **bare model id**:

| ref | picker showed | `providers.ts` says |
|---|---|---|
| `upstage/solar-pro3` | `solar-pro3` · 131K ctx | **Solar Pro 3** · 128K ctx |
| `upstage/solar-pro2` | `solar-pro2` | **Solar Pro 2** |
| `upstage/solar-mini` | `solar-mini` | **Solar Mini** |
| `upstage/solar-pro4` | Solar Pro 4 | Solar Pro 4 (upstream agrees) |

`maxTokens` and `cost` reach no surface today, so aligning those is consistency within the record rather than a visible fix — they were dead fields carrying wrong values. Thanks @typeey for catching that I had it backwards in the first draft.

**Nothing downstream rescued any of it**, which is what makes this more than cosmetic:

- `resolveModel()` (`src/config/config.ts`) reads `KNOWN_PROVIDERS` and never consults models.dev.
- `customModelMetaFromOption()` returns `undefined` for known refs, so the metadata isn't persisted to `customModels` either.

A known ref always runs on the curated record, no matter what the catalog said.

## The fix

Curated wins every field it specifies; upstream fills the gaps. That's already how `supportsVision` resolved — `resolveInput` reads curated first and falls back to `modalities.input`, and `ModelOption.supportsVision` documents the curated array as "the source of truth — pi-ai consumes it directly". This extends the same rule to the remaining fields, and adds curated `cost` to the lookup.

**Refs we don't curate are untouched** and still take everything from upstream — that's the entire point of merging models.dev in, and there's a new test pinning it so a future over-correction can't starve them.

## Why this isn't just an Upstage fix

The old precedence was defensible on "models.dev is fresher than our hand-written block", and for most providers it's invisible because our curated records happen to agree with theirs. Upstage is simply where the two sources diverge far enough to notice. The rule is provider-independent, so it doesn't wait for the next catalog to drift.

## Tests

`models-dev.test.ts:113` asserted the *old* behavior — a curated model taking the upstream `GPT-5.4 nano (live)` name — so it's re-pinned to the curated `GPT-5.4 nano`. Two tests added:

- **curated outranks contradicting upstream on every field** — stub disagrees with `gpt-5.4-nano` on name, reasoning, modalities, limits *and* price; all six assertions expect the curated values.
- **upstream still supplies every field for an uncurated ref** — guards the starvation regression.

The old stub's nano limits (`400000`/`128000`) happened to *equal* the curated ones, so it proved nothing about limit precedence; the new stub uses deliberately conflicting values.

**Mutation-tested.** Reverting the five `??` orders in `buildOption` fails both the new precedence test and the re-pinned merge test:

```
(fail) merges live data with curated entries when fetch succeeds
(fail) a curated record outranks contradicting models.dev metadata on every field
 11 pass, 2 fail
```

## Review note

The load-bearing lines are the `??` orders. A reviewer's instinct may be that upstream should win because it's fresher — that's exactly the bug, and it's invisible in a diff of argument order, so the rationale is recorded in a comment above `buildOption`.

## Verification

`bun run lint` (0 errors), `bun run format:check`, `bun run typecheck` clean. Full suite: **12440 pass / 31 skip / 0 fail**.