### PR TITLE
Scope canonical prose operands for first-party tools

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -854,6 +854,35 @@ describe('wrapPluginTool', () => {
       await rm(agentDir, { recursive: true, force: true })
     }
   })
+
+  test('plugin write tool rejects canonical secret target through enforceAndPinToolFiles without invoking plugin', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-plugin-write-secret-'))
+    let called = false
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ path: z.string(), content: z.string() }),
+      async execute() {
+        called = true
+        return { content: [] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'writer',
+      toolName: 'write',
+      agentDir,
+      sessionId: 's',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    try {
+      await expect(
+        wrapped.execute('c', { path: 'public/report.md', content: 'secrets.json' }, undefined, undefined, {} as never),
+      ).rejects.toThrow(/blocked.*privateSurfaceRead/)
+      expect(called).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('wrapSystemTool', () => {
@@ -1317,7 +1346,13 @@ describe('wrapSystemTool', () => {
     ]
     for (const [tool, args] of cases) {
       const before = JSON.stringify(args)
-      const pinned = await enforceAndPinToolFiles({ tool, args, agentDir, genericInputs: true })
+      const pinned = await enforceAndPinToolFiles({
+        tool,
+        args,
+        agentDir,
+        genericInputs: true,
+        toolProvenance: 'first-party',
+      })
       await pinned.cleanup()
       expect(JSON.stringify(args)).toBe(before)
     }
@@ -1382,7 +1417,13 @@ describe('wrapSystemTool', () => {
 
     for (const scope of ['cron', 'channels', 'config', 'plugins', 'skills']) {
       const args: Record<string, unknown> = { scope }
-      const pinned = await enforceAndPinToolFiles({ tool: 'reload', args, agentDir, genericInputs: true })
+      const pinned = await enforceAndPinToolFiles({
+        tool: 'reload',
+        args,
+        agentDir,
+        genericInputs: true,
+        toolProvenance: 'first-party',
+      })
       await pinned.cleanup()
       expect(args.scope).toBe(scope)
     }
@@ -1394,7 +1435,13 @@ describe('wrapSystemTool', () => {
     await mkdir(path.join(agentDir, 'cron'), { recursive: true })
 
     const args: Record<string, unknown> = { target_kind: 'cron' }
-    const pinned = await enforceAndPinToolFiles({ tool: 'stream_snapshot', args, agentDir, genericInputs: true })
+    const pinned = await enforceAndPinToolFiles({
+      tool: 'stream_snapshot',
+      args,
+      agentDir,
+      genericInputs: true,
+      toolProvenance: 'first-party',
+    })
     await pinned.cleanup()
     expect(args.target_kind).toBe('cron')
     await rm(agentDir, { recursive: true, force: true })
@@ -1404,7 +1451,13 @@ describe('wrapSystemTool', () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-grant-perm-'))
 
     const args: Record<string, unknown> = { role: 'guest', permission: 'channel.respond' }
-    const pinned = await enforceAndPinToolFiles({ tool: 'grant_role', args, agentDir, genericInputs: true })
+    const pinned = await enforceAndPinToolFiles({
+      tool: 'grant_role',
+      args,
+      agentDir,
+      genericInputs: true,
+      toolProvenance: 'first-party',
+    })
     await pinned.cleanup()
     expect(args.permission).toBe('channel.respond')
     await rm(agentDir, { recursive: true, force: true })
@@ -1484,7 +1537,13 @@ describe('wrapSystemTool', () => {
     ]
     for (const [tool, args] of cases) {
       const before = JSON.stringify(args)
-      const pinned = await enforceAndPinToolFiles({ tool, args, agentDir, genericInputs: true })
+      const pinned = await enforceAndPinToolFiles({
+        tool,
+        args,
+        agentDir,
+        genericInputs: true,
+        toolProvenance: 'first-party',
+      })
       await pinned.cleanup()
       expect(JSON.stringify(args)).toBe(before)
     }
@@ -2679,6 +2738,54 @@ describe('wrapBuiltinToolDefinition (hook + guard pipeline)', () => {
       expect(result.details as Record<string, unknown>).toEqual({ rewritten: true })
       expect((seen[0] as { path: string }).path).not.toBe(mutated)
       expect(observed[0]).toEqual({ path: mutated })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('first-party builtin write accepts long prose through both canonical guard passes', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-builtin-write-prose-'))
+    const workspace = path.join(agentDir, 'workspace')
+    const target = path.join(workspace, 'report.md')
+    const content = 'x'.repeat(300)
+    const provenances: unknown[] = []
+    const tool = {
+      name: 'write',
+      label: 'write',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), content: Type.String() }),
+      async execute(_callId: string, params: { path: string; content: string }) {
+        await writeFile(params.path, params.content)
+        return { content: [{ type: 'text' as const, text: 'written' }], details: undefined }
+      },
+    }
+    const hooks = createHookBus()
+    hooks.registerAll('security', agentDir, noopLogger, {
+      'tool.before': (event) => {
+        provenances.push(event.toolProvenance)
+        return checkPrivateSurfaceReadGuard({
+          tool: event.tool,
+          args: event.args,
+          agentDir,
+          hidden: { dirs: [], files: [] },
+          toolProvenance: event.toolProvenance,
+        })
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir, sessionId: 's', hooks })
+
+    try {
+      await mkdir(workspace)
+      if (lacksInodeAnchoring) {
+        await expect(
+          wrapped.execute('c', { path: target, content }, undefined, undefined, {} as never),
+        ).rejects.toThrow(/inode anchoring/)
+        expect(provenances).toEqual(['first-party'])
+        return
+      }
+      await wrapped.execute('c', { path: target, content }, undefined, undefined, {} as never)
+      expect(provenances).toEqual(['first-party'])
+      expect(await readFile(target, 'utf8')).toBe(content)
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -2175,9 +2175,10 @@ describe('wrapSystemTool', () => {
       expect((overflow.error as Error).message).toMatch(/waiter|queue/i)
     } finally {
       for (const controller of controllers) controller.abort()
+      await holder?.cleanup()
+      holder = undefined
       const outcomes = await Promise.all(waiters)
       await Promise.all(outcomes.flatMap((outcome) => ('pinned' in outcome ? [outcome.pinned.cleanup()] : [])))
-      await holder?.cleanup()
       await rm(agentDir, { recursive: true, force: true })
     }
   })

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -390,6 +390,7 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         tool: opts.toolName,
         args: before.args,
         agentDir: opts.agentDir,
+        toolProvenance: 'plugin',
         genericInputs: true,
         fileOperands: tool.fileOperands,
         logger: opts.logger,
@@ -488,6 +489,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
         tool: tool.name,
         args: mutableArgs,
         agentDir: opts.agentDir,
+        toolProvenance: 'first-party',
         genericInputs: tool.name !== 'mcp_call',
         ...(opts.permissions !== undefined
           ? { hidden: resolveHiddenPaths(opts.permissions, liveOrigin, opts.agentDir) }
@@ -565,6 +567,7 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
         sessionId: opts.sessionId,
         callId: toolCallId,
         args: mutableArgs,
+        toolProvenance: 'first-party',
         ...(liveOrigin !== undefined ? { origin: liveOrigin } : {}),
       })
       if (blockResult !== undefined) {
@@ -649,6 +652,7 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
             tool: tool.name,
             args: attemptArgs,
             agentDir: opts.agentDir,
+            toolProvenance: 'first-party',
             ...(opts.permissions !== undefined
               ? {
                   hidden:

--- a/src/agent/tool-file-safety.test.ts
+++ b/src/agent/tool-file-safety.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
-import { enforceCanonicalSecretDenial } from './tool-file-safety'
+import { enforceAndPinToolFiles, enforceCanonicalSecretDenial } from './tool-file-safety'
 
 test('enforceCanonicalSecretDenial ignores non-file declarations for canonical credentials', async () => {
   const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-canonical-denial-'))
@@ -16,6 +16,49 @@ test('enforceCanonicalSecretDenial ignores non-file declarations for canonical c
 
   try {
     expect(() => enforceCanonicalSecretDenial(options)).toThrow(/^blocked:/)
+  } finally {
+    await rm(agentDir, { recursive: true, force: true })
+  }
+})
+
+test('enforceCanonicalSecretDenial trusts prose semantics only for first-party builtins', async () => {
+  const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-canonical-prose-'))
+
+  try {
+    expect(() =>
+      enforceCanonicalSecretDenial({
+        tool: 'write',
+        args: { path: 'public/report.md', content: 'x'.repeat(300) },
+        agentDir,
+        toolProvenance: 'first-party',
+      }),
+    ).not.toThrow()
+    expect(() =>
+      enforceCanonicalSecretDenial({
+        tool: 'write',
+        args: { path: 'public/report.md', content: 'secrets.json' },
+        agentDir,
+        toolProvenance: 'plugin',
+      }),
+    ).toThrow(/^blocked:/)
+  } finally {
+    await rm(agentDir, { recursive: true, force: true })
+  }
+})
+
+test('plugin collisions cannot inherit first-party no-file-operand shortcuts', async () => {
+  const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-canonical-collision-'))
+
+  try {
+    await expect(
+      enforceAndPinToolFiles({
+        tool: 'channel_read',
+        args: { path: 'secrets.json' },
+        agentDir,
+        genericInputs: true,
+        toolProvenance: 'plugin',
+      }),
+    ).rejects.toThrow(/blocked:|ambiguous local file operand/)
   } finally {
     await rm(agentDir, { recursive: true, force: true })
   }

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -11,7 +11,7 @@ import {
   createPrivateSurfaceReadIdentityVerifier,
   type PrivateSurfaceIdentityVerifier,
 } from '@/bundled-plugins/security/policies/private-surface-read'
-import type { ToolFileOperands, ToolLogger, ToolResult } from '@/plugin'
+import type { ToolFileOperands, ToolLogger, ToolProvenance, ToolResult } from '@/plugin'
 import { CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
 import type { HiddenPaths } from '@/sandbox/hidden-paths'
 
@@ -84,6 +84,7 @@ export async function enforceAndPinToolFiles(
     hidden?: HiddenPaths
     logger?: Pick<ToolLogger, 'warn'>
     signal?: AbortSignal
+    toolProvenance?: ToolProvenance
   },
   hooks: EnforceAndPinToolFilesHooks = {},
 ): Promise<PinnedToolFiles> {
@@ -97,6 +98,7 @@ export async function enforceAndPinToolFiles(
     options.fileOperands,
     options.agentDir,
     options.logger,
+    options.toolProvenance,
   )
   enforceCanonicalSecretDenial(options)
   const outputs = outputTargets(options.tool, options.args, TOOL_OUTPUT_MAX_COUNT, options.fileOperands)
@@ -254,9 +256,16 @@ export function enforceCanonicalSecretDenial(options: {
   tool: string
   args: Record<string, unknown>
   agentDir: string
+  toolProvenance?: ToolProvenance
 }): void {
-  const { tool, args, agentDir } = options
-  const blocked = checkPrivateSurfaceReadGuard({ tool, args, agentDir, hidden: { dirs: [], files: [] } })
+  const { tool, args, agentDir, toolProvenance } = options
+  const blocked = checkPrivateSurfaceReadGuard({
+    tool,
+    args,
+    agentDir,
+    hidden: { dirs: [], files: [] },
+    ...(toolProvenance !== undefined ? { toolProvenance } : {}),
+  })
   if (blocked !== undefined) throw new Error(`blocked: ${blocked.reason}`)
 }
 
@@ -268,9 +277,10 @@ function fileTargets(
   fileOperands: ToolFileOperands | undefined,
   agentDir: string,
   logger: Pick<ToolLogger, 'warn'> | undefined,
+  toolProvenance: ToolProvenance | undefined,
 ): FileTarget[] {
   if (isOutputTool(tool)) return []
-  if (TOOLS_WITHOUT_LOCAL_FILE_OPERANDS.has(tool)) return []
+  if (toolProvenance === 'first-party' && TOOLS_WITHOUT_LOCAL_FILE_OPERANDS.has(tool)) return []
   if (tool === 'read' && typeof args.path === 'string') return [propertyTarget(args, 'path')]
   if (isTreeInputTool(tool)) {
     if (typeof args.path !== 'string') args.path = '.'

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -231,6 +231,112 @@ describe('private-surface-read guard — free-text field scoping (no false posit
     expect(check('append', { topic: 'workspace', body: 'about memory' })).toBeUndefined()
   })
 
+  test('does not resolve long first-party edit/write prose as canonical paths', () => {
+    const agentDir = realpathSync(mkdtempSync(path.join(tmpdir(), 'typeclaw-private-prose-')))
+    const longProse = 'x'.repeat(300)
+    const internalErrors: unknown[] = []
+    const hooks = { onInternalError: (error: unknown) => internalErrors.push(error) }
+
+    expect(
+      checkPrivateSurfaceReadGuard(
+        {
+          tool: 'edit',
+          args: { path: path.join(agentDir, 'cron.json'), edits: [{ oldText: longProse, newText: longProse }] },
+          agentDir,
+          hidden: privilegedHidden,
+          toolProvenance: 'first-party',
+        },
+        hooks,
+      ),
+    ).toBeUndefined()
+    expect(
+      checkPrivateSurfaceReadGuard(
+        {
+          tool: 'write',
+          args: { path: path.join(agentDir, 'cron.json'), content: longProse },
+          agentDir,
+          hidden: privilegedHidden,
+          toolProvenance: 'first-party',
+        },
+        hooks,
+      ),
+    ).toBeUndefined()
+    expect(internalErrors).toEqual([])
+  })
+
+  test('blocks write.content safe prose but metadata.content: secrets.json (exact operand-path boundary)', () => {
+    const agentDir = realpathSync(mkdtempSync(path.join(tmpdir(), 'typeclaw-operand-boundary-write-')))
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'write',
+        args: {
+          path: path.join(agentDir, 'report.md'),
+          content: 'x'.repeat(300),
+          metadata: { content: 'secrets.json' },
+        },
+        agentDir,
+        hidden: privilegedHidden,
+        toolProvenance: 'first-party',
+      })?.block,
+    ).toBe(true)
+  })
+
+  test('blocks edit.edits.oldText safe prose but metadata.oldText: secrets.json (exact operand-path boundary)', () => {
+    const agentDir = realpathSync(mkdtempSync(path.join(tmpdir(), 'typeclaw-operand-boundary-edit-')))
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'edit',
+        args: {
+          path: path.join(agentDir, 'report.md'),
+          edits: [{ oldText: 'x'.repeat(300), newText: 'replacement' }],
+          metadata: { oldText: 'secrets.json' },
+        },
+        agentDir,
+        hidden: privilegedHidden,
+        toolProvenance: 'first-party',
+      })?.block,
+    ).toBe(true)
+  })
+
+  test('keeps colliding plugin tools and file URIs in the canonical scan', () => {
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'write',
+        args: { path: 'public/report.md', content: 'secrets.json' },
+        agentDir: AGENT,
+        hidden: privilegedHidden,
+        toolProvenance: 'plugin',
+      })?.block,
+    ).toBe(true)
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'edit',
+        args: { path: 'public/report.md', edits: [{ oldText: 'secrets.json', newText: 'replacement' }] },
+        agentDir: AGENT,
+        hidden: privilegedHidden,
+        toolProvenance: 'plugin',
+      })?.block,
+    ).toBe(true)
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'write',
+        args: { path: 'public/report.md', content: 'file:///agent/secrets.json' },
+        agentDir: AGENT,
+        hidden: privilegedHidden,
+        toolProvenance: 'first-party',
+      })?.block,
+    ).toBe(true)
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'channel_read',
+        args: { path: 'secrets.json' },
+        agentDir: AGENT,
+        hidden: privilegedHidden,
+        toolProvenance: 'plugin',
+      })?.block,
+    ).toBe(true)
+  })
+
   test('STILL blocks a hidden path in a genuine path field (scoping did not open a hole)', () => {
     expect(check('read', { path: 'memory' })?.block).toBe(true)
     expect(check('read', { path: 'workspace/notes.md' })?.block).toBe(true)
@@ -1111,6 +1217,19 @@ describe('private-surface-read guard — honors a tool author fileOperands.nonFi
         agentDir: AGENT,
         hidden: guestHidden,
         fileOperands: { input: ['query'], nonFile: ['query'] },
+      })?.block,
+    ).toBe(true)
+  })
+
+  test('declared local input overrides a first-party write prose exemption for canonical secrets', () => {
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'write',
+        args: { path: 'public/report.md', content: 'secrets.json' },
+        agentDir: AGENT,
+        hidden: privilegedHidden,
+        fileOperands: { input: ['content'] },
+        toolProvenance: 'first-party',
       })?.block,
     ).toBe(true)
   })

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -31,11 +31,11 @@ import type { SecurityBlock } from '../policy'
 
 export const GUARD_PRIVATE_SURFACE_READ = 'privateSurfaceRead'
 
-// bash is excluded: its access to hidden paths is contained by the bwrap
-// sandbox (applyBashSandbox), not by blocking the call. Every OTHER tool is
-// scanned, so a new file-reading tool — bundled or third-party — is covered
-// the day it ships without a whitelist edit. web_search/web_fetch take URLs, not
-// local paths, and the path-plausibility filter keeps their args from matching.
+// First-party bash is excluded: its access to hidden paths is contained by the
+// bwrap sandbox (applyBashSandbox), not by blocking the call. Every OTHER tool
+// is scanned, so a new file-reading tool — bundled or third-party — is covered
+// the day it ships without a whitelist edit. A plugin colliding with an exempt
+// first-party name does not inherit the exemption.
 //
 // TOOLS_WITHOUT_LOCAL_FILE_OPERANDS is the SAME set the file-operand scanner
 // skips: first-party tools whose args are only remote ids/control tokens
@@ -82,7 +82,7 @@ export function checkPrivateSurfaceReadGuard(
   hooks: PrivateSurfaceIdentityScanHooks = {},
 ): SecurityBlock | undefined {
   const { tool, args, agentDir, hidden, fileOperands, toolProvenance } = options
-  if (UNSCANNED_TOOLS.has(tool)) return undefined
+  if (toolProvenance === 'first-party' && UNSCANNED_TOOLS.has(tool)) return undefined
   try {
     const { canonicalDirs, canonicalFiles, roleDirs, roleFiles } = deniedSurface(agentDir, hidden)
     const canonicalEmpty = canonicalDirs.length === 0 && canonicalFiles.length === 0
@@ -309,6 +309,13 @@ const CANONICAL_FREE_TEXT_KEYS_BY_TOOL: Record<string, ReadonlySet<string>> = {
   channel_reply: new Set(['text', 'filename']),
 }
 
+// Unlike channel fields, edit replacement text is nested. Match its complete
+// operand path so another field with the same key remains fail-closed.
+const CANONICAL_FREE_TEXT_OPERANDS_BY_TOOL: Record<string, ReadonlySet<string>> = {
+  edit: new Set(['edits.oldText', 'edits.newText']),
+  write: new Set(['content']),
+}
+
 // Trim before the `file:` test: an exempt prose key otherwise lets a
 // leading-whitespace `file:  file://…/memory` URI slip past the scan (the value
 // is not path-shaped and `isFileUrl` misses it), reaching a fetcher that trims
@@ -414,11 +421,15 @@ function walk(
   if (value !== null && typeof value === 'object') {
     const toolFreeText = FREE_TEXT_KEYS_BY_TOOL[tool]
     const canonicalToolFreeText = canonicalToolSemantics ? CANONICAL_FREE_TEXT_KEYS_BY_TOOL[tool] : undefined
+    const canonicalToolFreeTextOperands = canonicalToolSemantics
+      ? CANONICAL_FREE_TEXT_OPERANDS_BY_TOOL[tool]
+      : undefined
     for (const [childKey, item] of Object.entries(value)) {
+      const childPath = operandPath === '' ? childKey : `${operandPath}.${childKey}`
       const keyIsExempt =
         (!disableExemptions && (NON_PATH_KEYS.has(childKey) || (toolFreeText?.has(childKey) ?? false))) ||
-        (canonicalToolFreeText?.has(childKey) ?? false)
-      const childPath = operandPath === '' ? childKey : `${operandPath}.${childKey}`
+        (canonicalToolFreeText?.has(childKey) ?? false) ||
+        (canonicalToolFreeTextOperands?.has(childPath) ?? false)
       walk(
         item,
         out,


### PR DESCRIPTION
## Background

Production hit `ENAMETOOLONG` when a first-party `write`/`edit` call carried long prose in `content` or `edits.oldText`/`edits.newText`. The `privateSurfaceRead` guard's canonical-secret scan walks every string value looking for canonical secret filenames, and for tools without a declared free-text exemption it treats any string as a candidate filesystem path. Legitimate report bodies and replacement text routinely exceed the OS path length limit, so the guard's own path-resolution step threw instead of returning a clean allow/deny decision — a functional regression on ordinary `write`/`edit` usage, not an edge case.

## Summary

**Scope the prose exemption to first-party tools, by exact operand path, and propagate provenance so it can't be inherited.**

- `a2dd850e` adds `CANONICAL_FREE_TEXT_OPERANDS_BY_TOOL`, exempting `edit.edits.oldText`, `edit.edits.newText`, and `write.content` from the canonical-secret path scan — matched by full operand path (not bare key) so an unrelated field sharing the same key name stays fail-closed. The existing `UNSCANNED_TOOLS` (bash) exemption is also gated to `toolProvenance === 'first-party'`, so a plugin tool named `bash` no longer rides along.
- `5192bf25` threads a `toolProvenance` parameter (`first-party` | `plugin`) from each wrap site — `wrapPluginTool`, `wrapSystemTool`, `wrapBuiltinToolDefinition` — down through `enforceAndPinToolFiles`, `enforceCanonicalSecretDenial`, and into `checkPrivateSurfaceReadGuard`. `TOOLS_WITHOUT_LOCAL_FILE_OPERANDS` in `fileTargets` is likewise gated to `first-party` only.
- `837e662f` is an independent test-only fix: the queued-waiter overflow test awaited `holder.cleanup()` after awaiting every queued waiter, so cleanup never ran until every waiter's queue wait resolved — a wait-order deadlock on `origin/main` today, surfaced by the mandatory push-gate run rather than introduced by this branch. Releasing the snapshot holder before awaiting the waiters breaks the cycle. No production queue code changed.

The exemption is deliberately narrow: it is gated on both the exact operand path and `toolProvenance === 'first-party'`, so it only fires for the two builtin operands it was written for.

## What this does NOT do

- Does not weaken canonical secret denial. `secrets.json`, `.env`, `~/.ssh`, and friends stay blocked regardless of the exemption — pinned by "declared local input overrides a first-party write prose exemption for canonical secrets".
- Does not extend the prose exemption to plugins or any other third-party tool. A plugin colliding with an exempt first-party name (e.g. `channel_read`) does not inherit it — pinned by "plugin collisions cannot inherit first-party no-file-operand shortcuts" and "keeps colliding plugin tools and file URIs in the canonical scan".
- Does not accept file URIs as prose. A `file:///agent/secrets.json` value inside first-party write content is still blocked.
- Does not change production waiter/queue behavior. The teardown commit only reorders test cleanup.

## Review notes

Load-bearing files: `src/bundled-plugins/security/policies/private-surface-read.ts` (`CANONICAL_FREE_TEXT_OPERANDS_BY_TOOL`, the first-party gate on `UNSCANNED_TOOLS`), `src/agent/tool-file-safety.ts` (`toolProvenance` plumbing and the first-party gate on `TOOLS_WITHOUT_LOCAL_FILE_OPERANDS`), and `src/agent/plugin-tools.ts` (the three call sites tagging plugin vs first-party provenance).

Invariant to verify: a plugin tool colliding with an exempt first-party name is still fail-closed when it carries a canonical secret filename, and the exemption never widens beyond the two declared operand paths. The waiter-teardown commit is independently revertible from the other two — it fixes a pre-existing `origin/main` test deadlock, not a regression from this branch.

## Verification

- `bun run format` / `format:check` — passed
- `bun run typecheck` — clean
- `bun run lint` — 0 errors (no new warnings)
- Full suite: 12,533 pass, 31 skip, 0 fail across 598 files
- Focused private-surface / file-safety tests: 92 pass, 2 skip
- LSP diagnostics: clean
