### PR TITLE
fix: avoid canonicalizing channel message text

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -164,6 +164,42 @@ describe('wrapPluginTool', () => {
     expect(result).toMatchObject({ isError: true })
   })
 
+  test('blocks a colliding plugin channel_send text operand that names a canonical secret', async () => {
+    const calls: string[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ text: z.string() }),
+      async execute(args) {
+        calls.push(args.text)
+        return { content: [] }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('security', '/agent', noopLogger, {
+      'tool.before': (event) =>
+        checkPrivateSurfaceReadGuard({
+          tool: event.tool,
+          args: event.args,
+          agentDir: '/agent',
+          hidden: { dirs: [], files: [] },
+          toolProvenance: event.toolProvenance,
+        }),
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'collision',
+      toolName: 'channel_send',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks,
+    })
+
+    const result = await wrapped.execute('c', { text: 'secrets.json' }, undefined, undefined, {} as never)
+
+    expect(calls).toEqual([])
+    expect(result).toMatchObject({ isError: true })
+  })
+
   test('a nonFile-declared identifier colliding with a hidden dir passes the private-surface guard, undeclared still blocks', async () => {
     // Reproduces the guard-ordering the runtime uses: private-surface-read runs
     // in tool.before, BEFORE the file-operand scanner, and must honor the tool's

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -354,6 +354,8 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         sessionId: opts.sessionId,
         callId: toolCallId,
         args: mutableArgs,
+        toolProvenance: 'plugin',
+
         ...(liveOrigin !== undefined ? { origin: liveOrigin } : {}),
         ...(tool.fileOperands !== undefined ? { fileOperands: tool.fileOperands } : {}),
       }
@@ -453,6 +455,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
         sessionId: opts.sessionId,
         callId: toolCallId,
         args: mutableArgs,
+        toolProvenance: 'first-party',
         ...(liveOrigin !== undefined ? { origin: liveOrigin } : {}),
         ...(preflightFileOperands !== undefined ? { fileOperands: preflightFileOperands } : {}),
       })

--- a/src/bundled-plugins/security/index.test.ts
+++ b/src/bundled-plugins/security/index.test.ts
@@ -114,6 +114,16 @@ describe('security plugin wiring', () => {
     expect(result?.reason).toContain('outboundSecret')
   })
 
+  test('tool.before blocks a plugin-origin channel_send canonical credential argument', async () => {
+    const hook = await toolBeforeHook()
+    const result = await hook(
+      { ...toolEvent('channel_send', { text: 'secrets.json' }), toolProvenance: 'plugin' },
+      hookContext('/agent'),
+    )
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('privateSurfaceRead')
+  })
+
   test('tool.before blocks channel_send leaking env-var names (recon)', async () => {
     const hook = await toolBeforeHook()
     const result = await hook(

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -236,6 +236,7 @@ export default definePlugin({
               args: event.args,
               agentDir: ctx.agentDir,
               hidden: resolveHiddenPaths(ctx.permissions, event.origin, ctx.agentDir),
+              toolProvenance: event.toolProvenance,
               ...(event.fileOperands !== undefined ? { fileOperands: event.fileOperands } : {}),
             },
             {

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -31,7 +31,7 @@ const guestHidden: HiddenPaths = {
 const privilegedHidden: HiddenPaths = { dirs: [], files: [] }
 
 function check(tool: string, args: Record<string, unknown>, hidden: HiddenPaths = guestHidden) {
-  return checkPrivateSurfaceReadGuard({ tool, args, agentDir: AGENT, hidden })
+  return checkPrivateSurfaceReadGuard({ tool, args, agentDir: AGENT, hidden, toolProvenance: 'first-party' })
 }
 
 function localOnlyLstat(agentDir: string): (candidate: string) => Stats {
@@ -1037,6 +1037,7 @@ describe('private-surface-read guard — honors a tool author fileOperands.nonFi
         args: { text: 'secrets.json' },
         agentDir: AGENT,
         hidden: privilegedHidden,
+        toolProvenance: 'plugin',
         fileOperands: { input: ['text'] },
       })?.block,
     ).toBe(true)

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -190,6 +190,13 @@ describe('private-surface-read guard — free-text field scoping (no false posit
     expect(check('look_at_channel_attachment', { prompt: 'sessions' })).toBeUndefined()
   })
 
+  test('does not canonicalize a Korean channel message longer than one filesystem filename', () => {
+    const text = '보안 경로 검사와 무관한 Slack 메시지입니다. '.repeat(20)
+
+    expect(Buffer.byteLength(text, 'utf8')).toBeGreaterThan(255)
+    expect(check('channel_send', { text })).toBeUndefined()
+  })
+
   test('does not block an identifier-only tool whose remote id equals a hidden dir name', () => {
     // These tools read no local path (shared TOOLS_WITHOUT_LOCAL_FILE_OPERANDS
     // set); an id like workspace/target_id/task_id="memory" must not resolve to
@@ -230,6 +237,15 @@ describe('private-surface-read guard — free-text field scoping (no false posit
     expect(check('grep', { pattern: 'token', path: 'sessions' })?.block).toBe(true)
     expect(check('look_at', { images: [{ path: 'memory/x.png' }] })?.block).toBe(true)
     expect(check('channel_send', { text: 'memory', attachments: [{ path: 'sessions/s.jsonl' }] })?.block).toBe(true)
+  })
+
+  test('still blocks a hidden channel attachment path when text is free-form', () => {
+    expect(
+      check('channel_send', {
+        text: '보안 경로 검사와 무관한 Slack 메시지입니다. '.repeat(20),
+        attachments: [{ path: 'sessions/s.jsonl' }],
+      })?.block,
+    ).toBe(true)
   })
 
   test('fail-closed: an UNKNOWN key on an unknown tool is still scanned', () => {

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -1030,6 +1030,18 @@ describe('private-surface-read guard — honors a tool author fileOperands.nonFi
     ).toBe(true)
   })
 
+  test('blocks a colliding channel_send plugin local text operand from reading a canonical credential', () => {
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'channel_send',
+        args: { text: 'secrets.json' },
+        agentDir: AGENT,
+        hidden: privilegedHidden,
+        fileOperands: { input: ['text'] },
+      })?.block,
+    ).toBe(true)
+  })
+
   test('skips a declared nonFile operand colliding with a hidden dir', () => {
     expect(
       checkPrivateSurfaceReadGuard({

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -88,10 +88,12 @@ export function checkPrivateSurfaceReadGuard(
     const roleEmpty = roleDirs.length === 0 && roleFiles.length === 0
     if (canonicalEmpty && roleEmpty) return undefined
     const realpath = hooks.realpathNative ?? realpathSync.native
+    const nonFile = fileOperands?.nonFile === undefined ? undefined : new Set(fileOperands.nonFile)
+    const localOperands = collectLocalOperandPaths(fileOperands)
 
     if (!canonicalEmpty) {
       const identityScanner = createHardlinkIdentityScanner(agentDir, canonicalDirs, canonicalFiles, hooks)
-      for (const candidate of collectPathCandidates(args, tool, undefined, undefined, true)) {
+      for (const candidate of collectPathCandidates(args, tool, undefined, undefined, true, true)) {
         const hit = matchHidden(candidate, agentDir, canonicalDirs, canonicalFiles, identityScanner, realpath)
         if (hit !== undefined) return privateSurfacePathBlock(tool, candidate, hit)
       }
@@ -99,9 +101,7 @@ export function checkPrivateSurfaceReadGuard(
 
     if (!roleEmpty) {
       const identityScanner = createHardlinkIdentityScanner(agentDir, roleDirs, roleFiles, hooks)
-      const nonFile = fileOperands?.nonFile === undefined ? undefined : new Set(fileOperands.nonFile)
-      const localOperands = collectLocalOperandPaths(fileOperands)
-      for (const candidate of collectPathCandidates(args, tool, nonFile, localOperands, false)) {
+      for (const candidate of collectPathCandidates(args, tool, nonFile, localOperands)) {
         const hit = matchHidden(candidate, agentDir, roleDirs, roleFiles, identityScanner, realpath)
         if (hit !== undefined) return privateSurfacePathBlock(tool, candidate, hit)
       }
@@ -290,6 +290,17 @@ const FREE_TEXT_KEYS_BY_TOOL: Record<string, ReadonlySet<string>> = {
   channel_fetch_attachment: new Set(['filename']),
 }
 
+// Canonical credential checks normally scan every field, including generic
+// prose keys on unknown tools, because an unclassified plugin argument may
+// dereference a local file. These channel tools have an explicit schema:
+// addressing and message fields are remote identifiers or prose, while only
+// attachments[].path can read a local file. Keep this per-tool and per-key so
+// future tools remain fail-closed by default.
+const CANONICAL_FREE_TEXT_KEYS_BY_TOOL: Record<string, ReadonlySet<string>> = {
+  channel_send: new Set(['adapter', 'workspace', 'chat', 'thread', 'text', 'filename']),
+  channel_reply: new Set(['text', 'filename']),
+}
+
 // Trim before the `file:` test: an exempt prose key otherwise lets a
 // leading-whitespace `file:  file://…/memory` URI slip past the scan (the value
 // is not path-shaped and `isFileUrl` misses it), reaching a fetcher that trims
@@ -343,9 +354,10 @@ function collectPathCandidates(
   nonFile?: ReadonlySet<string>,
   localOperands?: ReadonlySet<string>,
   disableExemptions = false,
+  canonicalToolSemantics = false,
 ): string[] {
   const out: string[] = []
-  walk(value, out, tool, false, nonFile, localOperands, '', disableExemptions)
+  walk(value, out, tool, false, nonFile, localOperands, '', disableExemptions, canonicalToolSemantics)
   return out
 }
 
@@ -358,10 +370,11 @@ function walk(
   localOperands: ReadonlySet<string> | undefined,
   operandPath: string,
   disableExemptions: boolean,
+  canonicalToolSemantics: boolean,
   key?: string,
 ): void {
   if (typeof value === 'string') {
-    if (!disableExemptions) {
+    if (!disableExemptions || canonicalToolSemantics) {
       const declaredLocal = localOperands?.has(operandPath) === true
       if (!declaredLocal) {
         if (nonFile?.has(operandPath) === true) return
@@ -375,17 +388,41 @@ function walk(
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      walk(item, out, tool, underExempt, nonFile, localOperands, operandPath, disableExemptions, key)
+      walk(
+        item,
+        out,
+        tool,
+        underExempt,
+        nonFile,
+        localOperands,
+        operandPath,
+        disableExemptions,
+        canonicalToolSemantics,
+        key,
+      )
     }
     return
   }
   if (value !== null && typeof value === 'object') {
     const toolFreeText = FREE_TEXT_KEYS_BY_TOOL[tool]
+    const canonicalToolFreeText = canonicalToolSemantics ? CANONICAL_FREE_TEXT_KEYS_BY_TOOL[tool] : undefined
     for (const [childKey, item] of Object.entries(value)) {
-      if (disableExemptions && childKey === 'filename' && toolFreeText?.has(childKey) === true) continue
-      const keyIsExempt = !disableExemptions && (NON_PATH_KEYS.has(childKey) || (toolFreeText?.has(childKey) ?? false))
+      const keyIsExempt =
+        (!disableExemptions && (NON_PATH_KEYS.has(childKey) || (toolFreeText?.has(childKey) ?? false))) ||
+        (canonicalToolFreeText?.has(childKey) ?? false)
       const childPath = operandPath === '' ? childKey : `${operandPath}.${childKey}`
-      walk(item, out, tool, underExempt || keyIsExempt, nonFile, localOperands, childPath, disableExemptions, childKey)
+      walk(
+        item,
+        out,
+        tool,
+        underExempt || keyIsExempt,
+        nonFile,
+        localOperands,
+        childPath,
+        disableExemptions,
+        canonicalToolSemantics,
+        childKey,
+      )
     }
   }
 }

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -93,7 +93,7 @@ export function checkPrivateSurfaceReadGuard(
 
     if (!canonicalEmpty) {
       const identityScanner = createHardlinkIdentityScanner(agentDir, canonicalDirs, canonicalFiles, hooks)
-      for (const candidate of collectPathCandidates(args, tool, undefined, undefined, true, true)) {
+      for (const candidate of collectPathCandidates(args, tool, undefined, localOperands, true, true)) {
         const hit = matchHidden(candidate, agentDir, canonicalDirs, canonicalFiles, identityScanner, realpath)
         if (hit !== undefined) return privateSurfacePathBlock(tool, candidate, hit)
       }

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url'
 
 import { TOOLS_WITHOUT_LOCAL_FILE_OPERANDS } from '@/agent/tools-without-local-file-operands'
 import { RECOVER_MISSING_OR_UNSEARCHABLE, realIntendedPathSync } from '@/path-safety/real-intended-path'
-import type { ToolFileOperands } from '@/plugin'
+import type { ToolFileOperands, ToolProvenance } from '@/plugin'
 import {
   CANONICAL_AGENT_SECRET_FILES,
   CANONICAL_HOME_SECRET_DIRS,
@@ -77,10 +77,11 @@ export function checkPrivateSurfaceReadGuard(
     agentDir: string
     hidden: HiddenPaths
     fileOperands?: ToolFileOperands
+    toolProvenance?: ToolProvenance
   },
   hooks: PrivateSurfaceIdentityScanHooks = {},
 ): SecurityBlock | undefined {
-  const { tool, args, agentDir, hidden, fileOperands } = options
+  const { tool, args, agentDir, hidden, fileOperands, toolProvenance } = options
   if (UNSCANNED_TOOLS.has(tool)) return undefined
   try {
     const { canonicalDirs, canonicalFiles, roleDirs, roleFiles } = deniedSurface(agentDir, hidden)
@@ -93,7 +94,14 @@ export function checkPrivateSurfaceReadGuard(
 
     if (!canonicalEmpty) {
       const identityScanner = createHardlinkIdentityScanner(agentDir, canonicalDirs, canonicalFiles, hooks)
-      for (const candidate of collectPathCandidates(args, tool, undefined, localOperands, true, true)) {
+      for (const candidate of collectPathCandidates(
+        args,
+        tool,
+        undefined,
+        localOperands,
+        true,
+        toolProvenance === 'first-party',
+      )) {
         const hit = matchHidden(candidate, agentDir, canonicalDirs, canonicalFiles, identityScanner, realpath)
         if (hit !== undefined) return privateSurfacePathBlock(tool, candidate, hit)
       }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -61,6 +61,7 @@ export type {
   ToolBeforeResult,
   ToolContext,
   ToolFileOperands,
+  ToolProvenance,
   ToolLogger,
   ToolResult,
 } from './types'

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -220,12 +220,21 @@ export type SessionPromptEvent = {
 
 // Fired for plugin-defined tools and TypeClaw-exposed system tools, including
 // built-in pi tools (read/bash/edit/write/grep/find/ls) when plugins are wired.
+//
+// Set exclusively by TypeClaw's tool wrappers before a tool.before hook runs.
+// Tool names and arguments are model/plugin controlled, so guards must not use
+// either as evidence that a call is first-party.
+export type ToolProvenance = 'first-party' | 'plugin'
+
 export type ToolBeforeEvent = {
   tool: string
   sessionId: string
   callId: string
   args: Record<string, unknown>
   origin?: SessionOrigin
+  // Internal wrapper-authenticated provenance. Omitted only by direct callers;
+  // guards must treat an omitted value as untrusted.
+  toolProvenance?: ToolProvenance
   // The tool author's operand declarations (never model-controlled — set on the
   // static Tool definition at registration). Carried so a guard that runs before
   // the file-operand scanner (private-surface-read) can honor the same


### PR DESCRIPTION
## Problem

`privateSurfaceRead` has two scans:

1. a **canonical-secret scan** for runtime credentials such as `/agent/secrets.json`; and
2. a role-specific private-surface scan for directories such as `memory/` and `sessions/`.

The canonical scan intentionally disabled the generic free-text exemptions so an *unknown plugin* could not label a filesystem operand `text` and read a credential file. That defensive choice accidentally applied to the known `channel_send` schema as well. Its `text` value was therefore treated as a local candidate path and passed to `realpath` as `/agent/<entire message>`.

For a Korean message whose UTF-8 byte length exceeds the filesystem component limit, `realpath` raises `ENAMETOOLONG`. The guard correctly fails closed on a real path-validation error, but here it was validating a value that cannot be a filesystem operand. The call was rejected before the channel adapter/Slack API was reached.

### Representative example

This is a synthetic example, not production message content:

```ts
channel_send({
  adapter: 'slack-bot',
  workspace: 'T-example',
  chat: 'C-example',
  text: '배포 상태를 확인했습니다. '.repeat(40),
})
```

Before this patch, the canonical scan resolved the whole `text` payload as though it were an `/agent/...` pathname. After this patch, only a real upload operand is inspected:

```ts
channel_send({
  adapter: 'slack-bot',
  workspace: 'T-example',
  chat: 'C-example',
  text: '첨부 파일을 확인해 주세요.',
  attachments: [{ path: 'sessions/export.jsonl' }],
})
```

The attachment remains blocked because `attachments[].path` is still collected and checked against the private surface.

## Historical context

The split that made the canonical scan intentionally ignore generic free-text exemptions landed in [PR #1349](https://github.com/typeclaw/typeclaw/pull/1349), [`ad8a394d` — "Enforce role-derived denial where the MCP declaration is known"](https://github.com/typeclaw/typeclaw/commit/ad8a394dcf8b2464badc1f64c660d2cbb64794e7). That change hardened `mcp_call` handling: an unknown/MCP-declared operand must not bypass canonical credential protection merely because it uses a conventional prose key such as `text` or `query`.

That security objective remains valid. The regression came from applying the same unclassified-input rule to a first-party channel schema whose fields have known semantics. This PR restores the intended distinction without weakening PR #1349's protection for unknown plugin and MCP inputs.

## Decision

The patch adds a narrow canonical-scan exemption for schema-defined non-file fields of the **first-party** `channel_send` and `channel_reply` tools:

- message prose: `text`
- remote addressing / identifiers: `adapter`, `workspace`, `chat`, `thread`
- display metadata: `filename`

The exemption is selected from an internal `ToolBeforeEvent.toolProvenance` marker emitted by TypeClaw's wrappers—not from the model arguments or a tool name alone. Plugin and absent provenance are untrusted and receive the canonical fail-closed scan, even if a plugin reuses a channel tool name or omits `fileOperands`. A declared local operand also overrides the first-party exemption.

It does **not** exempt `attachments[].path`, path-like keys, or `file:` URIs. A `file:` value under an exempt field is still normalized and checked.

### Alternatives considered

| Alternative | Rejected because |
| --- | --- |
| Apply every generic free-text exemption to the canonical-secret scan | Unknown/future plugin tools may dereference a field named `text`, `query`, or `content`. Existing canonical-secret tests intentionally require those unknown-tool inputs to remain blocked. |
| Catch and ignore `ENAMETOOLONG` | Treats the symptom instead of the bad classification; arbitrary channel prose would still trigger filesystem work and other resolution failures. Ignoring canonicalization failures also weakens fail-closed handling for actual path operands. |
| Exempt `channel_send` entirely | Would allow `attachments[].path` to upload private files. |
| Use a first-party-provenance, known-field semantic exemption | Selected. The channel schemas establish that addressing, identifiers, and message bodies are remote/prose values, while `attachments[].path` is the local read operand. An internal provenance marker prevents colliding plugins from inheriting the exemption; declared local operands always override it; unknown tools remain fail-closed. |

## Root cause resolved

This fixes the classification error at the canonical scan boundary: **only trusted first-party channel message fields avoid filesystem canonicalization**. It does not change how filesystem errors are handled for fields that are semantically path-bearing, and a plugin cannot opt into the exemption through its tool name or arguments.

## Security and compatibility

- Preserves fail-closed behavior for actual local paths, including hidden attachment paths and canonical credential files.
- Preserves `file:` URI checks even under exempt first-party message fields.
- Preserves canonical-secret blocking for unknown, plugin-origin, and absent-provenance inputs; their field semantics are not trusted by default.
- Expands only expected message delivery behavior: long Unicode prose and remote channel identifiers are no longer treated as host paths.

## Tests

- Added a regression with Korean `channel_send.text` above 255 UTF-8 bytes; it failed before the fix with the generic internal-guard block and passes after it.
- Added a regression proving the same free-form Korean text does not exempt `attachments[].path: 'sessions/s.jsonl'`.
- Added direct guard and wrapper/security-hook regressions for a plugin colliding with `channel_send`, with and without `fileOperands`; `text: 'secrets.json'` remains blocked by the canonical-secret scan.
- `bun test --parallel src/bundled-plugins/security/policies/private-surface-read.test.ts src/bundled-plugins/security/index.test.ts` — 139 pass, 2 skip, 0 fail.
- `bun test --parallel src/agent/plugin-tools.test.ts` — 169 pass, 23 skip, 0 fail.
- `bun run typecheck` — pass.
- `bun run lint` — 0 errors; repository reports 69 existing warnings.
- `bun run format` — pass.
