### PR TITLE
Recover partial output from failed subagents

### DIFF
--- a/src/agent/live-subagents.test.ts
+++ b/src/agent/live-subagents.test.ts
@@ -242,6 +242,18 @@ describe('LiveSubagentRegistry', () => {
     const reg = new LiveSubagentRegistry()
     expect(reg.recordCompletionIfRunning('nope', { ok: true, durationMs: 1 })).toBe(false)
   })
+
+  test('captured final output is readable while running and cannot be added after settlement', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+
+    expect(reg.recordCapturedFinalMessageIfRunning('bg_t1', '<review>safe</review>')).toBe(true)
+    expect(reg.getCapturedFinalMessage('bg_t1')).toBe('<review>safe</review>')
+
+    reg.recordCompletionIfRunning('bg_t1', { ok: false, error: 'timeout', durationMs: 100 })
+    expect(reg.recordCapturedFinalMessageIfRunning('bg_t1', '<review>late</review>')).toBe(false)
+    expect(reg.getCapturedFinalMessage('bg_t1')).toBe('<review>safe</review>')
+  })
 })
 
 describe('snapshot.statusSummary rendering', () => {

--- a/src/agent/live-subagents.ts
+++ b/src/agent/live-subagents.ts
@@ -96,6 +96,7 @@ export type StatusSnapshot = {
 export class LiveSubagentRegistry {
   private readonly entries = new Map<string, LiveSubagent>()
   private readonly events = new Map<string, SubagentProgressEvent[]>()
+  private readonly capturedFinalMessages = new Map<string, string>()
 
   register(live: LiveSubagent): void {
     if (this.entries.has(live.taskId)) {
@@ -108,6 +109,7 @@ export class LiveSubagentRegistry {
   unregister(taskId: string): void {
     this.entries.delete(taskId)
     this.events.delete(taskId)
+    this.capturedFinalMessages.delete(taskId)
   }
 
   get(taskId: string): LiveSubagent | undefined {
@@ -134,6 +136,17 @@ export class LiveSubagentRegistry {
     if (ring.length > MAX_EVENTS_PER_SUBAGENT) {
       ring.splice(0, ring.length - MAX_EVENTS_PER_SUBAGENT)
     }
+  }
+
+  recordCapturedFinalMessageIfRunning(taskId: string, finalMessage: string): boolean {
+    const entry = this.entries.get(taskId)
+    if (entry === undefined || entry.status !== 'running') return false
+    this.capturedFinalMessages.set(taskId, finalMessage)
+    return true
+  }
+
+  getCapturedFinalMessage(taskId: string): string | undefined {
+    return this.capturedFinalMessages.get(taskId)
   }
 
   recordCompletion(taskId: string, completion: SubagentCompletion): void {
@@ -186,6 +199,7 @@ export class LiveSubagentRegistry {
   clear(): void {
     this.entries.clear()
     this.events.clear()
+    this.capturedFinalMessages.clear()
   }
 }
 

--- a/src/agent/subagent-completion-reminder.test.ts
+++ b/src/agent/subagent-completion-reminder.test.ts
@@ -58,6 +58,8 @@ describe('renderSubagentCompletionReminder', () => {
     })
     expect(recoverable).toContain('produced output before failing')
     expect(recoverable).toContain('subagent_output')
+    expect(recoverable).toContain('partial recovery data')
+    expect(recoverable).toContain('not a completed verdict')
 
     // when the flag is absent, the wording stays the plain "inspect" guidance
     const plain = renderSubagentCompletionReminder({
@@ -250,6 +252,23 @@ describe('parseSubagentCompletedPayload', () => {
     })
     expect(parsed?.ok).toBe(false)
     expect(parsed?.error).toBe('provider rate limit')
+  })
+
+  test('failed-completion payload preserves recoverability metadata but drops output bodies', () => {
+    const parsed = parseSubagentCompletedPayload({
+      kind: 'subagent.completed',
+      taskId: 'bg_review',
+      subagent: 'reviewer',
+      parentSessionId: 'ses_abc',
+      ok: false,
+      durationMs: 600_000,
+      error: 'timeout',
+      hasRecoverableOutput: true,
+      finalMessage: '<review>secret body</review>',
+    })
+
+    expect(parsed?.hasRecoverableOutput).toBe(true)
+    expect(parsed).not.toHaveProperty('finalMessage')
   })
 
   test('preserves a valid channelKey (with null thread)', () => {

--- a/src/agent/subagent-completion-reminder.ts
+++ b/src/agent/subagent-completion-reminder.ts
@@ -58,7 +58,7 @@ export function renderSubagentCompletionReminder(args: CompletionReminderArgs): 
   const err = args.error ?? 'unknown error'
   const recoveryHint =
     args.hasRecoverableOutput === true
-      ? `It produced output before failing — call subagent_output to recover it instead of redoing the work. `
+      ? `It produced output before failing — call subagent_output to recover it as partial recovery data, not a completed verdict, instead of redoing the work. `
       : `Use subagent_output to inspect. `
   return (
     `<system-reminder>\n` +

--- a/src/agent/subagent-drain.test.ts
+++ b/src/agent/subagent-drain.test.ts
@@ -455,6 +455,55 @@ describe('runSubagentDrain — maxChildWaitMs (wedged-child ceiling)', () => {
     expect(prompts[0]).toContain('FAILED')
   })
 
+  test('timeout winner preserves only final output captured before settlement and broadcasts metadata only', async () => {
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_review', { startedAt: 0 })
+    const review = '<review>\n<verdict>approve</verdict>\n</review>'
+    reg.recordCapturedFinalMessageIfRunning('bg_review', review)
+    const broadcasts: unknown[] = []
+    drain.stream.subscribe({ target: { kind: 'broadcast' } }, (message) => broadcasts.push(message.payload))
+
+    const watch = beginSubagentDrainWatch(drain)
+    const prompts: string[] = []
+    await runSubagentDrain(watch, {
+      drain,
+      prompt: async (text) => void prompts.push(text),
+      maxChildWaitMs: 5000,
+      now: () => 6000,
+    })
+
+    const completion = reg.get('bg_review')?.completion
+    expect(reg.get('bg_review')?.status).toBe('failed')
+    expect(completion?.error).toContain('drain wait')
+    expect(completion?.finalMessage).toBe(review)
+    expect(prompts[0]).toContain('produced output before failing')
+    expect(broadcasts).toHaveLength(1)
+    expect(broadcasts[0]).toMatchObject({ ok: false, hasRecoverableOutput: true })
+    expect(JSON.stringify(broadcasts[0])).not.toContain(review)
+
+    expect(reg.recordCapturedFinalMessageIfRunning('bg_review', '<review>late</review>')).toBe(false)
+    expect(reg.get('bg_review')?.completion?.finalMessage).toBe(review)
+  })
+
+  test('timeout winner does not claim recoverability for stale analysis captured as progress only', async () => {
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_analysis', { startedAt: 0 })
+    reg.recordEvent('bg_analysis', { kind: 'message', preview: '<analysis>still working</analysis>', ts: 100 })
+    const broadcasts: unknown[] = []
+    drain.stream.subscribe({ target: { kind: 'broadcast' } }, (message) => broadcasts.push(message.payload))
+
+    const watch = beginSubagentDrainWatch(drain)
+    await runSubagentDrain(watch, {
+      drain,
+      prompt: async () => {},
+      maxChildWaitMs: 5000,
+      now: () => 6000,
+    })
+
+    expect(reg.get('bg_analysis')?.completion?.finalMessage).toBeUndefined()
+    expect(broadcasts[0]).not.toHaveProperty('hasRecoverableOutput')
+  })
+
   test('a timer expiry (no broadcast) wakes the loop and expires the child at the boundary', async () => {
     // given: a fake scheduler so the expiry timer fires on demand — deterministic,
     // no real clock. The child is within the ceiling at loop entry (clock=30 <

--- a/src/agent/subagent-drain.ts
+++ b/src/agent/subagent-drain.ts
@@ -93,13 +93,22 @@ function expireOverdueChildren(
     if (child.startedAt > deadline) continue
     const durationMs = now() - child.startedAt
     const error = `subagent ${child.subagentName} exceeded the ${maxChildWaitMs}ms drain wait and was abandoned`
+    const finalMessage = drain.liveRegistry.getCapturedFinalMessage(child.taskId)
     // Claim the settlement BEFORE aborting. If the child's real completion
     // already won, skip — no double-settle, no broadcast. Awaiting abort here
     // would be the bug the ceiling exists to prevent: a wedged `session.abort()`
     // that never reaches idle would hang the drain, so fire-and-forget instead.
     // Logical settlement can precede physical teardown; startSubagent still
     // disposes the session when its own work settles.
-    if (!drain.liveRegistry.recordCompletionIfRunning(child.taskId, { ok: false, durationMs, error })) continue
+    if (
+      !drain.liveRegistry.recordCompletionIfRunning(child.taskId, {
+        ok: false,
+        durationMs,
+        error,
+        ...(finalMessage !== undefined ? { finalMessage } : {}),
+      })
+    )
+      continue
     drain.stream.publish({
       target: { kind: 'broadcast' },
       payload: {
@@ -110,6 +119,7 @@ function expireOverdueChildren(
         ok: false,
         durationMs,
         error,
+        ...(finalMessage !== undefined ? { hasRecoverableOutput: true } : {}),
       },
     })
     void child.abort().catch(() => {})

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -603,6 +603,7 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
     ...options,
     onFinalMessageCaptured: (msg) => {
       finalMessage = msg
+      options.onFinalMessageCaptured?.(msg)
     },
     onSessionCreated: (event) => {
       handleSettled = true

--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -228,6 +228,47 @@ describe('createSpawnSubagentTool — sync mode', () => {
     expect(details.error).toBe('provider exploded')
     expect(liveRegistry.get('bg_test1')?.status).toBe('failed')
   })
+
+  test('foreground failure with finalMessage marks output as partial recovery data, not verdict', async () => {
+    const session = emittingSession(() => ({
+      type: 'message_end',
+      message: { content: '<verdict>approve</verdict>' },
+    }))
+    const origPrompt = session.prompt.bind(session)
+    session.prompt = async (text: string) => {
+      await origPrompt(text)
+      throw new Error('crashed after partial output')
+    }
+    const { tool, liveRegistry } = fixedSpawn({ createSession: async () => session })
+
+    const result = await tool.execute(
+      'call_1',
+      { subagent_type: 'explorer', prompt: 'q', run_in_foreground: true },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    const details = result.details as {
+      ok: boolean
+      error?: string
+      finalMessage?: string
+      recoveryData?: boolean
+      partial?: boolean
+      verdict?: boolean
+    }
+    expect(details.ok).toBe(false)
+    expect(details.error).toBe('crashed after partial output')
+    expect(details.finalMessage).toBe('<verdict>approve</verdict>')
+    expect(details.recoveryData).toBe(true)
+    expect(details.partial).toBe(true)
+    expect(details.verdict).toBe(false)
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    expect(text).toContain('PARTIAL RECOVERY DATA')
+    expect(text).toContain('not a completed')
+    expect(text).toContain('even if it contains verdict-shaped text')
+    expect(liveRegistry.get('bg_test1')?.status).toBe('failed')
+  })
 })
 
 describe('createSpawnSubagentTool — background mode', () => {

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -29,7 +29,14 @@ export type SpawnSubagentToolDetails =
       taskId: string
       sessionId: string | undefined
     }
-  | { ok: false; error: string; finalMessage?: string }
+  | {
+      ok: false
+      error: string
+      finalMessage?: string
+      recoveryData?: true
+      partial?: true
+      verdict?: false
+    }
 
 export type CreateSpawnSubagentToolOptions = {
   registry: SubagentRegistry
@@ -136,6 +143,7 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
 
       const startedAt = now()
       const spawnedByRole = permissions?.resolveRole(origin)
+      let capturedFinalMessage: string | undefined
       const { handle, completion } = startSubagent(subagentName, {
         registry,
         createSessionForSubagent,
@@ -146,6 +154,10 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
         ...(spawnedByRole !== undefined ? { spawnedByRole } : {}),
         ...(origin !== undefined ? { spawnedByOrigin: origin } : {}),
         taskId,
+        onFinalMessageCaptured: (message) => {
+          capturedFinalMessage = message
+          liveRegistry.recordCapturedFinalMessageIfRunning(taskId, message)
+        },
       })
 
       let resolvedHandle: { taskId: string; sessionId: string | undefined; abort: () => Promise<void> } | undefined
@@ -168,6 +180,9 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
         abort: resolvedHandle.abort,
       }
       liveRegistry.register(live)
+      if (capturedFinalMessage !== undefined) {
+        liveRegistry.recordCapturedFinalMessageIfRunning(taskId, capturedFinalMessage)
+      }
 
       const channelKey =
         origin?.kind === 'channel'
@@ -222,15 +237,17 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
       const result = await completion
       const durationMs = now() - startedAt
       if (!result.ok) {
+        const hasRecoveryData = result.finalMessage !== undefined
         const details: SpawnSubagentToolDetails = {
           ok: false,
           error: result.error,
-          ...(result.finalMessage !== undefined ? { finalMessage: result.finalMessage } : {}),
+          ...(hasRecoveryData
+            ? { finalMessage: result.finalMessage, recoveryData: true, partial: true, verdict: false }
+            : {}),
         }
-        const recovered =
-          result.finalMessage !== undefined
-            ? ` It produced output before failing; recover it below instead of redoing the work:\n\n${result.finalMessage}`
-            : ''
+        const recovered = hasRecoveryData
+          ? ` It produced output before failing. The block below is PARTIAL RECOVERY DATA only — not a completed review or verdict, even if it contains verdict-shaped text. Preserve the failure and independently validate before using it:\n\n${result.finalMessage}`
+          : ''
         const failureText = `${subagentName} failed after ${durationMs}ms: ${result.error}.${recovered}`
         return {
           content: [

--- a/src/agent/tools/subagent-output.test.ts
+++ b/src/agent/tools/subagent-output.test.ts
@@ -4,6 +4,7 @@ import { createPermissionService, rolesConfigSchema } from '@/permissions'
 
 import { LiveSubagentRegistry, type LiveSubagent } from '../live-subagents'
 import type { SessionOrigin } from '../session-origin'
+import { INCOMPLETE_REVIEW_VERDICT } from '../subagents'
 import { createSubagentOutputTool } from './subagent-output'
 
 const ctx = {} as Parameters<ReturnType<typeof createSubagentOutputTool>['execute']>[4]
@@ -167,6 +168,58 @@ describe('createSubagentOutputTool — failed status', () => {
     const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
     expect(text).toContain('failed after')
     expect(text).toContain('provider rate limit')
+  })
+
+  test('labels recovered output as partial recovery data and explicitly not a completed verdict', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive({ subagentName: 'reviewer' }))
+    liveRegistry.recordCompletion('bg_o1', {
+      ok: false,
+      error: 'parent drain timeout',
+      durationMs: 600_000,
+      finalMessage: '<review>\n<verdict>approve</verdict>\n</review>',
+    })
+    const tool = createSubagentOutputTool({ liveRegistry, getOrigin: () => undefined })
+
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as {
+      status?: string
+      recoveryData?: boolean
+      partial?: boolean
+      verdict?: boolean
+      finalMessage?: string
+    }
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+
+    expect(details.status).toBe('failed')
+    expect(details.recoveryData).toBe(true)
+    expect(details.partial).toBe(true)
+    expect(details.verdict).toBe(false)
+    expect(details.finalMessage).toContain('<verdict>approve</verdict>')
+    expect(text).toContain('PARTIAL RECOVERY DATA')
+    expect(text).toContain('not a completed review or verdict')
+  })
+
+  test('provider-failure sentinel remains recovery data and cannot become a real verdict', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive({ subagentName: 'reviewer' }))
+    liveRegistry.recordCompletion('bg_o1', {
+      ok: false,
+      error: 'parent drain timeout',
+      durationMs: 600_000,
+      finalMessage: `<review><verdict>${INCOMPLETE_REVIEW_VERDICT}</verdict></review>`,
+    })
+    const tool = createSubagentOutputTool({ liveRegistry, getOrigin: () => undefined })
+
+    const result = await tool.execute('call_1', { task_id: 'bg_o1' }, undefined, undefined, ctx)
+    const details = result.details as { status?: string; recoveryData?: boolean; verdict?: boolean }
+
+    expect(details.status).toBe('failed')
+    expect(details.recoveryData).toBe(true)
+    expect(details.verdict).toBe(false)
+    expect(INCOMPLETE_REVIEW_VERDICT).not.toBe('approve')
+    expect(INCOMPLETE_REVIEW_VERDICT).not.toBe('request-changes')
+    expect(INCOMPLETE_REVIEW_VERDICT).not.toBe('comment')
   })
 })
 

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -38,6 +38,9 @@ export type SubagentOutputToolDetails =
       durationMs: number
       error: string
       finalMessage?: string
+      recoveryData?: true
+      partial?: true
+      verdict?: false
     }
   | { ok: false; error: string }
 
@@ -146,11 +149,13 @@ function renderSnapshot(snap: StatusSnapshot): ToolReturn {
     subagent: snap.subagentName,
     durationMs: snap.completion?.durationMs ?? snap.elapsedMs,
     error,
-    ...(finalMessage !== undefined ? { finalMessage } : {}),
+    ...(finalMessage !== undefined
+      ? { finalMessage, recoveryData: true as const, partial: true as const, verdict: false as const }
+      : {}),
   }
   const recovered =
     finalMessage !== undefined
-      ? ` It produced output before failing; recover it below instead of redoing the work:\n\n${finalMessage}`
+      ? ` It produced output before failing. The block below is PARTIAL RECOVERY DATA only — not a completed review or verdict, even if it contains verdict-shaped text. Preserve the failure and independently validate before using it:\n\n${finalMessage}`
       : ''
   return {
     content: [


### PR DESCRIPTION
## Background

A live subagent can produce useful output before it fails — either an explicit failure or a drain-timeout abandonment — but until now that output was discarded. `subagent_output`'s recovery path only had something to show when the subagent's own completion handler happened to carry a `finalMessage`; a child abandoned by the drain-timeout ceiling never got that far, so there was nothing to recover even though the subagent may have already streamed a complete answer.

Separately, when recovered output does exist, the framing around it was too weak. A failed subagent's captured final message can be verdict-shaped text (approval language, review comments, a pass/fail line) even though the subagent never reached a real completion. The prior recovery hint just said "recover it instead of redoing the work," which does not stop the calling agent from treating that partial, unverified text as an authoritative review outcome.

## Summary

Five commits, in dependency order:

- `f180d6d9` adds a `capturedFinalMessages` map to `LiveSubagentRegistry` with `recordCapturedFinalMessageIfRunning` / `getCapturedFinalMessage`. Recording is gated on the entry still being `running`, so a message can't be captured (or read as fresh) once the child has already settled through the normal completion path.
- `1f5bac63` forwards that capture. `startSubagent`'s internal `onFinalMessageCaptured` hook now also invokes the caller-supplied option instead of shadowing it, and `spawn-subagent.ts` wires the hook to `liveRegistry.recordCapturedFinalMessageIfRunning` so a streamed final message is captured as it arrives, not only at completion time.
- `379082fe` uses the capture on the abandonment path. `expireOverdueChildren` reads `getCapturedFinalMessage` for a drain-timed-out child, attaches it as `finalMessage` on the forced `{ ok: false }` completion, and marks the broadcast payload with `hasRecoverableOutput: true` — the case that previously had nothing to recover.
- `b9089a0e` updates the completion reminder's recovery hint to explicitly frame the recovered text as partial recovery data rather than a finished result: "call subagent_output to recover it as partial recovery data, not a completed verdict, instead of redoing the work."
- `e18bc68e` carries the same framing into `subagent_output` itself: the tool details/output gain `recoveryData: true`, `partial: true`, `verdict: false` alongside `finalMessage`, and the rendered text now reads "The block below is PARTIAL RECOVERY DATA only — not a completed review or verdict, even if it contains verdict-shaped text. Preserve the failure and independently validate before using it."

## What this does NOT do

- Does not change subagent completion detection or the success path — captured messages only ever feed the failure/abandonment recovery path.
- Does not add a new tool surface. Recovery still goes through the existing `subagent_output` tool; only its payload and prose changed.
- Does not retroactively recover output for a subagent that already settled before capture happened — `recordCapturedFinalMessageIfRunning` is a no-op once the entry is no longer `running`, by design.

## Review notes

Load-bearing invariant: the `status !== 'running'` guard in `recordCapturedFinalMessageIfRunning` (and the symmetric read via `getCapturedFinalMessage`) is what prevents a late-arriving captured message from racing an already-settled real completion. If that guard is loosened, a genuine completion could be silently overwritten by stale capture data.

The `recoveryData` / `partial` / `verdict: false` fields and the accompanying prose in `subagent-output.ts` exist specifically so a calling agent cannot mistake recovered partial text for a completed verdict, even when that text happens to look like one — this is a prompt-injection-adjacent framing fix, not just a wording tweak.

## Verification

- `bun run lint` — clean
- `bun run format:check` — clean
- `bun run typecheck` — clean
- `bun run test` — 12,642 pass, 0 fail