### PR TITLE
Allow quoted backslashes in gh jq filters

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 
 import {
   analyzeGhCommand,
+  canInjectPatIntoPassThroughGh,
   effectiveGhTokensForAuthenticatedUserEndpoint,
   usesGhApiAuthenticatedUserEndpoint,
 } from './gh-command'
@@ -486,6 +487,28 @@ describe('analyzeGhCommand', () => {
     })
   })
 
+  it('allows literal backslashes inside single-quoted jq filters', () => {
+    for (const filter of ['.patch | split("\\n") | join("\\n")', '.content | gsub("\\n"; "") | @base64d']) {
+      for (const jqArg of [`--jq '${filter}'`, `-q '${filter}'`, `--jq='${filter}'`, `-q='${filter}'`]) {
+        expect(analyzeGhCommand(`gh api /repos/acme/widgets/pulls ${jqArg}`)).toEqual({
+          kind: 'inject',
+          repoSlug: 'acme/widgets',
+        })
+      }
+    }
+  })
+
+  it('keeps shell-active backslashes outside single quotes blocked', () => {
+    for (const command of [
+      'gh api /repos/acme/widgets/pulls --jq split(\\"\\n\\")',
+      'gh api /repos/acme/widgets/pulls --jq "split(\\"\\n\\")"',
+      "gh api /repos/acme/widgets/pulls \\--jq '.patch'",
+      `gh api /repos/acme/widgets/pulls --jq '.patch\\n''; cat /proc/self/environ'`,
+    ]) {
+      expect(analyzeGhCommand(command).kind).toBe('block')
+    }
+  })
+
   it('allows inline raw/typed fields and rejects @file dereferences', () => {
     expect(analyzeGhCommand("gh api /repos/acme/widgets/issues -f body='safe text'")).toMatchObject({ kind: 'inject' })
     expect(analyzeGhCommand('gh api graphql -R acme/widgets -F number=7 -f query=x')).toMatchObject({
@@ -664,6 +687,15 @@ describe('analyzeGhCommand', () => {
         'block',
       )
       expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq \\-f/proc/self/environ').kind).toBe('block')
+    })
+
+    it('allows literal backslashes inside a single-quoted stdin-only jq filter', () => {
+      const command = `gh api /repos/acme/widgets/pulls | jq '.patch | split("\\n") | join("\\n")'`
+      expect(analyzeGhCommand(command)).toEqual({
+        kind: 'inject',
+        repoSlug: 'acme/widgets',
+        rewrittenCommand: `gh api /repos/acme/widgets/pulls | /usr/bin/env -u GH_TOKEN -u GITHUB_TOKEN jq '.patch | split("\\n") | join("\\n")'`,
+      })
     })
 
     it('allows known stdin-shaping coreutils flags (wc -l, cat -n, sort -r, uniq -c)', () => {
@@ -874,6 +906,20 @@ describe('analyzeGhCommand', () => {
     expect(nonLiteral.kind === 'block' && nonLiteral.code).toBe('non-literal-repo')
     const composition = analyzeGhCommand('set -e; gh label list -R acme/widgets')
     expect(composition.kind === 'block' && composition.code).toBe('composition')
+  })
+})
+
+describe('canInjectPatIntoPassThroughGh', () => {
+  it('allows literal backslashes inside single-quoted jq filters', () => {
+    const filter = '.content | gsub("\\n"; "") | @base64d'
+    for (const jqArg of [`--jq '${filter}'`, `-q '${filter}'`, `--jq='${filter}'`, `-q='${filter}'`]) {
+      expect(canInjectPatIntoPassThroughGh(`gh api /user ${jqArg}`)).toBe(true)
+    }
+  })
+
+  it('rejects shell-active backslashes outside single quotes', () => {
+    expect(canInjectPatIntoPassThroughGh('gh api /user \\--input /proc/self/environ')).toBe(false)
+    expect(canInjectPatIntoPassThroughGh('gh api /user --jq "gsub(\\"\\n\\"; \\"\\")"')).toBe(false)
   })
 })
 

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -262,7 +262,7 @@ function isAuthStatusTokenDisplayFlag(arg: string): boolean {
 
 export function canInjectPatIntoPassThroughGh(command: string): boolean {
   if (containsReviewGraphqlMutation(command)) return false
-  if (command.includes('\\')) return false
+  if (hasUnsafeGhStageBackslash(command)) return false
   if (!isSingleBareGhCommand(command)) return false
   const tokens = tokenize(command)
   const starts = findGhInvocations(tokens)
@@ -410,7 +410,7 @@ function isCredentialSafeGhCommand(command: string): boolean {
   const stages = splitTopLevelPipeStages(command)
   if (stages === null || stages.length === 0) return false
   const ghStage = (stages[0] as string).trim()
-  if (!isSingleBareGhCommand(ghStage) || ghStage.includes('\\')) return false
+  if (!isSingleBareGhCommand(ghStage) || hasUnsafeGhStageBackslash(ghStage)) return false
   const tokens = tokenize(ghStage)
   return tokens[0] === 'gh' && isCredentialSafeGhArgs(tokens.slice(1))
 }
@@ -568,12 +568,12 @@ const JQ_SAFE_BOOLEAN_SHORT = new Set(['r', 'c', 's', 'n', 'e', 'a', 'S', 'R', '
 // as the forbidden flag — an allowlist-bypass. Rejecting `\` closes that gap.
 function isStdinOnlyReaderStage(stage: string): boolean {
   if (containsShellActiveMetachar(stage)) return false
-  if (stage.includes('\\')) return false
   const tokens = splitStageTokens(stage)
   const cmd = tokens[0]
   if (cmd === undefined || !READER_ALLOWLIST.has(cmd)) return false
 
-  if (cmd === 'jq') return isStdinOnlyJqStage(tokens)
+  if (cmd === 'jq') return !hasUnsafeJqStageBackslash(stage) && isStdinOnlyJqStage(tokens)
+  if (stage.includes('\\')) return false
 
   const allowedFlags = READER_BOOLEAN_FLAGS[cmd]
   if (allowedFlags === undefined) return false
@@ -740,6 +740,99 @@ function splitStageTokens(stage: string): string[] {
   }
   if (has) tokens.push(current)
   return tokens
+}
+
+// Backslashes are shell-active outside single quotes, and the argv-ish tokenizers
+// below deliberately do not interpret shell escapes. The one safe use we support
+// is jq syntax such as `split("\\n")` when the complete filter operand is
+// single-quoted: the shell passes that backslash literally to jq, so it cannot
+// disguise a forbidden gh/jq flag or file operand.
+function hasUnsafeGhStageBackslash(stage: string): boolean {
+  if (!stage.includes('\\')) return false
+  const rawTokens = splitRawStageTokens(stage)
+  if (rawTokens === null) return true
+
+  for (let i = 0; i < rawTokens.length; i++) {
+    const raw = rawTokens[i] as string
+    if (!raw.includes('\\')) continue
+    const previous = rawTokens[i - 1]
+    if ((previous === '--jq' || previous === '-q') && isFullySingleQuoted(raw)) continue
+    const attachedFilter = raw.startsWith('--jq=')
+      ? raw.slice('--jq='.length)
+      : raw.startsWith('-q=')
+        ? raw.slice(3)
+        : null
+    if (attachedFilter !== null && isFullySingleQuoted(attachedFilter)) continue
+    return true
+  }
+  return false
+}
+
+function hasUnsafeJqStageBackslash(stage: string): boolean {
+  if (!stage.includes('\\')) return false
+  const rawTokens = splitRawStageTokens(stage)
+  if (rawTokens === null || rawTokens[0] !== 'jq') return true
+
+  let filterIndex: number | null = null
+  for (let i = 1; i < rawTokens.length; i++) {
+    const token = stripPairedQuotes(rawTokens[i] as string)
+    if (token === '--') return true
+    if (token.startsWith('--')) {
+      const consume = JQ_SAFE_VALUE_LONG[token]
+      if (consume !== undefined) i += consume
+      continue
+    }
+    if (token.startsWith('-') && token.length > 1) continue
+    filterIndex = i
+    break
+  }
+
+  for (let i = 1; i < rawTokens.length; i++) {
+    const raw = rawTokens[i] as string
+    if (!raw.includes('\\')) continue
+    if (i === filterIndex && isFullySingleQuoted(raw)) continue
+    return true
+  }
+  return false
+}
+
+function splitRawStageTokens(stage: string): string[] | null {
+  const tokens: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  for (const ch of stage) {
+    if (quote !== null) {
+      current += ch
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      current += ch
+      continue
+    }
+    if (ch === ' ' || ch === '\t') {
+      if (current !== '') {
+        tokens.push(current)
+        current = ''
+      }
+      continue
+    }
+    current += ch
+  }
+  if (quote !== null) return null
+  if (current !== '') tokens.push(current)
+  return tokens
+}
+
+function isFullySingleQuoted(raw: string): boolean {
+  return raw.length >= 2 && raw.startsWith("'") && raw.endsWith("'") && !raw.slice(1, -1).includes("'")
+}
+
+function stripPairedQuotes(raw: string): string {
+  if (raw.length < 2) return raw
+  const first = raw[0]
+  return first === raw[raw.length - 1] && (first === '"' || first === "'") ? raw.slice(1, -1) : raw
 }
 
 // Removes an unquoted `-R`/`--repo` flag (and its repo-slug value) from a single

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -716,6 +716,18 @@ describe('github-cli-auth plugin', () => {
     }
   })
 
+  test('injects a PAT for literal backslashes inside a single-quoted jq filter', async () => {
+    process.env.GH_TOKEN = 'ghp_primary'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: privilegedPermissions })
+    const filter = '.content | gsub("\\n"; "") | @base64d'
+
+    for (const jqArg of [`--jq '${filter}'`, `-q='${filter}'`]) {
+      const event = bashEvent(`gh api /user ${jqArg}`)
+      expect(await hook(event, hookCtx)).toBeUndefined()
+      expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghp_primary' })
+    }
+  })
+
   test('never injects a PAT into gh alias or extension execution surfaces', async () => {
     process.env.GH_TOKEN = 'ghp_primary'
     const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: privilegedPermissions })


### PR DESCRIPTION
## Background

The GitHub credential broker rejected any command containing a backslash before checking whether it was shell-active. That safely blocked escaped-flag bypasses, but it also blocked ordinary jq expressions such as `split("\n")` and `gsub("\n"; "")` when the complete filter was single-quoted.

Because the same blanket check guarded App-token minting, PAT brokerage, and reader pipelines, these otherwise safe `gh api --jq` calls ran without the command-scoped credential they needed.

## Summary

- Preserve raw quote boundaries while scanning `gh` and downstream `jq` stages.
- Allow backslashes only in a complete single-quoted jq filter operand.
- Support `--jq '...'`, `-q '...'`, `--jq='...'`, and `-q='...'` consistently.
- Keep unquoted, double-quoted, malformed, escaped-flag, file-operand, environment-reader, and module-loading forms fail-closed.
- Retain `GH_TOKEN` and `GITHUB_TOKEN` stripping for every downstream reader process.

The implementation uses separate checks for the leading `gh` stage and a stdin-only `jq` reader stage. The latter locates the filter through jq's existing safe-option arity table, so a backslash in an option value or additional operand is never mistaken for filter syntax.

## Security boundary

This does not remove the original backslash hardening. A backslash is accepted only where shell single quotes make it literal data passed to jq; every other placement remains rejected. Existing credential-exposure checks for `env`, `$ENV`, file dereferences, jq file/module flags, `import`/`include`, command composition, and unsafe readers are unchanged.

## Verification

- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun typecheck` — clean
- `bun run test` — 12,636 pass, 31 skip, 0 fail
- Focused `github-cli-auth` tests — 205 pass

No live GitHub API call was used; analyzer and plugin-integration behavior is covered with controlled tests.
