### PR TITLE
Add bounded adaptive HTML extraction fallback

### DIFF
--- a/docs/content/docs/internals/web-search.mdx
+++ b/docs/content/docs/internals/web-search.mdx
@@ -55,3 +55,88 @@ provide a safely inferable IPv4 field location—not because every member maps
 metadata. It does not guess arbitrary operator-specific RFC 6052 prefixes. The
 two `TYPECLAW_MODEL_HTTP_*` values are withheld from model bash, and raw `.env`
 is masked from model-driven file access.
+
+## Adaptive HTML extraction is a post-fetch fallback, not a retry
+
+`src/agent/tools/webfetch/adaptive-html.ts` only fires when `strategy` is
+auto-detected as `"readability"` (an explicit `strategy: "readability"` skips
+adaptive JSON-LD/classification and returns Readability's result as-is, even
+empty, but still shares parser and deterministic visibility safety checks — see `tool.ts`). It runs
+entirely on the HTML body that `safe-http` already
+fetched. There is no second network call: one fetch happens, then this module
+tries two extraction routes against that same body, in a fixed order.
+
+1. **Adaptive DOM complexity preflight, then Readability.** Before constructing
+   JSDOM, a forward-cursor scanner bounds the adaptive path to **5 MiB**, **20,000
+   tags**, and **256 open-element nesting levels**. It handles valid comments,
+   legacy HTML/XHTML prologs, quoted `>` attributes, HTML void elements,
+   `<plaintext>` through EOF, escaped script states, and raw script/style bodies
+   without regex backtracking. SVG and MathML subtrees, including HTML integration
+   points such as `foreignObject`, remain conservatively suppressed as metadata
+   sources while their lexical tags and depth are still counted. A trailing slash
+   does not close a non-void HTML element. Unterminated comments or quoted opening
+   tags that the scanner cannot model safely fail with a fixed structure-validation
+   diagnostic. Crossing a resource limit records a distinct fixed complexity
+   diagnostic. Either result skips JSDOM and structured fallback because the
+   same lexical context cannot be validated safely. Explicit `strategy: "readability"`
+   uses the same fence before JSDOM but otherwise preserves the existing
+   `applyReadability()` output behavior and skips the adaptive routes. Before
+   extraction, the shared pipeline removes deterministic visually hidden content from
+   attributes (excluding `inert`, which does not itself hide source-visible prose), inline declarations, closed `dialog`/`details` containers, and
+   embedded CSS rules that JSDOM can resolve locally. JSDOM does not load linked
+   stylesheets or other subresources, so source-visible content remains eligible
+   without introducing a second request. Embedded CSS evaluation is fenced by
+   stylesheet bytes, raw segment length, recursive rule count, per-selector
+   length, and a selector-list-component-by-element work budget before any computed-style traversal.
+   The limits protect against known
+   synchronous DOM complexity hazards; they are not a claim that every parser
+   denial-of-service shape is impossible. `applyReadabilityDetailed` preserves the existing
+   `applyReadability()` string API while reporting structural evidence: whether
+   Readability parsed an article, whether conversion fell back to the whole
+   body, semantic/prose containers, and script count. Concise pages remain
+   compatible when Readability identifies real article structure. Generic
+   unstructured output is rejected conservatively when the source instead has
+   the structure of a script-rendered shell; there is no language-specific
+   keyword or universal text-length gate.
+2. **Bounded schema.org Article JSON-LD rescue.** If Readability's output
+   isn't useful or fails after a valid preflight (a JS app shell with no visible
+   content is the common miss),
+   `extractJsonLdArticle` scans `<script type="application/ld+json">` blocks for
+   an `Article`/`NewsArticle`/`BlogPosting` node, skipping complete ordinary
+   script bodies before searching for another script (and recursing through arrays
+   and `@graph` containers to the fixed depth limit) and pulls `headline` +
+   `articleBody`/`description`. Concise structured articles are accepted when
+   Readability is genuinely unusable. Documents with embedded CSS skip this
+   route because the bounded lexical metadata scan does not execute the CSS
+   cascade; this prevents source-hidden structured data from bypassing the DOM
+   visibility checks. The
+   metadata payloads are accepted only from the first 1 MiB, while lexical
+   visibility context is validated across the full 5 MiB adaptive document.
+   Oversized documents skip this route. Block count, per-block bytes, and
+   per-field characters are also bounded, so a pathological page can't turn
+   this into unbounded work.
+3. **Neither worked.** If both routes come up empty, the tool returns an
+   error whose message says browser retrieval may be needed — it does not
+   retry the fetch, switch transport, or spawn a browser itself. Escalating to
+   an actual browser (if one is available) is left to the calling agent.
+
+Each attempt is recorded in order as `{ route, outcome, reason }` and surfaced
+on `details.extractionAttempts`. These structured details are available in the
+live tool result and persisted session records. The normal TUI preview and
+historical inspect text replay render only extracted content or the fixed final
+error, not the structured attempt details. The persisted data still records
+which route ran, why it was rejected, and in what sequence without diagnostics
+echoing fetched content or internal error strings.
+
+None of this touches `safe-http.ts`. The DNS-rebinding guard, redirect
+pinning, and Akamai warmup already produced the one HTML body this module
+works with; adaptive extraction is pure post-processing on that body, so the
+transport-layer guarantees above are unaffected by whether Readability or the
+JSON-LD rescue ends up producing the output.
+
+The bounded, ordered-route-then-validate shape here (try one extractor, fall
+back to a second only on a validated miss, stop rather than escalate) took
+inspiration from [`fivetaku/insane-search`](https://github.com/fivetaku/insane-search).
+TypeClaw does not vendor or execute any code from that project — `adaptive-html.ts`
+is an independent implementation against Readability and schema.org, not a
+port.

--- a/src/agent/tools/webfetch/adaptive-html.test.ts
+++ b/src/agent/tools/webfetch/adaptive-html.test.ts
@@ -1,0 +1,1169 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  extractAdaptiveHtml,
+  MAX_ADAPTIVE_HTML_ATTRIBUTES_PER_TAG,
+  MAX_ADAPTIVE_HTML_NESTING_DEPTH,
+  MAX_ADAPTIVE_HTML_SCAN_BYTES,
+  MAX_ADAPTIVE_HTML_TAG_COUNT,
+  scanJsonLdScripts,
+  validateAdaptiveHtmlComplexity,
+} from './adaptive-html'
+
+const articleScript = (body: string, attributes = 'type="application/ld+json"'): string =>
+  `<script ${attributes}>${JSON.stringify({ '@type': 'Article', headline: 'Update', articleBody: body })}</script>`
+
+const readabilityMiss = async () => ({
+  output: 'Readability extracted no content from this page.',
+  parsedArticle: false,
+  usedBodyFallback: true,
+  hasSemanticContentContainer: false,
+  hasArticleContainer: false,
+  proseElementCount: 0,
+  structuredContentElementCount: 0,
+  scriptCount: 0,
+  visibleTextCharacterCount: 0,
+})
+
+describe('adaptive HTML extraction', () => {
+  test('preserves a concise article that Readability genuinely identifies', async () => {
+    const result = await extractAdaptiveHtml(
+      '<html><head><title>Brief</title></head><body><article><h1>Brief</h1><p>Done today.</p></article></body></html>',
+      'https://example.com/brief',
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') expect(result.output).toContain('Done today.')
+    expect(result.attempts).toEqual([
+      { route: 'readability', outcome: 'success', reason: 'Readability identified article content' },
+    ])
+  })
+
+  test('accepts concise semantic content even when multiple scripts are present', async () => {
+    const result = await extractAdaptiveHtml(
+      '<html><body><main><h1>Status</h1><div>Done today</div></main><script src="/one.js"></script><script src="/two.js"></script></body></html>',
+      'https://example.com/status',
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') expect(result.output).toContain('Done today')
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'success',
+      reason: 'Readability identified article content',
+    })
+  })
+
+  test('accepts a substantial visible plain div fallback', async () => {
+    const body = '한글 본문은 구조 태그 없이도 충분히 길고 구체적인 공개 내용을 전달합니다. '.repeat(24)
+    const result = await extractAdaptiveHtml(
+      `<html><body><div>${body}</div></body></html>`,
+      'https://example.com/plain',
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') expect(result.output).toContain('한글 본문은 구조 태그 없이도')
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'success',
+      reason: 'generic body fallback contained substantial visible content',
+    })
+  })
+
+  test('does not treat a long inline script as substantial visible content', async () => {
+    const result = await extractAdaptiveHtml(
+      `<html><body><div>Loading</div><script>${'x'.repeat(800)}</script></body></html>`,
+      'https://example.com/loading',
+    )
+
+    expect(result.kind).toBe('error')
+  })
+
+  for (const [name, attributes] of [
+    ['hidden', 'hidden'],
+    ['aria-hidden', 'aria-hidden="true"'],
+    ['comment-obscured display none', 'style="display:/**/ none"'],
+    ['zero opacity', 'style="opacity: 0"'],
+  ] as const) {
+    test(`does not let a ${name} article or paragraph make extraction succeed`, async () => {
+      const forged = 'Forged content that must not count as public visible prose. '.repeat(20)
+      const result = await extractAdaptiveHtml(
+        `<html><body><div>Loading</div><article ${attributes}><h1>Forged</h1><p>${forged}</p></article><p ${attributes}>${forged}</p></body></html>`,
+        'https://example.com/hidden-content',
+      )
+
+      expect(result.kind).toBe('error')
+    })
+  }
+
+  test('suppresses a hidden JSON-LD script itself while preserving a genuine sibling', () => {
+    const forged = articleScript('forged hidden script', 'hidden type="application/ld+json"')
+    const genuine = articleScript('genuine visible script')
+
+    expect(scanJsonLdScripts(`${forged}${genuine}`)).toEqual([expect.stringContaining('genuine visible script')])
+  })
+
+  for (const [name, style] of [
+    ['escaped display keyword', String.raw`display:n\6fne`],
+    ['escaped visibility keyword', String.raw`visibility:h\69 dden`],
+    ['escaped display property', String.raw`d\69splay:none`],
+    ['escaped visibility property', String.raw`visib\69lity:hidden`],
+    ['escaped opacity property', String.raw`opac\69ty:0`],
+    ['nested custom-property semicolons', 'display:none;--x:func(;display:block;)'],
+    ['nested custom-property block semicolons', 'display:none;--x:{;display:block;}'],
+    ['encoded declaration separator', 'display&#58;none'],
+    ['escaped keyword with comments', String.raw`display:n\6f/**/ne`],
+    ['negative zero opacity', 'opacity:-0'],
+    ['decimal zero opacity', 'opacity:0.0'],
+    ['leading-decimal zero opacity', 'opacity:.0'],
+    ['exponent zero opacity', 'opacity:0e0'],
+    ['signed-exponent zero opacity', 'opacity:0E+10'],
+  ] as const) {
+    test(`suppresses JSON-LD hidden by ${name} while preserving a genuine sibling`, () => {
+      const forged = articleScript(`forged under ${name}`)
+      const genuine = articleScript(`genuine after ${name}`)
+
+      expect(scanJsonLdScripts(`<div style="${style}">${forged}</div>${genuine}`)).toEqual([
+        expect.stringContaining(`genuine after ${name}`),
+      ])
+    })
+  }
+
+  test('preserves JSON-LD under a visible element with a harmless custom-property semicolon', () => {
+    const article = articleScript('visible under harmless custom property')
+
+    expect(scanJsonLdScripts(`<div style='--label:"x; display:none";display:block'>${article}</div>`)).toEqual([
+      expect.stringContaining('visible under harmless custom property'),
+    ])
+  })
+
+  test('preserves JSON-LD under visible strings, URLs, and matched custom-property blocks', () => {
+    const article = articleScript('visible under bounded CSS blocks')
+    const styles = [
+      `--label:"x;display:none";display:block`,
+      `background:url("data:image/svg+xml;display:none");display:block`,
+      `--tokens:{color:red;nested:[one(two)]};display:block`,
+      `--label:"continued\\\nvalue";display:block`,
+    ]
+
+    for (const style of styles) {
+      expect(scanJsonLdScripts(`<div style='${style}'>${article}</div>`)).toEqual([
+        expect.stringContaining('visible under bounded CSS blocks'),
+      ])
+    }
+  })
+
+  for (const [name, style] of [
+    ['unbalanced function', 'display:block;--x:func(;display:none;'],
+    ['unterminated string', "display:block;--x:'unterminated"],
+    ['unterminated comment', 'display:block;--x:/* unterminated'],
+  ] as const) {
+    test(`fails closed on ${name} while preserving a genuine JSON-LD sibling`, () => {
+      const forged = articleScript(`forged under ${name}`)
+      const genuine = articleScript(`genuine after ${name}`)
+
+      expect(scanJsonLdScripts(`<div style="${style}">${forged}</div>${genuine}`)).toEqual([
+        expect.stringContaining(`genuine after ${name}`),
+      ])
+    })
+  }
+
+  test('fails closed on malformed opacity while preserving a genuine sibling', () => {
+    const article = articleScript('article under invalid opacity')
+    const genuine = articleScript('genuine sibling after invalid opacity')
+
+    expect(scanJsonLdScripts(`<div style="opacity:0junk">${article}</div>${genuine}`)).toEqual([
+      expect.stringContaining('genuine sibling after invalid opacity'),
+    ])
+  })
+
+  for (const [name, opacity] of [
+    ['negative', '-0.1'],
+    ['zero percentage', '0%'],
+    ['calculated zero', 'calc(0)'],
+    ['malformed positive sign', '+'],
+    ['malformed exponent', '0e'],
+  ] as const) {
+    test(`suppresses JSON-LD under ${name} opacity while preserving a genuine sibling`, () => {
+      const forged = articleScript(`forged under ${name} opacity`)
+      const genuine = articleScript(`genuine after ${name} opacity`)
+
+      expect(scanJsonLdScripts(`<div style="opacity:${opacity}">${forged}</div>${genuine}`)).toEqual([
+        expect.stringContaining(`genuine after ${name} opacity`),
+      ])
+    })
+  }
+
+  for (const opacity of ['0.1', '10%']) {
+    test(`preserves JSON-LD under positive opacity ${opacity}`, () => {
+      const article = articleScript(`visible under ${opacity}`)
+
+      expect(scanJsonLdScripts(`<div style="opacity:${opacity}">${article}</div>`)).toEqual([
+        expect.stringContaining(`visible under ${opacity}`),
+      ])
+    })
+  }
+
+  test('accepts substantial visible div content with two ordinary scripts', async () => {
+    const body = '충분히 긴 공개 본문입니다. '.repeat(48)
+    expect(Array.from(body).length).toBeGreaterThan(512)
+
+    const result = await extractAdaptiveHtml(
+      `<html><body><div>${body}</div><script src="/one.js"></script><script src="/two.js"></script></body></html>`,
+      'https://example.com/substantial-scripted',
+    )
+
+    expect(result.kind).toBe('success')
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'success',
+      reason: 'generic body fallback contained substantial visible content',
+    })
+  })
+
+  test('rejects a short heading shell with two scripts', async () => {
+    const result = await extractAdaptiveHtml(
+      '<html><body><h1>Status</h1><script src="/one.js"></script><script src="/two.js"></script></body></html>',
+      'https://example.com/heading-shell',
+    )
+
+    expect(result.kind).toBe('error')
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'unusable',
+      reason: 'generic body fallback looked like a script-rendered shell',
+    })
+  })
+
+  test('rejects a short visible plain div as page chrome', async () => {
+    const result = await extractAdaptiveHtml(
+      '<html><body><div>短い表示</div></body></html>',
+      'https://example.com/chrome',
+    )
+
+    expect(result.kind).toBe('error')
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'unusable',
+      reason: 'Readability identified only unstructured page chrome',
+    })
+  })
+
+  for (const [name, prose] of [
+    ['concise', 'Done today.'],
+    ['substantial', 'A complete release report with enough detail to explain the result and its impact.'.repeat(8)],
+  ] as const) {
+    test(`accepts ${name} non-semantic prose even when multiple scripts are present`, async () => {
+      const result = await extractAdaptiveHtml(
+        `<html><body><h1>Status</h1><p>${prose}</p><script src="/one.js"></script><script src="/two.js"></script></body></html>`,
+        `https://example.com/${name}`,
+      )
+
+      expect(result.kind).toBe('success')
+      expect(result.attempts[0]).toEqual({
+        route: 'readability',
+        outcome: 'success',
+        reason: 'Readability identified article content',
+      })
+    })
+  }
+
+  for (const [name, content, expected] of [
+    [
+      'heading and div content',
+      `<h1>Operational reference</h1><div>${'Concrete guidance with examples, constraints, and expected outcomes. '.repeat(20)}</div>`,
+      'Concrete guidance with examples',
+    ],
+    [
+      'definition list',
+      `<h1>Glossary</h1><dl>${Array.from({ length: 20 }, (_, index) => `<dt>Term ${index}</dt><dd>${'Precise definition with usage details. '.repeat(4)}</dd>`).join('')}</dl>`,
+      'Precise definition with usage details',
+    ],
+    [
+      'data table',
+      `<h1>Results</h1><table>${Array.from({ length: 20 }, (_, index) => `<tr><th>Item ${index}</th><td>${'Measured result with explanatory details. '.repeat(4)}</td></tr>`).join('')}</table>`,
+      'Measured result with explanatory details',
+    ],
+  ] as const) {
+    test(`accepts substantial useful ${name} parsed by Readability`, async () => {
+      const result = await extractAdaptiveHtml(`<html><body>${content}</body></html>`, `https://example.com/${name}`)
+
+      expect(result.kind).toBe('success')
+      if (result.kind === 'success') expect(result.output).toContain(expected)
+      expect(result.attempts[0]).toEqual({
+        route: 'readability',
+        outcome: 'success',
+        reason: 'generic body fallback contained substantial visible content',
+      })
+    })
+  }
+
+  test('accepts a concise JSON-LD article when Readability has no article', async () => {
+    const result = await extractAdaptiveHtml(
+      `<html><body><div id="app"></div>${articleScript('Brief update.')}</body></html>`,
+      'https://example.com/update',
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') expect(result.output).toBe('# Update\n\nBrief update.')
+  })
+
+  test('does not use JSON-LD when embedded CSS controls document visibility', async () => {
+    const result = await extractAdaptiveHtml(
+      `<html><head><style>.secret { display: none }</style></head><body><article class="secret"><p>${'Concealed prose. '.repeat(40)}</p></article>${articleScript('Public structured update.')}</body></html>`,
+      'https://example.com/stylesheet-fallback',
+    )
+
+    expect(result.kind).toBe('error')
+    expect(result.attempts).toEqual([
+      { route: 'readability', outcome: 'unusable', reason: 'Readability found no visible content' },
+      { route: 'json_ld', outcome: 'unusable', reason: 'no schema.org article content found' },
+    ])
+  })
+
+  for (const [name, opening, closing] of [
+    ['details', '<details>', '</details>'],
+    ['dialog', '<dialog>', '</dialog>'],
+  ] as const) {
+    test(`suppresses JSON-LD in closed ${name} and accepts an open sibling`, async () => {
+      const hidden = articleScript(`hidden in closed ${name}`)
+      const visible = articleScript(`visible in open ${name}`)
+      const html = `${opening}${hidden}${closing}<${name} open>${visible}${closing}`
+
+      expect(scanJsonLdScripts(html)).toEqual([expect.stringContaining(`visible in open ${name}`)])
+    })
+  }
+
+  test('recognizes an entity-encoded JSON-LD MIME type end to end', async () => {
+    const result = await extractAdaptiveHtml(
+      `<html><body><div id="app"></div>${articleScript('Encoded MIME update.', 'type="application&#x2f;ld+json"')}</body></html>`,
+      'https://example.com/encoded-mime',
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') expect(result.output).toContain('Encoded MIME update.')
+    expect(result.attempts.at(-1)?.route).toBe('json_ld')
+  })
+
+  test('recognizes a semicolonless numeric JSON-LD MIME type end to end', async () => {
+    const result = await extractAdaptiveHtml(
+      `<html><body><div id="app"></div>${articleScript('Semicolonless MIME update.', 'type="application&#47ld+json"')}</body></html>`,
+      'https://example.com/semicolonless-mime',
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') expect(result.output).toContain('Semicolonless MIME update.')
+    expect(result.attempts.at(-1)?.route).toBe('json_ld')
+  })
+
+  test('does not extract JSON-LD hidden by semicolonless numeric aria-hidden', async () => {
+    const forged = articleScript('must remain hidden')
+    const result = await extractAdaptiveHtml(
+      `<html><body><div id="app"></div><div aria-hidden="&#116rue">${forged}</div></body></html>`,
+      'https://example.com/semicolonless-aria',
+      { applyReadabilityDetailed: readabilityMiss },
+    )
+
+    expect(result.kind).toBe('error')
+    expect(result.attempts.at(-1)).toEqual({
+      route: 'json_ld',
+      outcome: 'unusable',
+      reason: 'no schema.org article content found',
+    })
+  })
+
+  test('uses the first duplicate visibility attribute when scanning JSON-LD', () => {
+    const article = articleScript('Duplicate attributes remain visible.')
+
+    expect(
+      scanJsonLdScripts(
+        `<div aria-hidden="false" aria-hidden="true" style="display:block" style="display:none">${article}</div>`,
+      ),
+    ).toHaveLength(1)
+    expect(
+      scanJsonLdScripts(
+        `<div aria-hidden="true" aria-hidden="false" style="display:block" style="display:none">${article}</div>`,
+      ),
+    ).toEqual([])
+    expect(
+      scanJsonLdScripts(
+        `<div style="display:none" style="display:block" aria-hidden="false" aria-hidden="true">${article}</div>`,
+      ),
+    ).toEqual([])
+  })
+
+  test('does not recover pseudo metadata after a plaintext start tag', async () => {
+    const html = `<plaintext>${articleScript('must remain plaintext')}${'<div>'.repeat(
+      MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1,
+    )}`
+
+    const result = await extractAdaptiveHtml(html, 'https://example.com/plaintext', {
+      applyReadabilityDetailed: readabilityMiss,
+    })
+
+    expect(result.kind).toBe('error')
+    expect(result.attempts).toEqual([
+      { route: 'readability', outcome: 'unusable', reason: 'Readability found no visible content' },
+      { route: 'json_ld', outcome: 'unusable', reason: 'no schema.org article content found' },
+    ])
+  })
+
+  for (const [name, prolog] of [
+    [
+      'HTML 4 public doctype',
+      '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">',
+    ],
+    [
+      'XHTML XML and public prolog',
+      '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
+    ],
+  ] as const) {
+    test(`extracts JSON-LD from a document with a legacy ${name}`, async () => {
+      const result = await extractAdaptiveHtml(
+        `${prolog}<html><body>${articleScript(`article after ${name}`)}</body></html>`,
+        'https://example.com/legacy',
+        { applyReadabilityDetailed: readabilityMiss },
+      )
+
+      expect(result.kind).toBe('success')
+      if (result.kind === 'success') expect(result.output).toContain(`article after ${name}`)
+    })
+  }
+
+  test('accepts substantial visible shell text without language-specific keyword matching', async () => {
+    const chrome = Array.from(
+      { length: 20 },
+      (_, index) => `<div class="placeholder">${index} ${'navigation placeholder '.repeat(8)}</div>`,
+    ).join('')
+    const html = `<html><head><title>Dashboard</title><script src="/runtime.js"></script><script src="/app.js"></script></head><body><div id="root">${chrome}</div><script>globalThis.__BOOT__={}</script></body></html>`
+
+    const result = await extractAdaptiveHtml(html, 'https://example.com/app')
+
+    expect(result.kind).toBe('success')
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'success',
+      reason: 'generic body fallback contained substantial visible content',
+    })
+  })
+
+  test('substantial visible content wins over generic script shell evidence', async () => {
+    const html = `<html><body><h1>상태</h1><div>${'자바스크립트가 활성화되어야 표시되는 대기 화면입니다. '.repeat(20)}</div><script src="/one.js"></script><script src="/two.js"></script></body></html>`
+
+    const result = await extractAdaptiveHtml(html, 'https://example.com/heading-shell')
+
+    expect(result.kind).toBe('success')
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'success',
+      reason: 'generic body fallback contained substantial visible content',
+    })
+  })
+
+  test('distinguishes extractor errors from ordinary content misses without leaking the error', async () => {
+    const result = await extractAdaptiveHtml('<html><body><div id="app"></div></body></html>', 'not a valid URL')
+
+    expect(result.kind).toBe('error')
+    if (result.kind === 'error') expect(result.message).toContain('An HTML extractor failed')
+    expect(JSON.stringify(result)).not.toContain('Invalid URL')
+    expect(result.attempts[0]?.outcome).toBe('error')
+  })
+
+  test('fences deeply nested HTML before invoking detailed Readability or JSON-LD', async () => {
+    let readabilityCalled = false
+    const nested = '<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)
+    const html = `${nested}${articleScript('Recovered after the DOM safety fence.')}`
+
+    const result = await extractAdaptiveHtml(html, 'https://example.com/nested', {
+      applyReadabilityDetailed: async () => {
+        readabilityCalled = true
+        throw new Error('must not run')
+      },
+    })
+
+    expect(readabilityCalled).toBe(false)
+    expect(result.kind).toBe('error')
+    expect(result.attempts).toEqual([
+      { route: 'readability', outcome: 'error', reason: 'adaptive HTML complexity limit exceeded' },
+      { route: 'json_ld', outcome: 'unusable', reason: 'no schema.org article content found' },
+    ])
+  })
+
+  for (const tag of ['div', 'x-widget']) {
+    test(`treats slash-marked non-void ${tag} elements as deep openings and rejects JSON-LD`, async () => {
+      let readabilityCalled = false
+      const html = `${`<${tag}/>`.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}${articleScript('Recovered after slash-marked nesting.')}`
+
+      const result = await extractAdaptiveHtml(html, 'https://example.com/slash-marked', {
+        applyReadabilityDetailed: async () => {
+          readabilityCalled = true
+          throw new Error('must not run')
+        },
+      })
+
+      expect(readabilityCalled).toBe(false)
+      expect(result.kind).toBe('error')
+      expect(result.attempts).toEqual([
+        { route: 'readability', outcome: 'error', reason: 'adaptive HTML complexity limit exceeded' },
+        { route: 'json_ld', outcome: 'unusable', reason: 'no schema.org article content found' },
+      ])
+    })
+  }
+
+  for (const [name, malformed] of [
+    ['abruptly closed comment', `<!-->${'<div/>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}`],
+    [
+      'abruptly closed comment with a later comment terminator',
+      `<!-->${'<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}-->`,
+    ],
+    ['abrupt empty comment', `<!--->${'<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}-->`],
+    ['nested comment opener', `<!-- outer <!-- inner -->${'<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}`],
+    ['unterminated comment', `<!-- hidden ${'<div/>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}`],
+    ['unterminated quoted opening tag', `<main title="hidden ${'<div/>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}`],
+  ] as const) {
+    test(`fails closed before Readability for an ${name}`, async () => {
+      let readabilityCalled = false
+
+      const result = await extractAdaptiveHtml(malformed, 'https://example.com/malformed', {
+        applyReadabilityDetailed: async () => {
+          readabilityCalled = true
+          throw new Error('must not run')
+        },
+      })
+
+      expect(readabilityCalled).toBe(false)
+      expect(result.attempts[0]).toEqual({
+        route: 'readability',
+        outcome: 'error',
+        reason: 'adaptive HTML structure could not be validated',
+      })
+    })
+  }
+})
+
+describe('adaptive HTML complexity validation', () => {
+  test('allows ordinary complex HTML', () => {
+    const html = `<!DoCtYpE html><!-- lead --><main data-label=">">${'<section><p>text</p></section>'.repeat(500)}<img src="x"><br></main>`
+
+    expect(validateAdaptiveHtmlComplexity(html)).toEqual({ valid: true })
+  })
+
+  test('accepts exactly the tag ceiling and rejects the next tag', () => {
+    expect(validateAdaptiveHtmlComplexity('<br>'.repeat(MAX_ADAPTIVE_HTML_TAG_COUNT))).toEqual({ valid: true })
+    expect(validateAdaptiveHtmlComplexity('<br>'.repeat(MAX_ADAPTIVE_HTML_TAG_COUNT + 1))).toEqual({
+      valid: false,
+      reason: 'adaptive HTML complexity limit exceeded',
+    })
+  })
+
+  test('rejects one tag over the ceiling before invoking Readability', async () => {
+    let readabilityCalled = false
+    const result = await extractAdaptiveHtml(
+      '<br>'.repeat(MAX_ADAPTIVE_HTML_TAG_COUNT + 1),
+      'https://example.com/excessive-tags',
+      {
+        applyReadabilityDetailed: async () => {
+          readabilityCalled = true
+          return readabilityMiss()
+        },
+      },
+    )
+
+    expect(readabilityCalled).toBe(false)
+    expect(result.attempts[0]).toEqual({
+      route: 'readability',
+      outcome: 'error',
+      reason: 'adaptive HTML complexity limit exceeded',
+    })
+  })
+
+  test('valid comments hide contained markup from the depth count', () => {
+    const html = `<!-- ${'<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)} --><main>ok</main>`
+
+    expect(validateAdaptiveHtmlComplexity(html)).toEqual({ valid: true })
+  })
+
+  test('quoted tag delimiters and malformed nesting cannot hide excessive depth', () => {
+    const html = `<div title="not > closed">${'<section data-x=">">'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}`
+
+    expect(validateAdaptiveHtmlComplexity(html)).toEqual({
+      valid: false,
+      reason: 'adaptive HTML complexity limit exceeded',
+    })
+  })
+
+  test('does not count valid omitted table row and cell end tags as nesting', () => {
+    const rows = Array.from({ length: 129 }, (_, index) => `<tr><th>Row ${index}<td>Value ${index}`).join('')
+
+    expect(validateAdaptiveHtmlComplexity(`<table><tbody>${rows}</table>`)).toEqual({ valid: true })
+  })
+
+  for (const [name, root] of [
+    ['SVG', 'svg'],
+    ['MathML', 'math'],
+  ] as const) {
+    test(`does not unwind table recovery across a ${name} root`, () => {
+      const fake = articleScript(`forged inside ${name}`)
+      const genuine = articleScript(`genuine after ${name}`)
+      const html = `<table><tr><td><${root}><tr><td></td></tr>${fake}</${root}></td></tr></table>${genuine}`
+
+      expect(scanJsonLdScripts(html)).toEqual([expect.stringContaining(`genuine after ${name}`)])
+    })
+  }
+
+  test('unwinds self-closing foreign descendants before scanning a later JSON-LD sibling', () => {
+    const genuine = articleScript('genuine after self-closing SVG path')
+
+    expect(scanJsonLdScripts(`<svg><path/></svg>${genuine}`)).toEqual([
+      expect.stringContaining('genuine after self-closing SVG path'),
+    ])
+  })
+
+  for (const root of ['svg', 'math']) {
+    test(`unwinds a self-closing ${root} root before a later JSON-LD sibling`, () => {
+      const genuine = articleScript(`genuine after self-closing ${root}`)
+
+      expect(scanJsonLdScripts(`<${root}/>${genuine}`)).toEqual([
+        expect.stringContaining(`genuine after self-closing ${root}`),
+      ])
+    })
+  }
+
+  test('does not pop through non-optional descendants of a hidden ancestor', () => {
+    const forged = articleScript('must remain under hidden ancestor')
+    const html = `<div hidden><select></div>${forged}`
+
+    expect(scanJsonLdScripts(html)).toEqual([])
+  })
+
+  test('recovers valid omitted paragraph and list-item end tags without false depth growth', () => {
+    const paragraphs = '<div><p>paragraph</div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 20)
+    const lists = `<ul>${'<li>item'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 20)}</ul>`
+
+    expect(validateAdaptiveHtmlComplexity(paragraphs)).toEqual({ valid: true })
+    expect(validateAdaptiveHtmlComplexity(lists)).toEqual({ valid: true })
+  })
+
+  test('closes omitted cells, rows, and prior sections for repeated tbody siblings', () => {
+    const sections = Array.from({ length: 300 }, (_, index) => `<tbody><tr><td>Value ${index}`).join('')
+
+    expect(validateAdaptiveHtmlComplexity(`<table>${sections}</table>`)).toEqual({ valid: true })
+  })
+
+  test('still rejects genuinely nested tags inside a table cell', () => {
+    const nested = '<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)
+
+    expect(validateAdaptiveHtmlComplexity(`<table><tr><td>${nested}</table>`)).toEqual({
+      valid: false,
+      reason: 'adaptive HTML complexity limit exceeded',
+    })
+  })
+
+  test('handles raw script and style bodies without treating their text as markup', () => {
+    const raw = '<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 10)
+    const html = `<script>const template = ${JSON.stringify(raw)}</script><style>.x::after{content:${JSON.stringify(raw)}}</style><main>ok</main>`
+
+    expect(validateAdaptiveHtmlComplexity(html)).toEqual({ valid: true })
+  })
+
+  for (const attributeCount of [15_000, 50_000]) {
+    test(`rejects a start tag with ${attributeCount.toLocaleString()} unique attributes`, () => {
+      const attributes = Array.from({ length: attributeCount }, (_, index) => ` data-${index}="x"`).join('')
+
+      expect(validateAdaptiveHtmlComplexity(`<main${attributes}>content</main>`)).toEqual({
+        valid: false,
+        reason: 'adaptive HTML complexity limit exceeded',
+      })
+    })
+  }
+
+  test('allows an ordinary start tag below the attribute limit', () => {
+    const attributes = Array.from(
+      { length: Math.min(100, MAX_ADAPTIVE_HTML_ATTRIBUTES_PER_TAG) },
+      (_, index) => ` data-${index}="x"`,
+    ).join('')
+
+    expect(validateAdaptiveHtmlComplexity(`<main${attributes}>content</main>`)).toEqual({ valid: true })
+  })
+
+  test('treats plaintext as text through EOF without counting textual tags or requiring a close', () => {
+    const html = `<main>before</main><plaintext>${'<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}`
+
+    expect(validateAdaptiveHtmlComplexity(html)).toEqual({ valid: true })
+  })
+
+  for (const [name, html] of [
+    ['MDN-style empty processing instruction', '<p>before</p><?><p>after</p>'],
+    ['arbitrary processing instruction', '<?render mode="fast"?><html></html>'],
+    ['mid-document XML-like instruction', '<html><?xml version="1.0"?></html>'],
+    ['non-doctype declaration', '<p>before</p><!bogus><p>after</p>'],
+    ['invalid quoted doctype declaration', '<!DOCTYPE html PUBLIC "safe<unsafe" "legacy.dtd"><html></html>'],
+    ['XML-like instruction with unknown attributes', '<?xml version="1.0" vendor="x"?><html></html>'],
+    ['unterminated XML-like quoted instruction', '<?xml version="1.0" encoding="UTF-8?><html></html>'],
+  ] as const) {
+    test(`accepts ${name} as an HTML bogus comment`, () => {
+      expect(validateAdaptiveHtmlComplexity(html)).toEqual({ valid: true })
+    })
+  }
+
+  test('completes a maximum-size bounded scan', () => {
+    const html = '<x></x>'.repeat(Math.floor(MAX_ADAPTIVE_HTML_SCAN_BYTES / 7)).slice(0, MAX_ADAPTIVE_HTML_SCAN_BYTES)
+
+    expect(validateAdaptiveHtmlComplexity(html)).toEqual({
+      valid: false,
+      reason: 'adaptive HTML complexity limit exceeded',
+    })
+  })
+})
+
+describe('bounded JSON-LD script scanner', () => {
+  test('preserves source offsets when non-ASCII text lowercases to a different length', () => {
+    const genuine = articleScript('genuine after dotted capital I')
+
+    expect(scanJsonLdScripts(`İ${genuine}`)).toEqual([expect.stringContaining('genuine after dotted capital I')])
+  })
+
+  test('recognizes exact type attributes case-insensitively with attribute variants', () => {
+    const html = [
+      articleScript('one', 'DATA-TYPE="application/ld+json"'),
+      articleScript('two', 'defer TYPE = application/ld+json data-x="1"'),
+      articleScript('three', "type='APPLICATION/LD+JSON'"),
+      articleScript('four', 'class=x type = "application/ld+json"'),
+    ].join('')
+
+    const blocks = scanJsonLdScripts(html)
+
+    expect(blocks).toHaveLength(3)
+    expect(blocks.join('\n')).not.toContain('"one"')
+    expect(blocks.join('\n')).toContain('"two"')
+    expect(blocks.join('\n')).toContain('"three"')
+    expect(blocks.join('\n')).toContain('"four"')
+  })
+
+  test('decodes bounded character references in relevant type attributes', () => {
+    const html = [
+      articleScript('decimal slash', 'type="application&#47;ld+json"'),
+      articleScript('hex slash', 'type="application&#x2f;ld+json"'),
+      articleScript('named slash', 'type="application&sol;ld+json"'),
+    ].join('')
+
+    expect(scanJsonLdScripts(html)).toHaveLength(3)
+  })
+
+  test('decodes semicolonless decimal and hexadecimal references without swallowing trailing text', () => {
+    const html = [
+      articleScript('decimal slash', 'type="application&#47ld+json"'),
+      articleScript('lowercase hex slash', 'type="application&#x2fld+json"'),
+      articleScript('uppercase hex slash', 'type="application&#X2Fld+json"'),
+    ].join('')
+
+    expect(scanJsonLdScripts(html)).toHaveLength(3)
+  })
+
+  test('uses only the first type attribute even when it is uncertain or missing a value', () => {
+    const uncertainFirst = articleScript(
+      'uncertain first type',
+      'type="application&unknown;ld+json" type="application/ld+json"',
+    )
+    const valuelessFirst = articleScript('valueless first type', 'type type="application/ld+json"')
+    const recognizedFirst = articleScript('recognized first type', 'type="application/ld+json" type="text/javascript"')
+
+    expect(scanJsonLdScripts(`${uncertainFirst}${valuelessFirst}${recognizedFirst}`)).toEqual([
+      expect.stringContaining('recognized first type'),
+    ])
+  })
+
+  test('trims HTML ASCII whitespace around the first type value but rejects MIME parameters', () => {
+    const html = [
+      articleScript('spaces', 'type="  application/ld+json  "'),
+      articleScript('tabs and newlines', 'type="\t\napplication/ld+json\r\f"'),
+      articleScript('parameters', 'type=" application/ld+json; charset=utf-8 "'),
+    ].join('')
+
+    const blocks = scanJsonLdScripts(html)
+    expect(blocks).toHaveLength(2)
+    expect(blocks.join('\n')).toContain('spaces')
+    expect(blocks.join('\n')).toContain('tabs and newlines')
+    expect(blocks.join('\n')).not.toContain('parameters')
+  })
+
+  test('fails closed on uncertain ampersand syntax in relevant metadata attributes', () => {
+    const forged = articleScript('uncertain type', 'type="application&unknown;ld+json"')
+    const nested = articleScript('uncertain style')
+    const genuine = articleScript('genuine sibling')
+
+    expect(scanJsonLdScripts(`${forged}<div style="display&unknown;none">${nested}</div>${genuine}`)).toEqual([
+      expect.stringContaining('genuine sibling'),
+    ])
+  })
+
+  test('requires an exact closing script tag name', () => {
+    const source = JSON.stringify({
+      '@type': 'Article',
+      articleBody: 'A JSON string containing </scripted> remains inside the block.',
+    })
+
+    expect(scanJsonLdScripts(`<script type="application/ld+json">${source}</script>`)).toEqual([source])
+  })
+
+  test('skips embedded JSON-LD-looking scripts inside an ordinary raw script body', () => {
+    const fake = articleScript('must not be extracted')
+    const genuine = articleScript('genuine sibling')
+    const html = `<script>const template = \`${fake}\`; const text = "</scripted>";</script>${genuine}`
+
+    expect(scanJsonLdScripts(html)).toEqual([expect.stringContaining('genuine sibling')])
+  })
+
+  for (const [name, attributes] of [
+    ['hidden', 'hidden'],
+    ['inert', 'inert'],
+    ['aria-hidden', 'aria-hidden="TRUE"'],
+    ['semicolonless decimal aria-hidden', 'aria-hidden="&#116rue"'],
+    ['semicolonless hexadecimal aria-hidden', 'aria-hidden="&#x74rue"'],
+    ['comment-obscured display none', 'style="display: /**/ none"'],
+    ['hidden visibility', 'style="visibility: hidden"'],
+    ['zero opacity', 'style="opacity: 0"'],
+  ] as const) {
+    test(`suppresses JSON-LD under a ${name} ancestor while preserving a genuine sibling`, () => {
+      const forged = articleScript(`forged under ${name}`)
+      const genuine = articleScript(`genuine after ${name}`)
+
+      expect(scanJsonLdScripts(`<div ${attributes}>${forged}</div>${genuine}`)).toEqual([
+        expect.stringContaining(`genuine after ${name}`),
+      ])
+    })
+  }
+
+  test('does not treat double-escaped script text as an outer script close', async () => {
+    const fake = articleScript('forged in double-escaped script text')
+    const genuine = articleScript('genuine after escaped script close')
+    const html = `<script><!--<script>inner</script>${fake}--></script>${genuine}`
+
+    expect(scanJsonLdScripts(html)).toEqual([expect.stringContaining('genuine after escaped script close')])
+
+    const result = await extractAdaptiveHtml(html, 'https://example.com/escaped-script', {
+      applyReadabilityDetailed: readabilityMiss,
+    })
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') {
+      expect(result.output).toContain('genuine after escaped script close')
+      expect(result.output).not.toContain('forged in double-escaped script text')
+    }
+  })
+
+  for (const [name, wrap] of [
+    ['SVG', (value: string) => `<svg><foreignObject>${value}</foreignObject></svg>`],
+    ['nested MathML', (value: string) => `<math><mrow><math>${value}</math></mrow></math>`],
+  ] as const) {
+    test(`suppresses scripts throughout the entire ${name} subtree`, () => {
+      const fake = articleScript(`fake in ${name}`)
+      const genuine = articleScript(`genuine after ${name}`)
+
+      expect(scanJsonLdScripts(`${wrap(fake)}${genuine}`)).toEqual([expect.stringContaining(`genuine after ${name}`)])
+    })
+  }
+
+  test('treats plaintext as raw text to EOF and emits no script blocks', () => {
+    const html = `<plaintext>${articleScript('fake after plaintext')}${'<script>'.repeat(1_000)}`
+
+    expect(scanJsonLdScripts(html)).toEqual([])
+  })
+
+  for (const [name, wrap] of [
+    ['comment', (value: string) => `<!-- ${value} -->`],
+    ['textarea', (value: string) => `<textarea>${value}</textarea>`],
+    ['title', (value: string) => `<title>${value}</title>`],
+    ['xmp', (value: string) => `<xmp>${value}</xmp>`],
+    ['iframe', (value: string) => `<iframe>${value}</iframe>`],
+    ['noembed', (value: string) => `<noembed>${value}</noembed>`],
+    ['noframes', (value: string) => `<noframes>${value}</noframes>`],
+    ['noscript', (value: string) => `<noscript>${value}</noscript>`],
+    ['template', (value: string) => `<template>${value}</template>`],
+  ] as const) {
+    test(`ignores pseudo JSON-LD inside ${name} while finding a genuine sibling`, () => {
+      const fake = articleScript(`fake in ${name}`)
+      const genuine = articleScript(`genuine after ${name}`)
+
+      expect(scanJsonLdScripts(`${wrap(fake)}${genuine}`)).toEqual([expect.stringContaining(`genuine after ${name}`)])
+    })
+  }
+
+  test('disables JSON-LD extraction for the entire document when embedded CSS exists', () => {
+    const fake = articleScript('fake in style')
+    const genuine = articleScript('genuine after style')
+
+    expect(scanJsonLdScripts(`<style>${fake}</style>${genuine}`)).toEqual([])
+  })
+
+  test('detects embedded CSS after the JSON-LD payload window', () => {
+    const genuine = articleScript('must be suppressed by later CSS context')
+    const html = `${genuine}${' '.repeat(1_000_000)}<style>.secret{display:none}</style>`
+
+    expect(scanJsonLdScripts(html)).toEqual([])
+  })
+
+  test('rejects a bare Article type under a conflicting explicit JSON-LD vocabulary', async () => {
+    const source = JSON.stringify({
+      '@context': 'https://evil.example/vocab',
+      '@type': 'Article',
+      headline: 'Forged',
+      articleBody: 'must not be treated as schema.org',
+    })
+
+    expect(scanJsonLdScripts(`<script type="application/ld+json">${source}</script>`)).toEqual([source])
+    const result = await extractAdaptiveHtml(
+      `<script type="application/ld+json">${source}</script>`,
+      'https://example.com',
+    )
+    expect(result.kind).toBe('error')
+  })
+
+  test('accepts an absolute schema.org Article type under another context', async () => {
+    const source = JSON.stringify({
+      '@context': 'https://evil.example/vocab',
+      '@type': 'https://schema.org/Article',
+      headline: 'Absolute schema type',
+      articleBody: 'accepted by its absolute vocabulary identifier',
+    })
+
+    const result = await extractAdaptiveHtml(
+      `<script type="application/ld+json">${source}</script>`,
+      'https://example.com',
+    )
+    expect(result.kind).toBe('success')
+  })
+
+  test('inherits a conflicting JSON-LD context into graph nodes', async () => {
+    const source = JSON.stringify({
+      '@context': 'https://evil.example/vocab',
+      '@graph': [{ '@type': 'Article', headline: 'Forged graph', articleBody: 'must remain rejected' }],
+    })
+
+    const result = await extractAdaptiveHtml(
+      `<script type="application/ld+json">${source}</script>`,
+      'https://example.com',
+    )
+    expect(result.kind).toBe('error')
+  })
+
+  test('resets an inherited JSON-LD context when a graph node declares null', async () => {
+    const source = JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@context': null,
+          '@type': 'Article',
+          headline: 'Reset context',
+          articleBody: 'must not inherit the parent schema vocabulary',
+        },
+      ],
+    })
+
+    const result = await extractAdaptiveHtml(
+      `<script type="application/ld+json">${source}</script>`,
+      'https://example.com',
+    )
+    expect(result.kind).toBe('error')
+  })
+
+  for (const [name, context] of [
+    ['trailing null reset', ['https://schema.org', null]],
+    [
+      'null reset followed by unrelated vocabulary',
+      ['https://schema.org', null, { '@vocab': 'https://evil.example/' }],
+    ],
+  ] as const) {
+    test(`rejects bare Article after a ${name}`, async () => {
+      const source = JSON.stringify({
+        '@context': context,
+        '@type': 'Article',
+        headline: 'Reset array context',
+        articleBody: 'must not use the earlier schema vocabulary',
+      })
+
+      const result = await extractAdaptiveHtml(
+        `<script type="application/ld+json">${source}</script>`,
+        'https://example.com',
+      )
+      expect(result.kind).toBe('error')
+    })
+  }
+
+  test('accepts a schema vocabulary declared after an array context reset', async () => {
+    const source = JSON.stringify({
+      '@context': ['https://evil.example/', null, 'https://schema.org'],
+      '@type': 'Article',
+      headline: 'Schema after reset',
+      articleBody: 'accepted from the final active vocabulary',
+    })
+
+    const result = await extractAdaptiveHtml(
+      `<script type="application/ld+json">${source}</script>`,
+      'https://example.com',
+    )
+    expect(result.kind).toBe('success')
+  })
+
+  for (const [name, context, type] of [
+    ['schema vocabulary', { '@vocab': 'https://schema.org/' }, 'Article'],
+    ['schema prefix', { schema: 'https://schema.org/' }, 'schema:Article'],
+    ['schema term mapping', { Story: 'https://schema.org/NewsArticle' }, 'Story'],
+  ] as const) {
+    test(`accepts ${name} JSON-LD type resolution`, async () => {
+      const source = JSON.stringify({
+        '@context': context,
+        '@type': type,
+        headline: 'Mapped schema type',
+        articleBody: 'accepted through explicit schema.org context',
+      })
+
+      const result = await extractAdaptiveHtml(
+        `<script type="application/ld+json">${source}</script>`,
+        'https://example.com',
+      )
+      expect(result.kind).toBe('success')
+    })
+  }
+
+  for (const [name, context, type] of [
+    [
+      'later term override',
+      [{ Story: 'https://schema.org/Article' }, { Story: 'https://evil.example/Article' }],
+      'Story',
+    ],
+    ['later vocabulary override', ['https://schema.org', { '@vocab': 'https://evil.example/' }], 'Article'],
+    [
+      'later prefix override',
+      [{ schema: 'https://schema.org/' }, { schema: 'https://evil.example/' }],
+      'schema:Article',
+    ],
+  ] as const) {
+    test(`rejects a ${name} away from schema.org`, async () => {
+      const source = JSON.stringify({
+        '@context': context,
+        '@type': type,
+        headline: 'Overridden context',
+        articleBody: 'must remain rejected',
+      })
+
+      const result = await extractAdaptiveHtml(
+        `<script type="application/ld+json">${source}</script>`,
+        'https://example.com',
+      )
+      expect(result.kind).toBe('error')
+    })
+  }
+
+  for (const style of ['<style>.secret{display:none}', '<style/>']) {
+    test(`detects an embedded style start without a normal close: ${style}`, () => {
+      const genuine = articleScript('must be suppressed by incomplete CSS context')
+
+      expect(scanJsonLdScripts(`${genuine}${style}`)).toEqual([])
+    })
+  }
+
+  for (const foreignPrefix of [
+    '<svg><plaintext></plaintext></svg>',
+    '<svg><textarea></textarea></svg>',
+    '<math><textarea></textarea></math>',
+  ]) {
+    test(`does not let foreign raw-text syntax hide a later style start: ${foreignPrefix}`, () => {
+      const genuine = articleScript('must be suppressed after foreign content')
+
+      expect(scanJsonLdScripts(`${genuine}${foreignPrefix}<style>.secret{display:none}</style>`)).toEqual([])
+    })
+  }
+
+  test('counts tags hidden behind foreign plaintext syntax', () => {
+    const html = `<svg><plaintext></plaintext></svg>${'<br>'.repeat(MAX_ADAPTIVE_HTML_TAG_COUNT + 1)}`
+
+    expect(validateAdaptiveHtmlComplexity(html)).toEqual({
+      valid: false,
+      reason: 'adaptive HTML complexity limit exceeded',
+    })
+  })
+
+  test('ignores all JSON-LD when malformed markup makes lexical context uncertain', () => {
+    const html = `<!-->${'<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1)}-->${articleScript('must not escape')}`
+
+    expect(scanJsonLdScripts(html)).toEqual([])
+  })
+
+  test('does not mistake </scripted> in an ordinary script string for its exact close', () => {
+    const genuine = articleScript('after exact ordinary close')
+    const html = `<script>const text = "</scripted>"; const template = "<script type=application/ld+json>{}</script>";</script>${genuine}`
+
+    expect(scanJsonLdScripts(html)).toEqual([expect.stringContaining('after exact ordinary close')])
+  })
+
+  test('advances linearly through many unterminated script starts', () => {
+    const html = '<script type="application/ld+json">{'.repeat(28_000)
+
+    expect(scanJsonLdScripts(html)).toEqual([])
+  }, 10_000)
+
+  test('scans at most the first 1,000,000 UTF-8 bytes and excludes a script crossing the boundary', () => {
+    const visible = articleScript('inside')
+    const crossing = `<script type="application/ld+json">${'x'.repeat(200)}</script>`
+    const html = `${visible}${' '.repeat(1_000_000 - visible.length - 100)}${crossing}${articleScript('outside')}`
+
+    expect(scanJsonLdScripts(html)).toEqual([expect.stringContaining('inside')])
+  })
+
+  test('measures the JSON-LD payload window in UTF-8 bytes for multibyte text', () => {
+    const outside = articleScript('outside multibyte byte window')
+    const html = `${'한'.repeat(340_000)}${outside}`
+
+    expect(scanJsonLdScripts(html)).toEqual([])
+  })
+
+  test('does not extract pseudo metadata inside a malformed prefix truncated at the scan boundary', () => {
+    const html = `<main title="${articleScript('must remain inside malformed attribute')}${'x'.repeat(1_100_000)}`
+
+    expect(scanJsonLdScripts(html)).toEqual([])
+  })
+
+  test('returns at most 32 complete blocks', () => {
+    const html = Array.from({ length: 33 }, (_, index) => articleScript(`body-${index}`)).join('')
+
+    const blocks = scanJsonLdScripts(html)
+
+    expect(blocks).toHaveLength(32)
+    expect(blocks.at(-1)).toContain('body-31')
+    expect(blocks.join('\n')).not.toContain('body-32')
+  })
+
+  test('skips blocks over 256,000 UTF-8 bytes', () => {
+    const oversized = articleScript('한'.repeat(90_000))
+
+    expect(scanJsonLdScripts(`${oversized}${articleScript('usable')}`)).toEqual([expect.stringContaining('usable')])
+  })
+
+  test('truncates extracted values to 200,000 characters', async () => {
+    const result = await extractAdaptiveHtml(
+      `<html><body><div id="app"></div>${articleScript('z'.repeat(220_000))}</body></html>`,
+      'https://example.com/large',
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') {
+      expect(result.output).toHaveLength(200_010)
+      expect(result.output.endsWith('z'.repeat(100))).toBe(true)
+    }
+  })
+
+  test('preserves a bounded JSON-LD value with 200,000 unmatched tag openers in linear time', async () => {
+    const unmatched = '<'.repeat(200_000)
+    const result = await extractAdaptiveHtml(
+      `<html><body><div id="app"></div>${articleScript(unmatched)}</body></html>`,
+      'https://example.com/unmatched-tag-openers',
+      { applyReadabilityDetailed: readabilityMiss },
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind === 'success') {
+      expect(result.output).toHaveLength(200_010)
+      expect(result.output.endsWith('<'.repeat(100))).toBe(true)
+    }
+  }, 10_000)
+})

--- a/src/agent/tools/webfetch/adaptive-html.ts
+++ b/src/agent/tools/webfetch/adaptive-html.ts
@@ -1,0 +1,319 @@
+import { walkHtmlLexically } from './html-lexical'
+import { applyReadabilityDetailed, type ReadabilityDetailedResult } from './strategies/readability'
+import type { HtmlExtractionAttempt } from './types'
+
+export type AdaptiveHtmlResult =
+  | { kind: 'success'; output: string; attempts: HtmlExtractionAttempt[] }
+  | { kind: 'error'; message: string; attempts: HtmlExtractionAttempt[] }
+
+type AdaptiveHtmlDependencies = {
+  applyReadabilityDetailed: typeof applyReadabilityDetailed
+}
+
+export const MAX_ADAPTIVE_HTML_SCAN_BYTES = 5 * 1024 * 1024
+export const MAX_ADAPTIVE_HTML_TAG_COUNT = 20_000
+export const MAX_ADAPTIVE_HTML_NESTING_DEPTH = 256
+export const MAX_ADAPTIVE_HTML_ATTRIBUTES_PER_TAG = 1_024
+export const MAX_ADAPTIVE_HTML_START_TAG_CHARS = 64 * 1024
+
+const MAX_JSON_LD_SCAN_BYTES = 1_000_000
+const MAX_JSON_LD_BLOCKS = 32
+const MAX_JSON_LD_BLOCK_BYTES = 256_000
+const MAX_JSON_LD_VALUE_CHARS = 200_000
+const ARTICLE_TYPES = new Set(['Article', 'NewsArticle', 'BlogPosting'])
+const EMPTY_READABILITY_OUTPUT = 'Readability extracted no content from this page.'
+const COMPLEXITY_LIMIT_REASON = 'adaptive HTML complexity limit exceeded'
+const MALFORMED_HTML_REASON = 'adaptive HTML structure could not be validated'
+// A bounded character floor accepts substantial script-free fallback while keeping short chrome fail-closed.
+const SUBSTANTIAL_VISIBLE_TEXT_CHARACTERS = 512
+const ENCODER = new TextEncoder()
+
+export async function extractAdaptiveHtml(
+  html: string,
+  url: string,
+  dependencies: AdaptiveHtmlDependencies = { applyReadabilityDetailed },
+): Promise<AdaptiveHtmlResult> {
+  const attempts: HtmlExtractionAttempt[] = []
+
+  const complexity = validateAdaptiveHtmlComplexity(html)
+  if (!complexity.valid) {
+    attempts.push({ route: 'readability', outcome: 'error', reason: complexity.reason })
+  } else {
+    try {
+      const readability = await dependencies.applyReadabilityDetailed(html, url)
+      const verdict = classifyReadability(readability)
+      if (verdict.useful) {
+        attempts.push({ route: 'readability', outcome: 'success', reason: verdict.reason })
+        return { kind: 'success', output: readability.output, attempts }
+      }
+      attempts.push({ route: 'readability', outcome: 'unusable', reason: verdict.reason })
+    } catch {
+      attempts.push({ route: 'readability', outcome: 'error', reason: 'Readability extraction failed' })
+    }
+  }
+
+  try {
+    const output = extractJsonLdArticle(html)
+    if (output !== null) {
+      attempts.push({ route: 'json_ld', outcome: 'success', reason: 'extracted schema.org article content' })
+      return { kind: 'success', output, attempts }
+    }
+    attempts.push({ route: 'json_ld', outcome: 'unusable', reason: 'no schema.org article content found' })
+  } catch {
+    attempts.push({ route: 'json_ld', outcome: 'error', reason: 'schema.org extraction failed' })
+  }
+
+  const extractorFailed = attempts.some(({ outcome }) => outcome === 'error')
+  return {
+    kind: 'error',
+    message: extractorFailed
+      ? 'An HTML extractor failed, and no public article content was recovered. Browser retrieval may be needed.'
+      : 'Fetched HTML did not contain public article content. The page may require client-side rendering or access controls; browser retrieval may be needed.',
+    attempts,
+  }
+}
+
+export type AdaptiveHtmlComplexityResult = { valid: true } | { valid: false; reason: string }
+
+export function validateAdaptiveHtmlComplexity(html: string): AdaptiveHtmlComplexityResult {
+  if (byteLength(html) > MAX_ADAPTIVE_HTML_SCAN_BYTES) return complexityFailure()
+  const result = walkHtmlLexically(html, {
+    maxTags: MAX_ADAPTIVE_HTML_TAG_COUNT,
+    maxDepth: MAX_ADAPTIVE_HTML_NESTING_DEPTH,
+    maxAttributesPerTag: MAX_ADAPTIVE_HTML_ATTRIBUTES_PER_TAG,
+    maxStartTagChars: MAX_ADAPTIVE_HTML_START_TAG_CHARS,
+  })
+  if (result.valid) return result
+  return result.failure === 'limit' ? complexityFailure() : { valid: false, reason: MALFORMED_HTML_REASON }
+}
+
+export function scanJsonLdScripts(html: string): string[] {
+  if (byteLength(html) > MAX_ADAPTIVE_HTML_SCAN_BYTES) return []
+  const payloadCharacterLimit = sliceByBytes(html, MAX_JSON_LD_SCAN_BYTES).length
+  const blocks: string[] = []
+  let embeddedStylesheetSeen = false
+  let inspected = 0
+  const result = walkHtmlLexically(html, {
+    maxTags: MAX_ADAPTIVE_HTML_TAG_COUNT,
+    maxDepth: MAX_ADAPTIVE_HTML_NESTING_DEPTH,
+    maxAttributesPerTag: MAX_ADAPTIVE_HTML_ATTRIBUTES_PER_TAG,
+    maxStartTagChars: MAX_ADAPTIVE_HTML_START_TAG_CHARS,
+    onStartTag: ({ name }) => {
+      if (name === 'style') embeddedStylesheetSeen = true
+    },
+    onRawElement: (element) => {
+      if (element.name === 'style') return
+      if (
+        element.name !== 'script' ||
+        element.metadataSuppressed ||
+        element.typeAttribute !== 'application/ld+json' ||
+        element.bodyEnd > payloadCharacterLimit ||
+        inspected >= MAX_JSON_LD_BLOCKS
+      ) {
+        return
+      }
+      inspected++
+      const source = html.slice(element.bodyStart, element.bodyEnd).trim()
+      if (source && byteLength(source) <= MAX_JSON_LD_BLOCK_BYTES) blocks.push(source)
+    },
+  })
+  return result.valid && !embeddedStylesheetSeen ? blocks : []
+}
+
+function classifyReadability(result: ReadabilityDetailedResult): { useful: boolean; reason: string } {
+  if (result.output === EMPTY_READABILITY_OUTPUT)
+    return { useful: false, reason: 'Readability found no visible content' }
+
+  const hasClearContent =
+    result.parsedArticle &&
+    (result.hasSemanticContentContainer || result.hasArticleContainer || result.proseElementCount > 0)
+  if (hasClearContent) {
+    return { useful: true, reason: 'Readability identified article content' }
+  }
+
+  if (result.visibleTextCharacterCount >= SUBSTANTIAL_VISIBLE_TEXT_CHARACTERS) {
+    return { useful: true, reason: 'generic body fallback contained substantial visible content' }
+  }
+
+  const scriptRenderedShell =
+    !result.hasSemanticContentContainer &&
+    result.scriptCount >= 2 &&
+    (result.structuredContentElementCount > 0 || result.scriptCount >= 3)
+
+  if (scriptRenderedShell) {
+    return { useful: false, reason: 'generic body fallback looked like a script-rendered shell' }
+  }
+
+  if (result.parsedArticle && result.structuredContentElementCount > 0) {
+    return { useful: true, reason: 'Readability identified article content' }
+  }
+
+  if (result.parsedArticle) {
+    return { useful: false, reason: 'Readability identified only unstructured page chrome' }
+  }
+
+  return { useful: false, reason: 'generic body fallback contained only short visible content' }
+}
+
+function complexityFailure(): AdaptiveHtmlComplexityResult {
+  return { valid: false, reason: COMPLEXITY_LIMIT_REASON }
+}
+
+function extractJsonLdArticle(html: string): string | null {
+  for (const source of scanJsonLdScripts(html)) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(source)
+    } catch {
+      continue
+    }
+    for (const candidate of articleCandidates(parsed)) {
+      const headline = plainText(candidate.headline)
+      const body = plainText(candidate.articleBody) || plainText(candidate.description)
+      if (!body) continue
+      return headline ? `# ${escapeMarkdownHeading(headline)}\n\n${body}` : body
+    }
+  }
+  return null
+}
+
+function articleCandidates(value: unknown, depth = 0, inheritedContext?: unknown): Array<Record<string, unknown>> {
+  if (depth > 4) return []
+  if (Array.isArray(value)) return value.flatMap((item) => articleCandidates(item, depth + 1, inheritedContext))
+  if (!isRecord(value)) return []
+
+  const context = Object.hasOwn(value, '@context') ? value['@context'] : inheritedContext
+  const candidates = isArticleType(value['@type'], context) ? [value] : []
+  const graph = value['@graph']
+  if (graph !== undefined) candidates.push(...articleCandidates(graph, depth + 1, context))
+  return candidates
+}
+
+function isArticleType(value: unknown, context: unknown): boolean {
+  const values = Array.isArray(value) ? value : [value]
+  return values.some((item) => {
+    if (typeof item !== 'string') return false
+    const absoluteSchemaType = schemaOrgName(item)
+    if (absoluteSchemaType !== null) return ARTICLE_TYPES.has(absoluteSchemaType)
+    if (context === undefined) return ARTICLE_TYPES.has(item)
+    const resolved = resolveContextType(item, context)
+    return resolved !== null && ARTICLE_TYPES.has(resolved)
+  })
+}
+
+function schemaOrgName(value: string): string | null {
+  const match = /^https?:\/\/schema\.org\/(?:[^/#]+[/#])?([^/#]+)$/iu.exec(value)
+  return match?.[1] ?? null
+}
+
+function resolveContextType(type: string, context: unknown, depth = 0): string | null {
+  return resolveContextDefinition(type, context, depth).value
+}
+
+function resolveContextDefinition(
+  type: string,
+  context: unknown,
+  depth: number,
+): { defined: boolean; value: string | null } {
+  if (depth > 4) return { defined: false, value: null }
+  if (context === null) return { defined: true, value: null }
+  if (typeof context === 'string') {
+    return { defined: true, value: isSchemaOrgBase(context) && ARTICLE_TYPES.has(type) ? type : null }
+  }
+  if (Array.isArray(context)) {
+    for (let index = context.length - 1; index >= 0; index--) {
+      const resolution = resolveContextDefinition(type, context[index], depth + 1)
+      if (resolution.defined) return resolution
+    }
+    return { defined: false, value: null }
+  }
+  if (!isRecord(context)) return { defined: false, value: null }
+
+  const termDefined = Object.hasOwn(context, type)
+  const term = context[type]
+  const termId = typeof term === 'string' ? term : isRecord(term) ? term['@id'] : undefined
+  if (termDefined) {
+    const absolute = typeof termId === 'string' ? schemaOrgName(termId) : null
+    return { defined: true, value: absolute }
+  }
+
+  const separator = type.indexOf(':')
+  if (separator > 0) {
+    const prefixName = type.slice(0, separator)
+    if (!Object.hasOwn(context, prefixName)) return { defined: false, value: null }
+    const prefix = context[prefixName]
+    const prefixId = typeof prefix === 'string' ? prefix : isRecord(prefix) ? prefix['@id'] : undefined
+    return {
+      defined: true,
+      value: typeof prefixId === 'string' && isSchemaOrgBase(prefixId) ? type.slice(separator + 1) : null,
+    }
+  }
+
+  if (!Object.hasOwn(context, '@vocab')) return { defined: false, value: null }
+  const vocabulary = context['@vocab']
+  return {
+    defined: true,
+    value: typeof vocabulary === 'string' && isSchemaOrgBase(vocabulary) ? type : null,
+  }
+}
+
+function isSchemaOrgBase(value: string): boolean {
+  return /^https?:\/\/schema\.org\/?$/iu.test(value)
+}
+
+function plainText(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return stripTags(value.slice(0, MAX_JSON_LD_VALUE_CHARS))
+    .replace(/&(?:nbsp|#160);/giu, ' ')
+    .replace(/&amp;/giu, '&')
+    .replace(/&lt;/giu, '<')
+    .replace(/&gt;/giu, '>')
+    .replace(/&quot;/giu, '"')
+    .replace(/&#39;|&apos;/giu, "'")
+    .replace(/\s+/gu, ' ')
+    .trim()
+}
+
+function stripTags(value: string): string {
+  const output: string[] = []
+  let copiedThrough = 0
+  let cursor = 0
+  while (cursor < value.length) {
+    if (value[cursor] !== '<') {
+      cursor++
+      continue
+    }
+    output.push(value.slice(copiedThrough, cursor))
+    const candidateStart = cursor
+    cursor++
+    while (cursor < value.length && value[cursor] !== '>') cursor++
+    if (cursor >= value.length) {
+      output.push(value.slice(candidateStart))
+      copiedThrough = value.length
+      break
+    }
+    output.push(' ')
+    cursor++
+    copiedThrough = cursor
+  }
+  if (copiedThrough < value.length) output.push(value.slice(copiedThrough))
+  return output.join('')
+}
+
+function escapeMarkdownHeading(value: string): string {
+  return value.replace(/([\\`*_[\]{}()#+.!|>-])/gu, '\\$1')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function byteLength(value: string): number {
+  return ENCODER.encode(value).byteLength
+}
+
+function sliceByBytes(value: string, maxBytes: number): string {
+  const bytes = ENCODER.encode(value)
+  if (bytes.byteLength <= maxBytes) return value
+  return new TextDecoder('utf-8', { fatal: false }).decode(bytes.slice(0, maxBytes))
+}

--- a/src/agent/tools/webfetch/html-lexical.ts
+++ b/src/agent/tools/webfetch/html-lexical.ts
@@ -1,0 +1,841 @@
+import { classifyRawInlineStyleVisibility } from './inline-style-visibility'
+
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+])
+const OPTIONAL_SAME_TAG_CLOSE = new Set([
+  'li',
+  'dt',
+  'dd',
+  'p',
+  'rt',
+  'rp',
+  'optgroup',
+  'option',
+  'thead',
+  'tbody',
+  'tfoot',
+  'tr',
+  'th',
+  'td',
+  'colgroup',
+])
+const RAW_TEXT_ELEMENTS = new Set(['script', 'style', 'textarea', 'title', 'xmp', 'iframe', 'noembed', 'noframes'])
+// Inert template content and noscript fallback markup are not public document metadata sources.
+const METADATA_SUPPRESSING_ELEMENTS = new Set(['template', 'noscript'])
+// HTML integration points inside SVG/MathML are deliberately still suppressed: faithfully
+// switching tokenizer namespaces is unnecessary risk for metadata-only extraction.
+const FOREIGN_ROOT_ELEMENTS = new Set(['svg', 'math'])
+const MAX_DOCTYPE_CHARS = 4_096
+const MAX_XML_DECLARATION_CHARS = 1_024
+const MAX_BOGUS_COMMENT_CHARS = 64 * 1024
+
+type HtmlStartTag = {
+  name: string
+  end: number
+  typeAttribute: string | null
+  metadataSuppressing: boolean
+  selfClosingSyntax: boolean
+}
+
+export type HtmlRawElement = {
+  name: string
+  typeAttribute: string | null
+  bodyStart: number
+  bodyEnd: number
+  metadataSuppressed: boolean
+}
+
+type HtmlLexicalWalkOptions = {
+  maxTags?: number
+  maxDepth?: number
+  maxAttributesPerTag?: number
+  maxStartTagChars?: number
+  allowIncompleteTail?: boolean
+  onStartTag?: (tag: { name: string; end: number }) => void
+  onRawElement?: (element: HtmlRawElement) => void
+}
+
+export type HtmlLexicalWalkResult = { valid: true } | { valid: false; failure: 'limit' | 'malformed' }
+
+type ParseResult<T> =
+  | { kind: 'ok'; value: T }
+  | { kind: 'text' }
+  | { kind: 'incomplete' }
+  | { kind: 'invalid' }
+  | { kind: 'limit' }
+
+type StackEntry = {
+  name: string
+  metadataSuppressing: boolean
+  foreignRoot: boolean
+}
+
+export function walkHtmlLexically(html: string, options: HtmlLexicalWalkOptions = {}): HtmlLexicalWalkResult {
+  const stack: StackEntry[] = []
+  let metadataSuppressionDepth = 0
+  let foreignNamespaceDepth = 0
+  let tagCount = 0
+  let cursor = 0
+  let xmlDeclarationAllowed = true
+
+  const recordTag = (): boolean => {
+    tagCount++
+    return options.maxTags === undefined || tagCount <= options.maxTags
+  }
+
+  const popStack = (): StackEntry | undefined => {
+    const closed = stack.pop()
+    if (closed?.metadataSuppressing) metadataSuppressionDepth--
+    if (closed?.foreignRoot) foreignNamespaceDepth--
+    return closed
+  }
+
+  const popThrough = (index: number): void => {
+    while (stack.length > index) popStack()
+  }
+
+  const closeOptionalElementsForStart = (name: string): void => {
+    const current = stack.at(-1)?.name
+    if ((name === 'dt' || name === 'dd') && (current === 'dt' || current === 'dd')) {
+      popStack()
+      return
+    }
+    if (name === 'tr') {
+      const row = findOpenTableEntry(stack, new Set(['tr']), new Set(['table', 'thead', 'tbody', 'tfoot']))
+      if (row >= 0) popThrough(row)
+      return
+    }
+    if (name === 'thead' || name === 'tbody' || name === 'tfoot') {
+      const priorTableContent = findOpenTableEntry(stack, new Set(['thead', 'tbody', 'tfoot']), new Set(['table']))
+      if (priorTableContent >= 0) popThrough(priorTableContent)
+      return
+    }
+    if (name === 'td' || name === 'th') {
+      const cell = findOpenTableEntry(stack, new Set(['td', 'th']), new Set(['tr', 'table']))
+      if (cell >= 0) popThrough(cell)
+      return
+    }
+    if (OPTIONAL_SAME_TAG_CLOSE.has(name) && current === name) popStack()
+  }
+
+  const closeTableEndTag = (name: string): boolean => {
+    const target = findTableEndTarget(stack, name)
+    if (target < 0) return false
+    popThrough(target)
+    return true
+  }
+
+  while (cursor < html.length) {
+    const open = html.indexOf('<', cursor)
+    if (open < 0) break
+    if (xmlDeclarationAllowed && !isIgnorablePrologText(html.slice(cursor, open))) xmlDeclarationAllowed = false
+
+    if (html.startsWith('<!--', open)) {
+      const comment = parseComment(html, open)
+      if (comment.kind === 'ok') {
+        xmlDeclarationAllowed = false
+        cursor = comment.value
+        continue
+      }
+      if (comment.kind === 'incomplete' && options.allowIncompleteTail) break
+      return malformed()
+    }
+
+    if (html[open + 1] === '!') {
+      const declaration = parseDoctype(html, open)
+      if (declaration.kind === 'ok') {
+        xmlDeclarationAllowed = false
+        cursor = declaration.value
+        continue
+      }
+      if (declaration.kind === 'invalid') {
+        const comment = parseBogusComment(html, open)
+        if (comment.kind === 'ok') {
+          xmlDeclarationAllowed = false
+          cursor = comment.value
+          continue
+        }
+        if (comment.kind === 'limit') return limitExceeded()
+        if (comment.kind === 'incomplete' && options.allowIncompleteTail) break
+      }
+      if (declaration.kind === 'incomplete' && options.allowIncompleteTail) break
+      return malformed()
+    }
+
+    if (html[open + 1] === '?') {
+      if (xmlDeclarationAllowed && html.startsWith('<?xml', open)) {
+        const declaration = parseXmlDeclaration(html, open)
+        if (declaration.kind === 'ok') {
+          xmlDeclarationAllowed = false
+          cursor = declaration.value
+          continue
+        }
+      }
+      const comment = parseBogusComment(html, open)
+      if (comment.kind === 'ok') {
+        xmlDeclarationAllowed = false
+        cursor = comment.value
+        continue
+      }
+      if (comment.kind === 'limit') return limitExceeded()
+      if (comment.kind === 'incomplete' && options.allowIncompleteTail) break
+      return malformed()
+    }
+
+    if (html[open + 1] === '/') {
+      xmlDeclarationAllowed = false
+      const closingTag = parseClosingTag(html, open)
+      if (closingTag.kind === 'text') {
+        cursor = open + 1
+        continue
+      }
+      if (closingTag.kind === 'incomplete' && options.allowIncompleteTail) break
+      if (closingTag.kind !== 'ok') return malformed()
+      if (!recordTag()) return limitExceeded()
+
+      if (!closeTableEndTag(closingTag.value.name)) {
+        const target = findLastOpenElement(stack, closingTag.value.name)
+        if (target >= 0 && stack.slice(target + 1).every(({ name }) => OPTIONAL_SAME_TAG_CLOSE.has(name))) {
+          popThrough(target)
+        }
+      }
+      cursor = closingTag.value.end + 1
+      continue
+    }
+
+    xmlDeclarationAllowed = false
+    const openingTag = parseOpeningTag(html, open, options)
+    if (openingTag.kind === 'text') {
+      cursor = open + 1
+      continue
+    }
+    if (openingTag.kind === 'incomplete' && options.allowIncompleteTail) break
+    if (openingTag.kind === 'limit') return limitExceeded()
+    if (openingTag.kind !== 'ok') return malformed()
+    if (!recordTag()) return limitExceeded()
+
+    const tag = openingTag.value
+    options.onStartTag?.({ name: tag.name, end: tag.end })
+    if (!VOID_ELEMENTS.has(tag.name)) {
+      closeOptionalElementsForStart(tag.name)
+      const inForeignContent = foreignNamespaceDepth > 0
+      const metadataSuppressed = metadataSuppressionDepth > 0 || foreignNamespaceDepth > 0
+      const entry = {
+        name: tag.name,
+        metadataSuppressing: METADATA_SUPPRESSING_ELEMENTS.has(tag.name) || tag.metadataSuppressing,
+        foreignRoot: FOREIGN_ROOT_ELEMENTS.has(tag.name),
+      }
+      stack.push(entry)
+      if (entry.metadataSuppressing) metadataSuppressionDepth++
+      if (entry.foreignRoot) foreignNamespaceDepth++
+      if (options.maxDepth !== undefined && stack.length > options.maxDepth) return limitExceeded()
+
+      cursor = tag.end + 1
+      if ((inForeignContent || entry.foreignRoot) && tag.selfClosingSyntax) {
+        popStack()
+        continue
+      }
+      if (tag.name === 'plaintext' && !inForeignContent) return { valid: true }
+      if (!RAW_TEXT_ELEMENTS.has(tag.name) || (inForeignContent && tag.name !== 'style')) continue
+
+      const closeStart =
+        tag.name === 'script' ? findScriptClosingTagStart(html, cursor) : findRawClosingTagStart(html, tag.name, cursor)
+      if (closeStart < 0) break
+      const closingTag = parseClosingTag(html, closeStart)
+      if (closingTag.kind === 'incomplete' && options.allowIncompleteTail) break
+      if (closingTag.kind !== 'ok') return malformed()
+
+      options.onRawElement?.({
+        name: tag.name,
+        typeAttribute: tag.typeAttribute,
+        bodyStart: cursor,
+        bodyEnd: closeStart,
+        metadataSuppressed: metadataSuppressed || entry.metadataSuppressing,
+      })
+
+      if (!recordTag()) return limitExceeded()
+      if (stack.at(-1)?.name === tag.name) popStack()
+      cursor = closingTag.value.end + 1
+      continue
+    }
+
+    cursor = tag.end + 1
+  }
+
+  return { valid: true }
+}
+
+function parseComment(html: string, open: number): ParseResult<number> {
+  let cursor = open + 4
+  if (html[cursor] === '>' || html.startsWith('->', cursor)) return { kind: 'invalid' }
+
+  while (cursor < html.length) {
+    if (html.startsWith('-->', cursor)) return { kind: 'ok', value: cursor + 3 }
+    if (html.startsWith('<!--', cursor) || html.startsWith('--', cursor)) return { kind: 'invalid' }
+    cursor++
+  }
+  return { kind: 'incomplete' }
+}
+
+function parseBogusComment(html: string, open: number): ParseResult<number> {
+  const end = html.indexOf('>', open + 2)
+  if (end < 0) return html.length - open > MAX_BOGUS_COMMENT_CHARS ? { kind: 'limit' } : { kind: 'incomplete' }
+  if (end - open > MAX_BOGUS_COMMENT_CHARS) return { kind: 'limit' }
+  return { kind: 'ok', value: end + 1 }
+}
+
+function parseDoctype(html: string, open: number): ParseResult<number> {
+  const keywordEnd = open + 9
+  if (!startsWithAsciiInsensitive(html, '<!doctype', open) || !isHtmlWhitespace(html[keywordEnd])) {
+    return { kind: 'invalid' }
+  }
+
+  const terminator = findQuoteAwareTerminator(html, keywordEnd, '>', MAX_DOCTYPE_CHARS)
+  if (terminator.kind !== 'ok') return terminator
+
+  let cursor = skipHtmlWhitespace(html, keywordEnd)
+  if (!startsWithAsciiInsensitive(html, 'html', cursor) || !isDoctypeNameBoundary(html[cursor + 4])) {
+    return { kind: 'invalid' }
+  }
+  cursor += 4
+  cursor = skipHtmlWhitespace(html, cursor)
+  if (cursor === terminator.value) return { kind: 'ok', value: terminator.value + 1 }
+
+  const externalIdStart = cursor
+  while (isAsciiLetter(html[cursor])) cursor++
+  const externalIdKind = asciiFoldSlice(html, externalIdStart, cursor)
+  if ((externalIdKind !== 'public' && externalIdKind !== 'system') || !isHtmlWhitespace(html[cursor])) {
+    return { kind: 'invalid' }
+  }
+  cursor = skipHtmlWhitespace(html, cursor)
+
+  const firstIdentifier = consumeQuotedValue(html, cursor, terminator.value)
+  if (firstIdentifier.kind !== 'ok') return { kind: 'invalid' }
+  cursor = skipHtmlWhitespace(html, firstIdentifier.value)
+
+  if (externalIdKind === 'public' && cursor < terminator.value) {
+    const systemIdentifier = consumeQuotedValue(html, cursor, terminator.value)
+    if (systemIdentifier.kind !== 'ok') return { kind: 'invalid' }
+    cursor = skipHtmlWhitespace(html, systemIdentifier.value)
+  }
+  if (cursor !== terminator.value) return { kind: 'invalid' }
+  return { kind: 'ok', value: terminator.value + 1 }
+}
+
+function parseXmlDeclaration(html: string, open: number): ParseResult<number> {
+  if (!html.startsWith('<?xml', open) || !isHtmlWhitespace(html[open + 5])) return { kind: 'invalid' }
+
+  const terminator = findQuoteAwareTerminator(html, open + 5, '?>', MAX_XML_DECLARATION_CHARS)
+  if (terminator.kind !== 'ok') return terminator
+
+  const attributes: Array<{ name: string; value: string }> = []
+  let cursor = open + 5
+  while (cursor < terminator.value) {
+    if (!isHtmlWhitespace(html[cursor])) return { kind: 'invalid' }
+    cursor = skipHtmlWhitespace(html, cursor)
+    if (cursor === terminator.value) break
+
+    const nameStart = cursor
+    while (isXmlNameCharacter(html[cursor])) cursor++
+    if (cursor === nameStart) return { kind: 'invalid' }
+    const name = html.slice(nameStart, cursor)
+    cursor = skipHtmlWhitespace(html, cursor)
+    if (html[cursor] !== '=') return { kind: 'invalid' }
+    cursor = skipHtmlWhitespace(html, cursor + 1)
+
+    const valueStart = cursor
+    const quoted = consumeQuotedValue(html, cursor, terminator.value)
+    if (quoted.kind !== 'ok') return { kind: 'invalid' }
+    const quote = html[valueStart]
+    attributes.push({ name, value: html.slice(valueStart + 1, quoted.value - 1) })
+    if (quote !== '"' && quote !== "'") return { kind: 'invalid' }
+    cursor = quoted.value
+  }
+
+  if (attributes.length < 1 || attributes.length > 3) return { kind: 'invalid' }
+  if (attributes[0]?.name !== 'version' || attributes[0].value !== '1.0') return { kind: 'invalid' }
+  if (attributes[1]?.name === 'encoding' && !/^[A-Za-z][A-Za-z0-9._-]*$/u.test(attributes[1].value)) {
+    return { kind: 'invalid' }
+  }
+  const standalone = attributes.find(({ name }) => name === 'standalone')
+  if (standalone !== undefined && standalone.value !== 'yes' && standalone.value !== 'no') {
+    return { kind: 'invalid' }
+  }
+  const expectedNames = [
+    'version',
+    ...(attributes.some(({ name }) => name === 'encoding') ? ['encoding'] : []),
+    ...(standalone === undefined ? [] : ['standalone']),
+  ]
+  if (attributes.some(({ name }, index) => name !== expectedNames[index])) return { kind: 'invalid' }
+  return { kind: 'ok', value: terminator.value + 2 }
+}
+
+function findQuoteAwareTerminator(
+  html: string,
+  from: number,
+  terminator: '>' | '?>',
+  maxChars: number,
+): ParseResult<number> {
+  const limit = Math.min(html.length, from + maxChars)
+  let quote: '"' | "'" | null = null
+  let cursor = from
+
+  while (cursor < limit) {
+    const char = html[cursor]
+    if (char === '<') return { kind: 'invalid' }
+    if (quote !== null) {
+      if (char === quote) quote = null
+      cursor++
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      cursor++
+      continue
+    }
+    if (html.startsWith(terminator, cursor)) return { kind: 'ok', value: cursor }
+    cursor++
+  }
+
+  return limit < html.length ? { kind: 'invalid' } : { kind: 'incomplete' }
+}
+
+function consumeQuotedValue(html: string, from: number, end: number): ParseResult<number> {
+  const quote = html[from]
+  if (quote !== '"' && quote !== "'") return { kind: 'invalid' }
+
+  let cursor = from + 1
+  while (cursor < end) {
+    if (html[cursor] === '<') return { kind: 'invalid' }
+    if (html[cursor] === quote) return { kind: 'ok', value: cursor + 1 }
+    cursor++
+  }
+  return { kind: 'invalid' }
+}
+
+function parseOpeningTag(
+  html: string,
+  open: number,
+  limits: Pick<HtmlLexicalWalkOptions, 'maxAttributesPerTag' | 'maxStartTagChars'>,
+): ParseResult<HtmlStartTag> {
+  const nameStart = open + 1
+  if (!isAsciiLetter(html[nameStart])) return { kind: 'text' }
+
+  const nameEnd = consumeTagName(html, nameStart)
+  if (!isTagBoundary(html[nameEnd])) return { kind: 'invalid' }
+  const name = asciiFoldSlice(html, nameStart, nameEnd)
+  let typeAttribute: string | null = null
+  let typeAttributeSeen = false
+  let ariaHiddenAttributeSeen = false
+  let styleAttributeSeen = false
+  let openAttributeSeen = false
+  let metadataSuppressing = false
+  let cursor = nameEnd
+  let attributeCount = 0
+  const exceedsStartTagLimit = (position: number): boolean =>
+    limits.maxStartTagChars !== undefined && position - open > limits.maxStartTagChars
+
+  while (cursor < html.length) {
+    if (exceedsStartTagLimit(cursor)) return { kind: 'limit' }
+    cursor = skipHtmlWhitespace(html, cursor)
+    if (exceedsStartTagLimit(cursor)) return { kind: 'limit' }
+    const char = html[cursor]
+    if (char === '>')
+      return {
+        kind: 'ok',
+        value: {
+          name,
+          end: cursor,
+          typeAttribute,
+          metadataSuppressing: metadataSuppressing || (isClosedNativeContainer(name) && !openAttributeSeen),
+          selfClosingSyntax: false,
+        },
+      }
+    if (char === undefined) return { kind: 'incomplete' }
+    if (char === '/') {
+      if (html[cursor + 1] === '>') {
+        return {
+          kind: 'ok',
+          value: {
+            name,
+            end: cursor + 1,
+            typeAttribute,
+            metadataSuppressing: metadataSuppressing || (isClosedNativeContainer(name) && !openAttributeSeen),
+            selfClosingSyntax: true,
+          },
+        }
+      }
+      return { kind: 'invalid' }
+    }
+    if (char === '<' || char === '=' || char === '"' || char === "'") return { kind: 'invalid' }
+
+    const attributeStart = cursor
+    while (cursor < html.length && !isAttributeNameBoundary(html[cursor])) {
+      cursor++
+      if (exceedsStartTagLimit(cursor)) return { kind: 'limit' }
+    }
+    if (cursor === attributeStart) return { kind: 'invalid' }
+    attributeCount++
+    if (limits.maxAttributesPerTag !== undefined && attributeCount > limits.maxAttributesPerTag) {
+      return { kind: 'limit' }
+    }
+    const attributeName = asciiFoldSlice(html, attributeStart, cursor)
+    cursor = skipHtmlWhitespace(html, cursor)
+
+    let attributeValue: string | null = null
+    let attributeValueUncertain = false
+    if (html[cursor] === '=') {
+      cursor = skipHtmlWhitespace(html, cursor + 1)
+      const quote = html[cursor]
+      if (quote === '"' || quote === "'") {
+        const valueStart = ++cursor
+        while (cursor < html.length && html[cursor] !== quote) {
+          cursor++
+          if (exceedsStartTagLimit(cursor)) return { kind: 'limit' }
+        }
+        if (cursor >= html.length) return { kind: 'incomplete' }
+        const rawAttributeValue = html.slice(valueStart, cursor)
+        attributeValue = decodeRelevantAttributeValue(rawAttributeValue)
+        attributeValueUncertain = attributeValue === null && rawAttributeValue.includes('&')
+        cursor++
+      } else {
+        const valueStart = cursor
+        while (cursor < html.length && !isUnquotedAttributeBoundary(html[cursor])) {
+          if (isInvalidUnquotedAttributeCharacter(html[cursor])) return { kind: 'invalid' }
+          cursor++
+          if (exceedsStartTagLimit(cursor)) return { kind: 'limit' }
+        }
+        if (cursor === valueStart) return { kind: 'invalid' }
+        const rawAttributeValue = html.slice(valueStart, cursor)
+        attributeValue = decodeRelevantAttributeValue(rawAttributeValue)
+        attributeValueUncertain = attributeValue === null && rawAttributeValue.includes('&')
+      }
+    }
+
+    if (attributeName === 'type' && !typeAttributeSeen) {
+      typeAttributeSeen = true
+      typeAttribute = attributeValue === null ? null : asciiFold(trimHtmlWhitespace(attributeValue))
+    }
+    if (attributeName === 'open') openAttributeSeen = true
+    if (attributeName === 'hidden' || attributeName === 'inert') metadataSuppressing = true
+    if (attributeName === 'aria-hidden' && !ariaHiddenAttributeSeen) {
+      ariaHiddenAttributeSeen = true
+      if (asciiFold(attributeValue?.trim() ?? '') === 'true') metadataSuppressing = true
+    }
+    if (attributeName === 'style' && !styleAttributeSeen) {
+      styleAttributeSeen = true
+      if (
+        attributeValueUncertain ||
+        (attributeValue !== null && classifyRawInlineStyleVisibility(attributeValue) !== 'visible')
+      ) {
+        metadataSuppressing = true
+      }
+    }
+  }
+
+  return { kind: 'incomplete' }
+}
+
+function isClosedNativeContainer(name: string): boolean {
+  return name === 'details' || name === 'dialog'
+}
+
+function findLastOpenElement(stack: StackEntry[], name: string): number {
+  for (let index = stack.length - 1; index >= 0; index--) {
+    if (stack[index]?.name === name) return index
+  }
+  return -1
+}
+
+function parseClosingTag(html: string, open: number): ParseResult<{ name: string; end: number }> {
+  const nameStart = open + 2
+  if (!isAsciiLetter(html[nameStart])) return { kind: 'invalid' }
+
+  const nameEnd = consumeTagName(html, nameStart)
+  if (!isTagBoundary(html[nameEnd])) return { kind: 'invalid' }
+  const end = skipHtmlWhitespace(html, nameEnd)
+  if (html[end] === undefined) return { kind: 'incomplete' }
+  if (html[end] !== '>') return { kind: 'invalid' }
+  return { kind: 'ok', value: { name: asciiFoldSlice(html, nameStart, nameEnd), end } }
+}
+
+function findRawClosingTagStart(html: string, name: string, from: number): number {
+  const prefix = `</${name}`
+  let cursor = from
+  while (cursor < html.length) {
+    const index = html.indexOf('<', cursor)
+    if (index < 0) return -1
+    if (startsWithAsciiInsensitive(html, prefix, index) && isTagBoundary(html[index + prefix.length])) return index
+    cursor = index + 1
+  }
+  return -1
+}
+
+function findScriptClosingTagStart(html: string, from: number): number {
+  type ScriptState = 'data' | 'escaped' | 'double-escaped'
+
+  let state: ScriptState = 'data'
+  let cursor = from
+  while (cursor < html.length) {
+    if (state === 'data') {
+      if (html.startsWith('<!--', cursor)) {
+        state = 'escaped'
+        cursor += 4
+        continue
+      }
+      if (isScriptEndTagAt(html, cursor)) return cursor
+    } else if (state === 'escaped') {
+      if (html.startsWith('-->', cursor)) {
+        state = 'data'
+        cursor += 3
+        continue
+      }
+      if (isScriptStartTagAt(html, cursor)) {
+        state = 'double-escaped'
+        cursor += 7
+        continue
+      }
+      if (isScriptEndTagAt(html, cursor)) return cursor
+    } else if (isScriptEndTagAt(html, cursor)) {
+      state = 'escaped'
+      cursor += 8
+      continue
+    }
+    cursor++
+  }
+  return -1
+}
+
+function isScriptStartTagAt(html: string, cursor: number): boolean {
+  const prefix = '<script'
+  return startsWithAsciiInsensitive(html, prefix, cursor) && isTagBoundary(html[cursor + prefix.length])
+}
+
+function isScriptEndTagAt(html: string, cursor: number): boolean {
+  const prefix = '</script'
+  return startsWithAsciiInsensitive(html, prefix, cursor) && isTagBoundary(html[cursor + prefix.length])
+}
+
+function findOpenTableEntry(stack: StackEntry[], targets: Set<string>, boundaries: Set<string>): number {
+  for (let index = stack.length - 1; index >= 0; index--) {
+    const entry = stack[index]!
+    if (entry.metadataSuppressing || entry.foreignRoot) return -1
+    const name = entry.name
+    if (targets.has(name)) return index
+    if (boundaries.has(name)) return -1
+  }
+  return -1
+}
+
+function findTableEndTarget(stack: StackEntry[], name: string): number {
+  const isSection = name === 'thead' || name === 'tbody' || name === 'tfoot'
+  if (!isSection && name !== 'table') return -1
+
+  const allowed = isSection ? new Set(['tr', 'td', 'th']) : new Set(['thead', 'tbody', 'tfoot', 'tr', 'td', 'th'])
+  for (let index = stack.length - 1; index >= 0; index--) {
+    const entry = stack[index]!
+    if (entry.metadataSuppressing || entry.foreignRoot) return -1
+    if (entry.name === name) return index
+    if (!allowed.has(entry.name)) return -1
+  }
+  return -1
+}
+
+function consumeTagName(html: string, from: number): number {
+  let cursor = from
+  while (isTagNameCharacter(html[cursor])) cursor++
+  return cursor
+}
+
+function skipHtmlWhitespace(html: string, from: number): number {
+  let cursor = from
+  while (isHtmlWhitespace(html[cursor])) cursor++
+  return cursor
+}
+
+function isAsciiLetter(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z]/u.test(char)
+}
+
+function isTagNameCharacter(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9:_-]/u.test(char)
+}
+
+function isXmlNameCharacter(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z]/u.test(char)
+}
+
+function isHtmlWhitespace(char: string | undefined): boolean {
+  return char === '\t' || char === '\n' || char === '\f' || char === '\r' || char === ' '
+}
+
+function isTagBoundary(char: string | undefined): boolean {
+  return char === undefined || isHtmlWhitespace(char) || char === '/' || char === '>'
+}
+
+function isDoctypeNameBoundary(char: string | undefined): boolean {
+  return isHtmlWhitespace(char) || char === '>'
+}
+
+function isAttributeNameBoundary(char: string | undefined): boolean {
+  return char === undefined || isHtmlWhitespace(char) || char === '/' || char === '>' || char === '='
+}
+
+function isUnquotedAttributeBoundary(char: string | undefined): boolean {
+  return char === undefined || isHtmlWhitespace(char) || char === '>'
+}
+
+function isInvalidUnquotedAttributeCharacter(char: string | undefined): boolean {
+  return char === '<' || char === '=' || char === '"' || char === "'" || char === '`'
+}
+
+function isIgnorablePrologText(value: string): boolean {
+  return /^\uFEFF?[\t\n\f\r ]*$/u.test(value)
+}
+
+function trimHtmlWhitespace(value: string): string {
+  return value.replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/gu, '')
+}
+
+function asciiFoldSlice(value: string, start: number, end: number): string {
+  let folded = ''
+  for (let index = start; index < end; index++) folded += asciiFoldCharacter(value[index])
+  return folded
+}
+
+function asciiFold(value: string): string {
+  let folded = ''
+  for (const char of value) folded += asciiFoldCharacter(char)
+  return folded
+}
+
+const NAMED_ATTRIBUTE_REFERENCES: Readonly<Record<string, string>> = {
+  amp: '&',
+  apos: "'",
+  colon: ':',
+  gt: '>',
+  lt: '<',
+  quot: '"',
+  sol: '/',
+}
+
+const WINDOWS_1252_REFERENCES: Readonly<Record<number, number>> = {
+  0x80: 0x20ac,
+  0x82: 0x201a,
+  0x83: 0x0192,
+  0x84: 0x201e,
+  0x85: 0x2026,
+  0x86: 0x2020,
+  0x87: 0x2021,
+  0x88: 0x02c6,
+  0x89: 0x2030,
+  0x8a: 0x0160,
+  0x8b: 0x2039,
+  0x8c: 0x0152,
+  0x8e: 0x017d,
+  0x91: 0x2018,
+  0x92: 0x2019,
+  0x93: 0x201c,
+  0x94: 0x201d,
+  0x95: 0x2022,
+  0x96: 0x2013,
+  0x97: 0x2014,
+  0x98: 0x02dc,
+  0x99: 0x2122,
+  0x9a: 0x0161,
+  0x9b: 0x203a,
+  0x9c: 0x0153,
+  0x9e: 0x017e,
+  0x9f: 0x0178,
+}
+
+function decodeRelevantAttributeValue(value: string): string | null {
+  let decoded = ''
+  let cursor = 0
+  while (cursor < value.length) {
+    const ampersand = value.indexOf('&', cursor)
+    if (ampersand < 0) return decoded + value.slice(cursor)
+    decoded += value.slice(cursor, ampersand)
+    const numeric = consumeNumericAttributeReference(value, ampersand)
+    if (numeric !== null) {
+      decoded += numeric.replacement
+      cursor = numeric.end
+      continue
+    }
+
+    const semicolon = value.indexOf(';', ampersand + 1)
+    if (semicolon < 0 || semicolon - ampersand > 32) return null
+    const replacement = NAMED_ATTRIBUTE_REFERENCES[asciiFold(value.slice(ampersand + 1, semicolon))]
+    if (replacement === undefined) return null
+    decoded += replacement
+    cursor = semicolon + 1
+  }
+  return decoded
+}
+
+function consumeNumericAttributeReference(
+  value: string,
+  ampersand: number,
+): { replacement: string; end: number } | null {
+  if (value[ampersand + 1] !== '#') return null
+  const hexadecimal = value[ampersand + 2] === 'x' || value[ampersand + 2] === 'X'
+  const digitStart = ampersand + (hexadecimal ? 3 : 2)
+  let digitEnd = digitStart
+  while (hexadecimal ? isAsciiHexDigit(value[digitEnd]) : isAsciiDigit(value[digitEnd])) digitEnd++
+  if (digitEnd === digitStart || digitEnd - ampersand > 32) return null
+
+  const digits = value.slice(digitStart, digitEnd)
+  const parsed = Number.parseInt(digits, hexadecimal ? 16 : 10)
+  const remapped = WINDOWS_1252_REFERENCES[parsed] ?? parsed
+  const replacement =
+    remapped === 0 || remapped > 0x10ffff || (remapped >= 0xd800 && remapped <= 0xdfff)
+      ? '\uFFFD'
+      : String.fromCodePoint(remapped)
+  return { replacement, end: value[digitEnd] === ';' ? digitEnd + 1 : digitEnd }
+}
+
+function isAsciiDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= '0' && char <= '9'
+}
+
+function isAsciiHexDigit(char: string | undefined): boolean {
+  return (
+    isAsciiDigit(char) || (char !== undefined && asciiFoldCharacter(char) >= 'a' && asciiFoldCharacter(char) <= 'f')
+  )
+}
+
+function startsWithAsciiInsensitive(value: string, expectedLowercase: string, start: number): boolean {
+  if (start + expectedLowercase.length > value.length) return false
+  for (let index = 0; index < expectedLowercase.length; index++) {
+    if (asciiFoldCharacter(value[start + index]) !== expectedLowercase[index]) return false
+  }
+  return true
+}
+
+function asciiFoldCharacter(char: string | undefined): string {
+  if (char === undefined) return ''
+  const code = char.charCodeAt(0)
+  return code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : char
+}
+
+function malformed(): HtmlLexicalWalkResult {
+  return { valid: false, failure: 'malformed' }
+}
+
+function limitExceeded(): HtmlLexicalWalkResult {
+  return { valid: false, failure: 'limit' }
+}

--- a/src/agent/tools/webfetch/inline-style-visibility.test.ts
+++ b/src/agent/tools/webfetch/inline-style-visibility.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test'
+
+import { classifyRawInlineStyleVisibility } from './inline-style-visibility'
+
+describe('classifyRawInlineStyleVisibility', () => {
+  for (const style of [
+    String.raw`display:n\6fne`,
+    String.raw`visibility:h\69 dden`,
+    String.raw`d\69splay:none`,
+    String.raw`visib\69lity:hidden`,
+    String.raw`opac\69ty:0`,
+    String.raw`display:n\6f/**/ne`,
+    '--label:"x; display:block";display:none',
+    'background:url("data:image/svg+xml;display:block");display:none',
+    'display:none;--x:func(;display:block;)',
+    'display:none;--x:{;display:block;}',
+    'display:no\
+ne',
+    'opacity:-0.1',
+    'opacity:0%',
+    'opacity:calc(0)',
+    'opacity:calc( /**/ 0% /**/ )',
+  ]) {
+    test(`classifies ${style} as hidden`, () => {
+      expect(classifyRawInlineStyleVisibility(style)).toBe('hidden')
+    })
+  }
+
+  for (const style of [
+    'opacity:+',
+    'opacity:0e',
+    'opacity:calc(0 + 0)',
+    'opacity:calc(1)',
+    'opacity:var(--opacity)',
+    'display:bogus',
+    'display:none;--x:func(;display:block;',
+    'display:none;--x:[mismatched)',
+    'display:none;--x:{unclosed',
+    'display:none;--x:"unterminated',
+    'display:none;--x:/* unterminated',
+    'display:none;--x:bad\\',
+    'display:none;--x:func(((((((((((((((((((((((((((((((((x)))))))))))))))))))))))))))))))))',
+  ]) {
+    test(`classifies ${style} as uncertain`, () => {
+      expect(classifyRawInlineStyleVisibility(style)).toBe('uncertain')
+    })
+  }
+
+  for (const style of [
+    'opacity:0.1',
+    'opacity:10%',
+    'display:none;display:block',
+    '--label:"x; display:none";display:block',
+    '--url:url("data:image/svg+xml;display:none");display:block',
+    '--label:"line\\\ncontinuation;display:none";display:block',
+    '--url:url(data:image/svg+xml\\\n;base64,AAAA);display:block',
+    '--tokens:{color:red; nested:[one(two)]};display:block',
+    'display:initial;visibility:initial;opacity:initial',
+  ]) {
+    test(`classifies ${style} as visible`, () => {
+      expect(classifyRawInlineStyleVisibility(style)).toBe('visible')
+    })
+  }
+
+  test('uses the last relevant declaration for each property', () => {
+    expect(classifyRawInlineStyleVisibility('display:block;display:none')).toBe('hidden')
+    expect(classifyRawInlineStyleVisibility('content-visibility:hidden')).toBe('hidden')
+    expect(classifyRawInlineStyleVisibility('content-visibility:visible')).toBe('visible')
+    expect(classifyRawInlineStyleVisibility('opacity:0;opacity:1')).toBe('visible')
+    expect(classifyRawInlineStyleVisibility('opacity:1;opacity:0e')).toBe('uncertain')
+  })
+
+  test('models important declarations ahead of normal declarations', () => {
+    expect(classifyRawInlineStyleVisibility('display:none!important;display:block')).toBe('hidden')
+    expect(classifyRawInlineStyleVisibility('display:none;display:block!important')).toBe('visible')
+    expect(classifyRawInlineStyleVisibility('display:none!important;display:block!important')).toBe('visible')
+    expect(classifyRawInlineStyleVisibility('display:block!important;display:none')).toBe('visible')
+  })
+
+  test('fails closed when malformed importance could change the result', () => {
+    expect(classifyRawInlineStyleVisibility('display:block;display:none ! urgent')).toBe('uncertain')
+  })
+
+  for (const keyword of ['inherit', 'unset', 'revert', 'revert-layer']) {
+    test(`classifies CSS-wide ${keyword} as uncertain without cascade context`, () => {
+      expect(classifyRawInlineStyleVisibility(`display:${keyword}`)).toBe('uncertain')
+      expect(classifyRawInlineStyleVisibility(`visibility:${keyword}`)).toBe('uncertain')
+      expect(classifyRawInlineStyleVisibility(`opacity:${keyword}`)).toBe('uncertain')
+    })
+  }
+})

--- a/src/agent/tools/webfetch/inline-style-visibility.ts
+++ b/src/agent/tools/webfetch/inline-style-visibility.ts
@@ -1,0 +1,281 @@
+export type InlineStyleVisibility = 'hidden' | 'visible' | 'uncertain'
+
+const MAX_RAW_INLINE_STYLE_CHARS = 64 * 1024
+const MAX_CSS_NESTING_DEPTH = 32
+const RELEVANT_PROPERTIES = new Set(['content-visibility', 'display', 'visibility', 'opacity'])
+const CSS_NUMBER = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/iu
+const CSS_PERCENTAGE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?%$/iu
+const VISIBLE_DISPLAY_VALUES = new Set([
+  'block',
+  'contents',
+  'flex',
+  'flow-root',
+  'grid',
+  'inline',
+  'inline-block',
+  'inline-flex',
+  'inline-grid',
+  'inline-table',
+  'list-item',
+  'ruby',
+  'ruby-base',
+  'ruby-base-container',
+  'ruby-text',
+  'ruby-text-container',
+  'table',
+  'table-caption',
+  'table-cell',
+  'table-column',
+  'table-column-group',
+  'table-footer-group',
+  'table-header-group',
+  'table-row',
+  'table-row-group',
+])
+
+type RelevantDeclaration = {
+  importance: 'normal' | 'important' | 'uncertain'
+  visibility: InlineStyleVisibility
+}
+
+// The result covers only deterministic inline display, visibility, opacity, and content visibility.
+// "Uncertain" means a relevant declaration cannot be safely classified and callers
+// handling public extraction should suppress it just like "hidden".
+export function classifyRawInlineStyleVisibility(style: string): InlineStyleVisibility {
+  if (style.length > MAX_RAW_INLINE_STYLE_CHARS) return 'uncertain'
+  const scanned = scanDeclarations(style)
+  if (scanned === null) return 'uncertain'
+
+  const declarations = new Map<string, RelevantDeclaration[]>()
+  for (const { rawProperty, rawValue } of scanned) {
+    const decodedProperty = decodeCssEscapes(rawProperty)
+    if (!decodedProperty.valid) {
+      if (!rawProperty.trimStart().startsWith('--')) return 'uncertain'
+      continue
+    }
+    const property = asciiFold(decodedProperty.value.trim())
+    if (!RELEVANT_PROPERTIES.has(property)) continue
+
+    const declaration = classifyDeclaration(property, rawValue)
+    const prior = declarations.get(property)
+    if (prior === undefined) declarations.set(property, [declaration])
+    else prior.push(declaration)
+  }
+
+  let result: InlineStyleVisibility = 'visible'
+  for (const propertyDeclarations of declarations.values()) {
+    const winner = winningDeclaration(propertyDeclarations)
+    if (winner === 'hidden') return 'hidden'
+    if (winner === 'uncertain') result = 'uncertain'
+  }
+  return result
+}
+
+type ScannedDeclaration = { rawProperty: string; rawValue: string }
+
+function scanDeclarations(style: string): ScannedDeclaration[] | null {
+  const declarations: ScannedDeclaration[] = []
+  let declaration: string[] = []
+  let separator = -1
+  let quote: '"' | "'" | null = null
+  const blocks: string[] = []
+  let cursor = 0
+
+  const finishDeclaration = (): void => {
+    if (separator >= 0) {
+      const source = declaration.join('')
+      declarations.push({ rawProperty: source.slice(0, separator), rawValue: source.slice(separator + 1) })
+    }
+    declaration = []
+    separator = -1
+  }
+
+  while (cursor < style.length) {
+    const char = style[cursor]!
+    if (char === '\\') {
+      const escaped = style[cursor + 1]
+      if (escaped === undefined) return null
+      if (isCssNewline(escaped)) {
+        cursor += escaped === '\r' && style[cursor + 2] === '\n' ? 3 : 2
+        continue
+      }
+      declaration.push(char, escaped)
+      cursor += 2
+      continue
+    }
+    if (quote !== null) {
+      declaration.push(char)
+      if (char === quote) quote = null
+      cursor++
+      continue
+    }
+    if (style.startsWith('/*', cursor)) {
+      const end = style.indexOf('*/', cursor + 2)
+      if (end < 0) return null
+      declaration.push(' ')
+      cursor = end + 2
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      declaration.push(char)
+      cursor++
+      continue
+    }
+    if (char === '(' || char === '[' || char === '{') {
+      blocks.push(char)
+      if (blocks.length > MAX_CSS_NESTING_DEPTH) return null
+      declaration.push(char)
+      cursor++
+      continue
+    }
+    if (char === ')' || char === ']' || char === '}') {
+      if (blocks.pop() !== matchingBlockStart(char)) return null
+      declaration.push(char)
+      cursor++
+      continue
+    }
+    if (blocks.length === 0 && char === ':' && separator < 0) separator = declaration.length
+    if (blocks.length === 0 && char === ';') finishDeclaration()
+    else declaration.push(char)
+    cursor++
+  }
+
+  if (quote !== null || blocks.length !== 0) return null
+  finishDeclaration()
+  return declarations
+}
+
+function classifyDeclaration(property: string, rawValue: string): RelevantDeclaration {
+  const decoded = decodeCssEscapes(rawValue)
+  if (!decoded.valid) return { importance: 'normal', visibility: 'uncertain' }
+
+  const important = extractImportance(decoded.value)
+  if (important.importance === 'uncertain') return { importance: 'uncertain', visibility: 'uncertain' }
+  const value = asciiFold(important.value.trim())
+
+  return {
+    importance: important.importance,
+    visibility:
+      property === 'opacity'
+        ? classifyOpacity(value)
+        : property === 'content-visibility'
+          ? classifyContentVisibility(value)
+          : property === 'display'
+            ? classifyDisplay(value)
+            : classifyVisibility(value),
+  }
+}
+
+function classifyContentVisibility(value: string): InlineStyleVisibility {
+  if (value === 'hidden') return 'hidden'
+  if (value === 'visible' || value === 'auto' || value === 'initial') return 'visible'
+  return 'uncertain'
+}
+
+function winningDeclaration(declarations: RelevantDeclaration[]): InlineStyleVisibility {
+  if (declarations.some(({ importance }) => importance === 'uncertain')) return 'uncertain'
+  const important = declarations.filter(({ importance }) => importance === 'important')
+  return (important.length > 0 ? important : declarations).at(-1)?.visibility ?? 'visible'
+}
+
+function classifyDisplay(value: string): InlineStyleVisibility {
+  if (value === 'none') return 'hidden'
+  if (value === 'initial') return 'visible'
+  return VISIBLE_DISPLAY_VALUES.has(value) ? 'visible' : 'uncertain'
+}
+
+function classifyVisibility(value: string): InlineStyleVisibility {
+  if (value === 'hidden' || value === 'collapse') return 'hidden'
+  if (value === 'visible' || value === 'initial') return 'visible'
+  return 'uncertain'
+}
+
+function classifyOpacity(value: string): InlineStyleVisibility {
+  if (value === 'initial') return 'visible'
+  const simpleCalc = /^calc\(\s*([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?%?)\s*\)$/iu.exec(value)
+  const numeric = simpleCalc?.[1] ?? value
+  if (!CSS_NUMBER.test(numeric) && !CSS_PERCENTAGE.test(numeric)) return 'uncertain'
+  const number = Number(numeric.endsWith('%') ? numeric.slice(0, -1) : numeric)
+  if (!Number.isFinite(number)) return 'uncertain'
+  if (simpleCalc !== null) return number === 0 ? 'hidden' : 'uncertain'
+  return number <= 0 ? 'hidden' : 'visible'
+}
+
+function extractImportance(value: string): {
+  importance: 'normal' | 'important' | 'uncertain'
+  value: string
+} {
+  const marker = /!\s*important\s*$/iu.exec(value)
+  if (marker !== null) {
+    const before = value.slice(0, marker.index)
+    return { importance: before.includes('!') ? 'uncertain' : 'important', value: before }
+  }
+  return value.includes('!') ? { importance: 'uncertain', value } : { importance: 'normal', value }
+}
+
+function decodeCssEscapes(value: string): { valid: true; value: string } | { valid: false } {
+  let decoded = ''
+  let cursor = 0
+  while (cursor < value.length) {
+    const char = value[cursor]!
+    if (char !== '\\') {
+      decoded += char
+      cursor++
+      continue
+    }
+
+    cursor++
+    const escaped = value[cursor]
+    if (escaped === undefined) return { valid: false }
+    if (isCssNewline(escaped)) {
+      cursor += escaped === '\r' && value[cursor + 1] === '\n' ? 2 : 1
+      continue
+    }
+    if (!isAsciiHexDigit(escaped)) {
+      decoded += escaped
+      cursor++
+      continue
+    }
+
+    const hexStart = cursor
+    while (cursor < value.length && cursor - hexStart < 6 && isAsciiHexDigit(value[cursor]!)) cursor++
+    const codePoint = Number.parseInt(value.slice(hexStart, cursor), 16)
+    decoded +=
+      codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+        ? '\uFFFD'
+        : String.fromCodePoint(codePoint)
+    if (isCssWhitespace(value[cursor])) {
+      if (value[cursor] === '\r' && value[cursor + 1] === '\n') cursor++
+      cursor++
+    }
+  }
+  return { valid: true, value: decoded }
+}
+
+function isAsciiHexDigit(char: string): boolean {
+  const code = char.charCodeAt(0)
+  return (code >= 48 && code <= 57) || (code >= 65 && code <= 70) || (code >= 97 && code <= 102)
+}
+
+function isCssWhitespace(char: string | undefined): boolean {
+  return char === '\t' || char === '\n' || char === '\f' || char === '\r' || char === ' '
+}
+
+function isCssNewline(char: string): boolean {
+  return char === '\n' || char === '\r' || char === '\f'
+}
+
+function matchingBlockStart(close: ')' | ']' | '}'): '(' | '[' | '{' {
+  if (close === ')') return '('
+  return close === ']' ? '[' : '{'
+}
+
+function asciiFold(value: string): string {
+  let folded = ''
+  for (const char of value) {
+    const code = char.charCodeAt(0)
+    folded += code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : char
+  }
+  return folded
+}

--- a/src/agent/tools/webfetch/strategies/readability.test.ts
+++ b/src/agent/tools/webfetch/strategies/readability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { applyReadability } from './readability'
+import { applyReadability, applyReadabilityDetailed } from './readability'
 
 const ARTICLE = `
 <!doctype html>
@@ -38,5 +38,230 @@ describe('applyReadability', () => {
   test('returns a clear message when there is nothing to extract', async () => {
     const result = await applyReadability('<html><body></body></html>', 'https://example.com/empty')
     expect(result).toBe('Readability extracted no content from this page.')
+  })
+
+  test('reports whether output came from a parsed article or generic body fallback', async () => {
+    const article = await applyReadabilityDetailed(ARTICLE, 'https://example.com/post')
+    const fallback = await applyReadabilityDetailed(
+      '<html><body><div id="root">Application placeholder</div><script src="/app.js"></script></body></html>',
+      'https://example.com/app',
+    )
+
+    expect(article.parsedArticle).toBe(true)
+    expect(article.usedBodyFallback).toBe(false)
+    expect(article.hasSemanticContentContainer).toBe(true)
+    expect(fallback.parsedArticle).toBe(true)
+    expect(fallback.hasSemanticContentContainer).toBe(false)
+    expect(fallback.proseElementCount).toBe(0)
+    expect(fallback.structuredContentElementCount).toBe(0)
+    expect(fallback.scriptCount).toBe(1)
+    expect(fallback.visibleTextCharacterCount).toBe('Application placeholder'.length)
+  })
+
+  test('excludes script and hidden content from visible text evidence', async () => {
+    const result = await applyReadabilityDetailed(
+      `<html><head><title>${'hidden'.repeat(100)}</title></head><body><div>Loading</div><script>${'x'.repeat(800)}</script><template>${'z'.repeat(800)}</template><noscript>${'n'.repeat(800)}</noscript><noframes>${'f'.repeat(800)}</noframes><div hidden>${'h'.repeat(800)}</div><div aria-hidden="true">${'a'.repeat(800)}</div><div style="display: none">${'d'.repeat(800)}</div><div style="visibility:hidden">${'v'.repeat(800)}</div></body></html>`,
+      'https://example.com/loading',
+    )
+
+    expect(result.visibleTextCharacterCount).toBe('Loading'.length)
+  })
+
+  test('prunes hidden structure before collecting evidence or parsing with Readability', async () => {
+    const hiddenArticle = 'Forged hidden article body with enough prose to satisfy extraction. '.repeat(12)
+    const result = await applyReadabilityDetailed(
+      `<html><body><div>Loading</div><article hidden><h1>Forged</h1><p>${hiddenArticle}</p></article><main aria-hidden="true"><p>${hiddenArticle}</p></main><p aria-hidden="true">${hiddenArticle}</p><p style="display:/**/ none">${hiddenArticle}</p><p style="visibility: collapse">${hiddenArticle}</p><p style="opacity: 0">${hiddenArticle}</p><p style="position:absolute;left:-10000px">${hiddenArticle}</p><input type="hidden" value="forged"><script hidden src="/hidden.js"></script><script src="/visible.js"></script></body></html>`,
+      'https://example.com/hidden',
+    )
+
+    expect(result.output).not.toContain('Forged hidden article')
+    expect(result.hasSemanticContentContainer).toBe(false)
+    expect(result.hasArticleContainer).toBe(false)
+    expect(result.proseElementCount).toBe(0)
+    expect(result.scriptCount).toBe(1)
+    expect(result.visibleTextCharacterCount).toBe('Loading'.length)
+  })
+
+  test('prunes content hidden by an embedded stylesheet while preserving visible prose', async () => {
+    const concealed = 'Concealed stylesheet-controlled article. '.repeat(40)
+    const visible = 'Visible article alongside an embedded stylesheet. '.repeat(40)
+    const result = await applyReadabilityDetailed(
+      `<html><head><style>.secret { display: none }</style></head><body><article class="secret"><h1>Hidden</h1><p>${concealed}</p></article><article><h1>Visible</h1><p>${visible}</p></article></body></html>`,
+      'https://example.com/embedded-stylesheet',
+    )
+
+    expect(result.output).toContain('Visible article alongside an embedded stylesheet')
+    expect(result.output).not.toContain('Concealed stylesheet-controlled article')
+  })
+
+  test('rejects embedded stylesheets whose rule-to-element work exceeds the budget', async () => {
+    const rules = Array.from({ length: 800 }, (_, index) => `.rule-${index}{display:block}`).join('')
+    const elements = '<p>content</p>'.repeat(3_000)
+
+    await expect(
+      applyReadability(
+        `<html><head><style>${rules}</style></head><body>${elements}</body></html>`,
+        'https://example.com/css-budget',
+      ),
+    ).rejects.toThrow('Embedded stylesheet complexity limit exceeded')
+  })
+
+  test('rejects many short selector-list components before JSDOM work exceeds the budget', async () => {
+    const selectorList = Array.from({ length: 600 }, () => '.s').join(',')
+    const elements = '<i>content</i>'.repeat(3_500)
+
+    await expect(
+      applyReadability(
+        `<html><head><style>${selectorList}{display:block}</style></head><body>${elements}</body></html>`,
+        'https://example.com/selector-list-budget',
+      ),
+    ).rejects.toThrow('Embedded stylesheet complexity limit exceeded')
+  })
+
+  test('accepts selector commas nested in functions, strings, attributes, and escapes', async () => {
+    const prose = 'Visible prose selected by ordinary bounded CSS. '.repeat(40)
+    const result = await applyReadability(
+      String.raw`<html><head><style>:is(.one,.two),[data-label="x,y"],.escaped\,comma{display:block}</style></head><body><article><p>${prose}</p></article></body></html>`,
+      'https://example.com/nested-selector-commas',
+    )
+
+    expect(result).toContain('Visible prose selected by ordinary bounded CSS')
+  })
+
+  test('rejects a single pathological selector before computed-style matching', async () => {
+    const selector = '.x'.repeat(2_000)
+
+    await expect(
+      applyReadability(
+        `<html><head><style>${selector}{display:none}</style></head><body><article><p>content</p></article></body></html>`,
+        'https://example.com/selector-budget',
+      ),
+    ).rejects.toThrow('Embedded stylesheet complexity limit exceeded')
+  })
+
+  test('rejects a pathological selector in the raw preflight before JSDOM construction', async () => {
+    const selector = '.x'.repeat(40_000)
+    const startedAt = performance.now()
+
+    await expect(
+      applyReadability(`<style>${selector}{display:none}</style><p>content</p>`, 'https://example.com/raw-selector'),
+    ).rejects.toThrow('Embedded stylesheet complexity limit exceeded')
+    expect(performance.now() - startedAt).toBeLessThan(500)
+  })
+
+  test('preserves source-visible article content when an external stylesheet is not loaded', async () => {
+    const visible = 'Source-visible article with an unresolved linked stylesheet. '.repeat(40)
+    const result = await applyReadability(
+      `<html><head><link rel="stylesheet" href="/site.css"></head><body><article><h1>Visible</h1><p>${visible}</p></article></body></html>`,
+      'https://example.com/linked-stylesheet',
+    )
+
+    expect(result).toContain('Source-visible article with an unresolved linked stylesheet')
+  })
+
+  test('preserves source-visible prose inside an inert article', async () => {
+    const prose = 'Source-visible inert article prose remains extractable. '.repeat(40)
+    const result = await applyReadability(
+      `<html><body><article inert><h1>Reference</h1><p>${prose}</p></article></body></html>`,
+      'https://example.com/inert-article',
+    )
+
+    expect(result).toContain('Source-visible inert article prose remains extractable')
+  })
+
+  test('prunes deterministic native and inline hidden states', async () => {
+    const concealed = 'Deterministically concealed article prose. '.repeat(40)
+    const visible = 'Genuine visible sibling article prose. '.repeat(40)
+    const result = await applyReadabilityDetailed(
+      `<html><body><article style="content-visibility:hidden"><p>${concealed}</p></article><dialog><article><p>${concealed}</p></article></dialog><details><summary>Visible summary</summary><article><p>${concealed}</p></article></details><article><h1>Visible</h1><p>${visible}</p></article></body></html>`,
+      'https://example.com/native-hidden',
+    )
+
+    expect(result.output).toContain('Genuine visible sibling article prose')
+    expect(result.output).not.toContain('Deterministically concealed article prose')
+    expect(result.visibleTextCharacterCount).toBe(`Visible summaryVisible${visible}`.trim().length)
+  })
+
+  for (const opacity of ['-0', '0.0', '.0', '0e0', '0E+10']) {
+    test(`prunes content with CSS opacity ${opacity}`, async () => {
+      const hidden = 'Hidden opacity content. '.repeat(40)
+      const result = await applyReadabilityDetailed(
+        `<html><body><div>Loading</div><article style="opacity:${opacity}"><p>${hidden}</p></article></body></html>`,
+        'https://example.com/opacity',
+      )
+
+      expect(result.output).not.toContain('Hidden opacity content')
+      expect(result.hasArticleContainer).toBe(false)
+      expect(result.visibleTextCharacterCount).toBe('Loading'.length)
+    })
+  }
+
+  for (const [name, style] of [
+    ['escaped display', String.raw`display:n\6fne`],
+    ['escaped visibility', String.raw`visibility:h\69 dden`],
+    ['escaped display property', String.raw`d\69splay:none`],
+    ['escaped visibility property', String.raw`visib\69lity:hidden`],
+    ['escaped opacity property', String.raw`opac\69ty:0`],
+    ['nested custom-property semicolons', 'display:none;--x:func(;display:block;)'],
+    ['nested custom-property block semicolons', 'display:none;--x:{;display:block;}'],
+    ['escaped newline continuation', 'display:no\\\nne'],
+    ['negative opacity', 'opacity:-0.1'],
+    ['zero percentage opacity', 'opacity:0%'],
+    ['calculated zero opacity', 'opacity:calc(0)'],
+    ['malformed positive sign opacity', 'opacity:+'],
+    ['malformed exponent opacity', 'opacity:0e'],
+  ] as const) {
+    test(`prunes an article hidden by ${name} and extracts its genuine sibling`, async () => {
+      const hidden = `Hidden ${name} article. `.repeat(40)
+      const genuine = 'Genuine visible article content with enough prose for extraction. '.repeat(20)
+      const result = await applyReadability(
+        `<html><body><article style="${style}"><h1>Hidden</h1><p>${hidden}</p></article><article><h1>Genuine</h1><p>${genuine}</p></article></body></html>`,
+        'https://example.com/style-parity',
+      )
+
+      expect(result).toContain('Genuine visible article')
+      expect(result).not.toContain(`Hidden ${name} article`)
+    })
+  }
+
+  test('keeps a visible article with a harmless custom-property semicolon', async () => {
+    const visible = 'Genuine visible article with a harmless custom property. '.repeat(40)
+    const result = await applyReadability(
+      `<html><body><article style='--label:"x; display:none";display:block'><h1>Visible</h1><p>${visible}</p></article></body></html>`,
+      'https://example.com/custom-property',
+    )
+
+    expect(result).toContain('Genuine visible article with a harmless custom property')
+  })
+
+  test('keeps visible articles with matched blocks, strings, URLs, continuations, and initial values', async () => {
+    const visible = 'Genuine article through valid CSS grammar. '.repeat(40)
+    const styles = [
+      `--tokens:{color:red;nested:[one(two)]};display:block`,
+      `--label:"x;display:none";display:block`,
+      `background:url("data:image/svg+xml;display:none");display:block`,
+      `--label:"continued\\\nvalue";display:block`,
+      `display:initial;visibility:initial;opacity:initial`,
+    ]
+
+    for (const style of styles) {
+      const result = await applyReadability(
+        `<html><body><article style='${style}'><h1>Visible</h1><p>${visible}</p></article></body></html>`,
+        'https://example.com/valid-css',
+      )
+      expect(result).toContain('Genuine article through valid CSS grammar')
+    }
+  })
+
+  test('keeps articles with positive numeric and percentage opacity', async () => {
+    for (const opacity of ['0.1', '10%']) {
+      const visible = `Visible positive ${opacity} opacity article. `.repeat(40)
+      const result = await applyReadability(
+        `<html><body><article style="opacity:${opacity}"><h1>Visible</h1><p>${visible}</p></article></body></html>`,
+        'https://example.com/positive-opacity',
+      )
+
+      expect(result).toContain(`Visible positive ${opacity} opacity article`)
+    }
   })
 })

--- a/src/agent/tools/webfetch/strategies/readability.ts
+++ b/src/agent/tools/webfetch/strategies/readability.ts
@@ -1,6 +1,9 @@
 import type { Readability as ReadabilityClass } from '@mozilla/readability'
 import type TurndownService from 'turndown'
 
+import { walkHtmlLexically } from '../html-lexical'
+import { classifyRawInlineStyleVisibility } from '../inline-style-visibility'
+
 // Perf: jsdom (+readability+turndown) costs ~40-60MB RSS at import time. Keep it
 // lazy so idle agents that never call web_fetch don't pay for it. Do NOT hoist to
 // a top-level import.
@@ -11,6 +14,12 @@ type ReadabilityDeps = {
 }
 
 let depsPromise: Promise<ReadabilityDeps> | undefined
+
+const MAX_EMBEDDED_STYLE_CHARS = 256 * 1024
+const MAX_EMBEDDED_STYLE_RULES = 1_024
+const MAX_COMPUTED_STYLE_WORK = 2_000_000
+const MAX_SELECTOR_CHARS = 2_048
+const MAX_RAW_CSS_SEGMENT_CHARS = 16 * 1024
 
 async function loadDeps(): Promise<ReadabilityDeps> {
   depsPromise ??= (async () => {
@@ -34,20 +43,312 @@ async function loadDeps(): Promise<ReadabilityDeps> {
 
 type ReadabilityDocument = ConstructorParameters<typeof ReadabilityClass>[0]
 
-export async function applyReadability(html: string, url: string): Promise<string> {
-  const { Readability, JSDOM, turndown } = await loadDeps()
+export type ReadabilityDetailedResult = {
+  output: string
+  parsedArticle: boolean
+  usedBodyFallback: boolean
+  hasSemanticContentContainer: boolean
+  hasArticleContainer: boolean
+  proseElementCount: number
+  structuredContentElementCount: number
+  scriptCount: number
+  visibleTextCharacterCount: number
+}
 
+export async function applyReadability(html: string, url: string): Promise<string> {
+  return (await applyReadabilityDetailed(html, url)).output
+}
+
+export async function applyReadabilityDetailed(html: string, url: string): Promise<ReadabilityDetailedResult> {
+  preflightEmbeddedStylesheets(html)
+  const { Readability, JSDOM, turndown } = await loadDeps()
   const dom = new JSDOM(html, { url })
-  const document = dom.window.document.cloneNode(true) as unknown as ReadabilityDocument
+  const sourceDocument = dom.window.document
+  const computedStyle = buildComputedStyleResolver(sourceDocument, (element) => dom.window.getComputedStyle(element))
+  pruneHiddenContent(sourceDocument, computedStyle)
+  const document = sourceDocument.cloneNode(true) as Document & ReadabilityDocument
+  const scriptCount = document.querySelectorAll('script').length
+  document.querySelectorAll('script, style, template, noscript, noframes').forEach((element) => element.remove())
+
+  const hasSemanticContentContainer = document.querySelector('article, main, [role="main"]') !== null
+  const hasArticleContainer = document.querySelector('article') !== null
+  const proseElementCount = document.querySelectorAll('p, blockquote, pre').length
+  const structuredContentElementCount = document.querySelectorAll('h1, h2, h3, h4, h5, h6, dl, table').length
+  const visibleTextCharacterCount = countVisibleTextCharacters(document.body)
+  const fallbackSource = document.body?.innerHTML ?? ''
   const article = new Readability(document).parse()
 
-  const source = article?.content?.trim() ? article.content : html
+  const source = article?.content?.trim() ? article.content : fallbackSource
   const markdown = turndown.turndown(source).trim()
+  const output = renderOutput(markdown, article?.title)
 
+  return {
+    output,
+    parsedArticle: article?.content?.trim() !== undefined && article.content.trim().length > 0,
+    usedBodyFallback: !article?.content?.trim(),
+    hasSemanticContentContainer,
+    hasArticleContainer,
+    proseElementCount,
+    structuredContentElementCount,
+    scriptCount,
+    visibleTextCharacterCount,
+  }
+}
+
+function preflightEmbeddedStylesheets(html: string): void {
+  const sources: string[] = []
+  let elementCount = 0
+  let styleStartCount = 0
+  const result = walkHtmlLexically(html, {
+    onStartTag: ({ name }) => {
+      elementCount++
+      if (name === 'style') styleStartCount++
+    },
+    onRawElement: (element) => {
+      if (element.name === 'style') sources.push(html.slice(element.bodyStart, element.bodyEnd))
+    },
+  })
+  if (!result.valid || styleStartCount === 0) return
+  if (sources.length !== styleStartCount) throw new Error('Embedded stylesheet complexity limit exceeded')
+
+  let characters = 0
+  let rules = 0
+  let selectorComponents = 0
+  for (const source of sources) {
+    characters += source.length
+    if (characters > MAX_EMBEDDED_STYLE_CHARS) throw new Error('Embedded stylesheet complexity limit exceeded')
+    const counted = countRawCssRules(source)
+    rules += counted.rules
+    selectorComponents += counted.selectorComponents
+    if (rules > MAX_EMBEDDED_STYLE_RULES) throw new Error('Embedded stylesheet complexity limit exceeded')
+  }
+  if (selectorComponents * elementCount > MAX_COMPUTED_STYLE_WORK) {
+    throw new Error('Embedded stylesheet complexity limit exceeded')
+  }
+}
+
+function countRawCssRules(source: string): { rules: number; selectorComponents: number } {
+  let rules = 0
+  let selectorComponents = 0
+  let preludeLength = 0
+  let preludeStart = 0
+  let quote: '"' | "'" | null = null
+  let cursor = 0
+  while (cursor < source.length) {
+    const char = source[cursor]!
+    if (char === '\\') {
+      if (cursor + 1 >= source.length) throw new Error('Embedded stylesheet complexity limit exceeded')
+      cursor += 2
+      preludeLength += 2
+      continue
+    }
+    if (quote !== null) {
+      if (char === quote) quote = null
+      cursor++
+      continue
+    }
+    if (source.startsWith('/*', cursor)) {
+      const end = source.indexOf('*/', cursor + 2)
+      if (end < 0) throw new Error('Embedded stylesheet complexity limit exceeded')
+      cursor = end + 2
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      cursor++
+      continue
+    }
+    if (char === '{') {
+      rules++
+      if (preludeLength > MAX_RAW_CSS_SEGMENT_CHARS || rules > MAX_EMBEDDED_STYLE_RULES) {
+        throw new Error('Embedded stylesheet complexity limit exceeded')
+      }
+      selectorComponents += countSelectorListComponents(source.slice(preludeStart, cursor), MAX_RAW_CSS_SEGMENT_CHARS)
+      preludeLength = 0
+      preludeStart = cursor + 1
+    } else if (char === '}' || char === ';') {
+      preludeLength = 0
+      preludeStart = cursor + 1
+    } else {
+      preludeLength++
+      if (preludeLength > MAX_RAW_CSS_SEGMENT_CHARS) throw new Error('Embedded stylesheet complexity limit exceeded')
+    }
+    cursor++
+  }
+  if (quote !== null) throw new Error('Embedded stylesheet complexity limit exceeded')
+  countSelectorListComponents(source.slice(preludeStart), MAX_RAW_CSS_SEGMENT_CHARS)
+  return { rules, selectorComponents }
+}
+
+function buildComputedStyleResolver(
+  document: Document,
+  resolve: (element: Element) => CSSStyleDeclaration,
+): ((element: Element) => CSSStyleDeclaration) | undefined {
+  const styles = Array.from(document.querySelectorAll('style'))
+  if (styles.length === 0) return undefined
+
+  let styleCharacters = 0
+  let ruleCount = 0
+  let selectorComponentCount = 0
+  for (const style of styles) {
+    styleCharacters += style.textContent?.length ?? 0
+    if (styleCharacters > MAX_EMBEDDED_STYLE_CHARS) throw new Error('Embedded stylesheet complexity limit exceeded')
+    const counted =
+      style.sheet === null
+        ? { rules: MAX_EMBEDDED_STYLE_RULES + 1, selectorComponents: MAX_EMBEDDED_STYLE_RULES + 1 }
+        : countCssRules(style.sheet.cssRules)
+    ruleCount += counted.rules
+    selectorComponentCount += counted.selectorComponents
+    if (ruleCount > MAX_EMBEDDED_STYLE_RULES) throw new Error('Embedded stylesheet complexity limit exceeded')
+  }
+
+  const elementCount = document.querySelectorAll('*').length
+  if (selectorComponentCount * elementCount > MAX_COMPUTED_STYLE_WORK) {
+    throw new Error('Embedded stylesheet complexity limit exceeded')
+  }
+  return resolve
+}
+
+function countCssRules(rules: CSSRuleList): { rules: number; selectorComponents: number } {
+  let count = 0
+  let selectorComponents = 0
+  const pending = Array.from(rules)
+  while (pending.length > 0) {
+    const rule = pending.pop()!
+    count++
+    if (count > MAX_EMBEDDED_STYLE_RULES) return { rules: count, selectorComponents }
+    const prelude =
+      'selectorText' in rule ? (rule as CSSStyleRule).selectorText : rule.cssText.slice(0, rule.cssText.indexOf('{'))
+    selectorComponents += countSelectorListComponents(prelude, MAX_SELECTOR_CHARS)
+    if ('cssRules' in rule) pending.push(...Array.from((rule as CSSGroupingRule).cssRules))
+  }
+  return { rules: count, selectorComponents }
+}
+
+function countSelectorListComponents(source: string, maxLength: number): number {
+  if (source.length > maxLength) throw new Error('Embedded stylesheet complexity limit exceeded')
+  let components = 1
+  let quote: '"' | "'" | null = null
+  let parentheses = 0
+  let brackets = 0
+  let cursor = 0
+  while (cursor < source.length) {
+    const char = source[cursor]!
+    if (char === '\\') {
+      if (cursor + 1 >= source.length) throw new Error('Embedded stylesheet complexity limit exceeded')
+      cursor += 2
+      continue
+    }
+    if (quote !== null) {
+      if (char === quote) quote = null
+      cursor++
+      continue
+    }
+    if (source.startsWith('/*', cursor)) {
+      const end = source.indexOf('*/', cursor + 2)
+      if (end < 0) throw new Error('Embedded stylesheet complexity limit exceeded')
+      cursor = end + 2
+      continue
+    }
+    if (char === '"' || char === "'") quote = char
+    else if (char === '(') parentheses++
+    else if (char === ')') {
+      if (parentheses === 0) throw new Error('Embedded stylesheet complexity limit exceeded')
+      parentheses--
+    } else if (char === '[') brackets++
+    else if (char === ']') {
+      if (brackets === 0) throw new Error('Embedded stylesheet complexity limit exceeded')
+      brackets--
+    } else if (char === ',' && parentheses === 0 && brackets === 0) components++
+    cursor++
+  }
+  if (quote !== null || parentheses !== 0 || brackets !== 0) {
+    throw new Error('Embedded stylesheet complexity limit exceeded')
+  }
+  return components
+}
+
+function countVisibleTextCharacters(body: HTMLElement | null): number {
+  if (body === null) return 0
+  return Array.from(normalizeVisibleText(body.textContent ?? '')).length
+}
+
+function pruneHiddenContent(
+  document: Document,
+  computedStyle: ((element: Element) => CSSStyleDeclaration) | undefined,
+): void {
+  for (const details of document.querySelectorAll('details:not([open])')) pruneClosedDetails(details)
+
+  for (const element of document.querySelectorAll('*')) {
+    if (isHiddenElement(element, computedStyle)) element.remove()
+  }
+}
+
+function pruneClosedDetails(details: Element): void {
+  const summary = Array.from(details.children).find((child) => child.tagName === 'SUMMARY')
+  for (const child of Array.from(details.childNodes)) {
+    if (child !== summary) child.remove()
+  }
+}
+
+function isHiddenElement(
+  element: Element,
+  computedStyle: ((element: Element) => CSSStyleDeclaration) | undefined,
+): boolean {
+  if (element.hasAttribute('hidden')) return true
+  if (element.getAttribute('aria-hidden')?.toLocaleLowerCase() === 'true') return true
+  if (element.tagName === 'INPUT' && element.getAttribute('type')?.toLocaleLowerCase() === 'hidden') return true
+  if (element.tagName === 'DIALOG' && !element.hasAttribute('open')) return true
+
+  const rawStyle = element.getAttribute('style')
+  if (rawStyle !== null && classifyRawInlineStyleVisibility(rawStyle) !== 'visible') return true
+
+  if ('style' in element) {
+    const { position, left, top } = (element as HTMLElement).style
+    if ((position === 'absolute' || position === 'fixed') && (isFarOffscreen(left) || isFarOffscreen(top))) return true
+  }
+
+  if (computedStyle === undefined || NON_CONTENT_ELEMENTS.has(element.tagName)) return false
+  let resolved: CSSStyleDeclaration
+  try {
+    resolved = computedStyle(element)
+  } catch {
+    return false
+  }
+  if (resolved.display === 'none' || resolved.visibility === 'hidden' || resolved.visibility === 'collapse') return true
+  if (resolved.getPropertyValue('content-visibility').trim().toLocaleLowerCase() === 'hidden') return true
+  const opacity = Number(resolved.opacity)
+  if (resolved.opacity !== '' && Number.isFinite(opacity) && opacity <= 0) return true
+
+  return false
+}
+
+const NON_CONTENT_ELEMENTS = new Set([
+  'HEAD',
+  'LINK',
+  'META',
+  'NOFRAMES',
+  'NOSCRIPT',
+  'SCRIPT',
+  'STYLE',
+  'TEMPLATE',
+  'TITLE',
+])
+
+function isFarOffscreen(value: string): boolean {
+  const match = /^(-?(?:\d+\.?\d*|\.\d+))(px|rem|em|vw|vh)$/iu.exec(value.trim())
+  return match !== null && Number(match[1]) <= -1_000
+}
+
+function normalizeVisibleText(value: string): string {
+  return value.replace(/\s+/gu, ' ').trim()
+}
+
+function renderOutput(markdown: string, title: string | null | undefined): string {
   if (!markdown) return 'Readability extracted no content from this page.'
 
-  if (article?.title) {
-    return `# ${article.title}\n\n${markdown}`
+  if (title) {
+    return `# ${title}\n\n${markdown}`
   }
   return markdown
 }

--- a/src/agent/tools/webfetch/tool.test.ts
+++ b/src/agent/tools/webfetch/tool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
+import { MAX_ADAPTIVE_HTML_NESTING_DEPTH } from './adaptive-html'
 import { _setForceFallbackForTest } from './fetch'
 import { webFetchTool } from './tool'
 import type { WebFetchDetails } from './types'
@@ -51,6 +52,14 @@ const ARTICLE_HTML = `
 </article>
 </body></html>`
 
+function articleScriptForTool(body: string): string {
+  return `<script type="application/ld+json">${JSON.stringify({
+    '@type': 'Article',
+    headline: 'Large article',
+    articleBody: body,
+  })}</script>`
+}
+
 describe('webfetch: URL handling', () => {
   test('rewrites bare hostnames to https://', async () => {
     fetchResponse = () => new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } })
@@ -72,7 +81,7 @@ describe('webfetch: URL handling', () => {
 })
 
 describe('webfetch: strategy auto-detection', () => {
-  test('HTML content-type defaults to readability', async () => {
+  test('ordinary HTML article succeeds through readability with one diagnostic attempt', async () => {
     fetchResponse = () =>
       new Response(ARTICLE_HTML, { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } })
 
@@ -81,8 +90,152 @@ describe('webfetch: strategy auto-detection', () => {
 
     expect(details.strategy).toBe('readability')
     expect(details.autoDetected).toBe(true)
+    expect(details.extractionAttempts).toEqual([
+      { route: 'readability', outcome: 'success', reason: 'Readability identified article content' },
+    ])
     expect(textOf(result)).toContain('# Sample')
     expect(textOf(result)).toContain('paragraph with enough body text')
+  })
+
+  test('caps a rescued JSON-LD article at the readability output limit', async () => {
+    const body = 'z'.repeat(220_000)
+    fetchResponse = () =>
+      new Response(`<html><body><div id="app"></div>${articleScriptForTool(body)}</body></html>`, {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+
+    const result = await webFetchTool.execute('id', { url: 'https://example.com/large' }, undefined, undefined, ctx)
+
+    expect(detailsOf(result).truncated).toBe(true)
+    expect(detailsOf(result).bytesOut).toBeLessThan(201_000)
+    expect(textOf(result)).toContain('[Output truncated:')
+  })
+
+  test('falls back from unusable readability output to schema.org JSON-LD in order', async () => {
+    const html = `<!doctype html><html><body>
+      <nav>Home</nav>
+      <script type="application/ld+json">${JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'NewsArticle',
+        headline: 'Structured report',
+        articleBody:
+          'This report contains enough substantive structured article content to rescue a page whose visible HTML is only an application shell.',
+      })}</script>
+    </body></html>`
+    fetchResponse = () => new Response(html, { status: 200, headers: { 'content-type': 'text/html' } })
+
+    const result = await webFetchTool.execute('id', { url: 'https://example.com/report' }, undefined, undefined, ctx)
+
+    expect(textOf(result)).toContain('# Structured report')
+    expect(textOf(result)).toContain('substantive structured article content')
+    expect(detailsOf(result).extractionAttempts).toEqual([
+      { route: 'readability', outcome: 'unusable', reason: 'Readability identified only unstructured page chrome' },
+      { route: 'json_ld', outcome: 'success', reason: 'extracted schema.org article content' },
+    ])
+    expect(fetchCalls).toHaveLength(1)
+  })
+
+  test('decodes encoded JSON-LD MIME syntax through safe fetch and adaptive extraction', async () => {
+    const html = `<html><body><div>Shell</div>${articleScriptForTool('Encoded MIME body.').replace(
+      'application/ld+json',
+      'application&#x2f;ld+json',
+    )}</body></html>`
+    fetchResponse = () => new Response(html, { status: 200, headers: { 'content-type': 'text/html' } })
+
+    const result = await webFetchTool.execute('id', { url: 'https://example.com/encoded' }, undefined, undefined, ctx)
+
+    expect(textOf(result)).toContain('Encoded MIME body.')
+    expect(detailsOf(result).extractionAttempts?.at(-1)?.route).toBe('json_ld')
+    expect(fetchCalls).toHaveLength(1)
+  })
+
+  test('decodes semicolonless numeric JSON-LD MIME syntax through safe fetch and adaptive extraction', async () => {
+    const html = `<html><body><div>Shell</div>${articleScriptForTool('Semicolonless MIME body.').replace(
+      'application/ld+json',
+      'application&#47ld+json',
+    )}</body></html>`
+    fetchResponse = () => new Response(html, { status: 200, headers: { 'content-type': 'text/html' } })
+
+    const result = await webFetchTool.execute(
+      'id',
+      { url: 'https://example.com/semicolonless' },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(textOf(result)).toContain('Semicolonless MIME body.')
+    expect(detailsOf(result).extractionAttempts?.at(-1)?.route).toBe('json_ld')
+    expect(fetchCalls).toHaveLength(1)
+  })
+
+  test('ignores malformed and unrelated JSON-LD blocks', async () => {
+    const html = `<!doctype html><html><body><div>Short shell</div>
+      <script type="application/ld+json">{"@type":"Article",broken}</script>
+      <script type="application/ld+json">${JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Product',
+        description:
+          'A long product description must not be mistaken for public article content by the fallback route.',
+      })}</script>
+    </body></html>`
+    fetchResponse = () => new Response(html, { status: 200, headers: { 'content-type': 'text/html' } })
+
+    const result = await webFetchTool.execute('id', { url: 'https://example.com/app' }, undefined, undefined, ctx)
+
+    expect(detailsOf(result).error).toBe(true)
+    expect(detailsOf(result).extractionAttempts).toEqual([
+      {
+        route: 'readability',
+        outcome: 'unusable',
+        reason: 'Readability identified only unstructured page chrome',
+      },
+      { route: 'json_ld', outcome: 'unusable', reason: 'no schema.org article content found' },
+    ])
+  })
+
+  test('rejects a false-success HTML shell and keeps diagnostics free of fetched content', async () => {
+    const secretShell = 'SHELL_MARKER_7f93'
+    fetchResponse = () =>
+      new Response(`<html><body><div>${secretShell}</div></body></html>`, {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+
+    const result = await webFetchTool.execute('id', { url: 'https://example.com/shell' }, undefined, undefined, ctx)
+    const details = detailsOf(result)
+
+    expect(details.error).toBe(true)
+    expect(textOf(result)).toContain('browser retrieval may be needed')
+    expect(details.extractionAttempts?.map(({ route, outcome }) => ({ route, outcome }))).toEqual([
+      { route: 'readability', outcome: 'unusable' },
+      { route: 'json_ld', outcome: 'unusable' },
+    ])
+    expect(JSON.stringify(details.extractionAttempts)).not.toContain(secretShell)
+  })
+
+  test('extracts non-English schema.org article content', async () => {
+    const html = `<html><body><div>앱</div><script type="application/ld+json">${JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        { '@type': 'WebSite', name: '예시' },
+        {
+          '@type': 'BlogPosting',
+          headline: '구조화된 소식',
+          articleBody:
+            '이 글은 구조화된 데이터에 담긴 충분히 의미 있는 한국어 본문입니다. 화면에는 짧은 앱 셸만 있지만 공개된 기사 내용을 안전하게 추출할 수 있습니다.',
+        },
+      ],
+    })}</script></body></html>`
+    fetchResponse = () => new Response(html, { status: 200, headers: { 'content-type': 'text/html' } })
+
+    const result = await webFetchTool.execute('id', { url: 'https://example.com/ko' }, undefined, undefined, ctx)
+
+    expect(detailsOf(result).error).toBeUndefined()
+    expect(textOf(result)).toContain('# 구조화된 소식')
+    expect(textOf(result)).toContain('의미 있는 한국어 본문')
+    expect(detailsOf(result).extractionAttempts?.[1]?.route).toBe('json_ld')
   })
 
   test('JSON content-type without explicit strategy returns a guidance error', async () => {
@@ -209,6 +362,105 @@ describe('webfetch: explicit strategies', () => {
     )
 
     expect(textOf(result)).toBe('<html>raw body</html>')
+    expect(detailsOf(result).extractionAttempts).toBeUndefined()
+  })
+
+  test('explicit readability preserves its existing empty-page result without adaptive fallback', async () => {
+    fetchResponse = () => new Response('<html><body></body></html>', { headers: { 'content-type': 'text/html' } })
+
+    const result = await webFetchTool.execute(
+      'id',
+      { url: 'https://example.com/empty', strategy: 'readability' },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(textOf(result)).toBe('Readability extracted no content from this page.')
+    expect(detailsOf(result).error).toBeUndefined()
+    expect(detailsOf(result).autoDetected).toBe(false)
+    expect(detailsOf(result).extractionAttempts).toBeUndefined()
+  })
+
+  test('explicit readability preserves ordinary article output without adaptive diagnostics', async () => {
+    fetchResponse = () => new Response(ARTICLE_HTML, { headers: { 'content-type': 'text/html' } })
+
+    const result = await webFetchTool.execute(
+      'id',
+      { url: 'https://example.com/article', strategy: 'readability' },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(textOf(result)).toContain('# Sample')
+    expect(detailsOf(result).error).toBeUndefined()
+    expect(detailsOf(result).autoDetected).toBe(false)
+    expect(detailsOf(result).extractionAttempts).toBeUndefined()
+  })
+
+  test('explicit readability preserves source-visible content with an unresolved linked stylesheet', async () => {
+    fetchResponse = () =>
+      new Response(
+        `<html><head><link rel="stylesheet" href="/site.css"></head><body><article><h1>Visible</h1><p>${'Source-visible linked stylesheet article. '.repeat(40)}</p></article></body></html>`,
+        { headers: { 'content-type': 'text/html' } },
+      )
+
+    const result = await webFetchTool.execute(
+      'id',
+      { url: 'https://example.com/stylesheet', strategy: 'readability' },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(textOf(result)).toContain('Source-visible linked stylesheet article')
+    expect(detailsOf(result).error).toBeUndefined()
+    expect(detailsOf(result).strategy).toBe('readability')
+    expect(detailsOf(result).autoDetected).toBe(false)
+    expect(detailsOf(result).extractionAttempts).toBeUndefined()
+  })
+
+  test('explicit readability rejects deeply nested HTML before invoking the DOM parser', async () => {
+    fetchResponse = () =>
+      new Response('<div>'.repeat(MAX_ADAPTIVE_HTML_NESTING_DEPTH + 1), {
+        headers: { 'content-type': 'text/html' },
+      })
+
+    const result = await webFetchTool.execute(
+      'id',
+      { url: 'https://example.com/deep', strategy: 'readability' },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(textOf(result)).toBe('adaptive HTML complexity limit exceeded')
+    expect(detailsOf(result).error).toBe(true)
+    expect(detailsOf(result).strategy).toBe('readability')
+    expect(detailsOf(result).autoDetected).toBe(false)
+    expect(detailsOf(result).extractionAttempts).toBeUndefined()
+  })
+
+  test('explicit readability rejects excessive start-tag attributes before invoking the DOM parser', async () => {
+    const attributes = Array.from({ length: 15_000 }, (_, index) => ` data-${index}="x"`).join('')
+    fetchResponse = () =>
+      new Response(`<main${attributes}>content</main>`, {
+        headers: { 'content-type': 'text/html' },
+      })
+
+    const result = await webFetchTool.execute(
+      'id',
+      { url: 'https://example.com/attributes', strategy: 'readability' },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(textOf(result)).toBe('adaptive HTML complexity limit exceeded')
+    expect(detailsOf(result).error).toBe(true)
+    expect(detailsOf(result).strategy).toBe('readability')
+    expect(detailsOf(result).autoDetected).toBe(false)
   })
 })
 

--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -1,6 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { extractAdaptiveHtml, validateAdaptiveHtmlComplexity } from './adaptive-html'
 import { fetchWithLimits, normalizeUrl, parseMimeType, WebFetchError } from './fetch'
 import { applyGrep, GrepError } from './strategies/grep'
 import { applyJq, JqError } from './strategies/jq'
@@ -14,6 +15,7 @@ import {
   MAX_TIMEOUT_SECONDS,
   OUTPUT_CAPS,
   type WebFetchDetails,
+  type HtmlExtractionAttempt,
 } from './types'
 
 const STRATEGY_VALUES = ['readability', 'jq', 'selector', 'grep', 'snapshot', 'raw'] as const
@@ -32,7 +34,12 @@ export const webFetchTool = defineTool({
     'fingerprinting (mouse/scroll/timing), interactive CAPTCHAs, or IP-reputation blocks — a 403 from those ' +
     'layers is expected and unrecoverable from this tool. ' +
     'Strategy guide:\n' +
-    '- "readability": extract article content as markdown (blogs, docs, news). Default for HTML.\n' +
+    '- "readability": extract article content as markdown (blogs, docs, news). Default for HTML — when auto-detected, ' +
+    'a linear DOM-complexity preflight (5 MiB scan, 20,000 tags, 256 nesting levels) runs before Readability; a ' +
+    'Readability miss (e.g. a JS app shell with no visible content) is rescued by scanning for a bounded schema.org ' +
+    'Article/NewsArticle/BlogPosting JSON-LD block before giving up; if neither yields meaningful text the error says ' +
+    'browser retrieval may be needed. Passing `strategy: "readability"` explicitly skips adaptive JSON-LD/classification ' +
+    "and returns Readability's result as-is, even when empty, but still shares parser and deterministic visibility safety checks.\n" +
     '- "jq": query JSON APIs (npm registry, GitHub API). Pass `query` (e.g. ".items[].name").\n' +
     '- "selector": extract text from elements matching a CSS selector. Pass `selector` (e.g. ".price").\n' +
     '- "grep": filter lines by regex with optional `before`/`after` context. Pass `pattern`.\n' +
@@ -125,8 +132,41 @@ export const webFetchTool = defineTool({
     }
 
     let output: string
+    let extractionAttempts: HtmlExtractionAttempt[] | undefined
     try {
-      output = await runStrategy(strategy, response.body, response.finalUrl, params)
+      if (strategy === 'readability' && autoDetected) {
+        const extracted = await extractAdaptiveHtml(response.body, response.finalUrl)
+        extractionAttempts = extracted.attempts
+        if (extracted.kind === 'error') {
+          return errorResult(normalizedUrl, extracted.message, {
+            startedAt,
+            finalUrl: response.finalUrl,
+            contentType: response.contentType,
+            httpStatus: response.httpStatus,
+            bytesIn: response.bytesIn,
+            strategy,
+            autoDetected,
+            extractionAttempts,
+          })
+        }
+        output = extracted.output
+      } else {
+        if (strategy === 'readability') {
+          const complexity = validateAdaptiveHtmlComplexity(response.body)
+          if (!complexity.valid) {
+            return errorResult(normalizedUrl, complexity.reason, {
+              startedAt,
+              finalUrl: response.finalUrl,
+              contentType: response.contentType,
+              httpStatus: response.httpStatus,
+              bytesIn: response.bytesIn,
+              strategy,
+              autoDetected,
+            })
+          }
+        }
+        output = await runStrategy(strategy, response.body, response.finalUrl, params)
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       return errorResult(normalizedUrl, message, {
@@ -152,6 +192,7 @@ export const webFetchTool = defineTool({
       bytesOut: byteLength(capped.text),
       truncated: capped.truncated,
       durationMs: Date.now() - startedAt,
+      ...(extractionAttempts === undefined ? {} : { extractionAttempts }),
       ...(response.antibotWarmup?.triggered
         ? {
             antibotWarmup: {
@@ -286,6 +327,8 @@ function errorResult(
     bytesOut: byteLength(message),
     truncated: false,
     durationMs: Date.now() - startedAt,
+    ...(rest.antibotWarmup === undefined ? {} : { antibotWarmup: rest.antibotWarmup }),
+    ...(rest.extractionAttempts === undefined ? {} : { extractionAttempts: rest.extractionAttempts }),
     error: true,
     message,
   }

--- a/src/agent/tools/webfetch/types.ts
+++ b/src/agent/tools/webfetch/types.ts
@@ -7,6 +7,12 @@ export type AntibotWarmupDetails = {
   replayStatus?: number
 }
 
+export type HtmlExtractionAttempt = {
+  route: 'readability' | 'json_ld'
+  outcome: 'success' | 'unusable' | 'error'
+  reason: string
+}
+
 export type WebFetchDetails = {
   url: string
   finalUrl: string
@@ -19,6 +25,7 @@ export type WebFetchDetails = {
   truncated: boolean
   durationMs: number
   antibotWarmup?: AntibotWarmupDetails
+  extractionAttempts?: HtmlExtractionAttempt[]
   error?: boolean
   message?: string
 }


### PR DESCRIPTION
## Background

The web fetch tool's `readability` strategy returns whatever Readability produces, or nothing. A JS-rendered app shell with no server-side content is a common miss: Readability finds no article, the tool returns near-empty output, and the calling agent has no signal beyond "this didn't work" — it can't tell whether the page is actually empty or whether a different extraction route would have found the content.

Many of those shells still carry the page's real content as schema.org `Article`/`NewsArticle`/`BlogPosting` JSON-LD, which Readability's DOM-shaped heuristics never look at.

## Summary

Adds a bounded, ordered fallback that runs entirely on the HTML body `safe-http` already fetched — no second network call, no browser, no change to the transport layer (DNS-rebinding guard, redirect pinning, Akamai warmup are untouched).

When `strategy` is auto-detected as `readability` (not explicitly requested), `extractAdaptiveHtml` (`src/agent/tools/webfetch/adaptive-html.ts`) tries two routes in a fixed order:

1. **Readability, behind a DOM-complexity preflight.** A forward-cursor lexical scanner (`html-lexical.ts`) bounds the adaptive path to 5 MiB, 20,000 tags, and 256 open-element nesting levels before JSDOM is ever constructed, handling comments, legacy prologs, quoted attributes, void elements, `<plaintext>`, and raw script/style bodies without regex backtracking. SVG/MathML subtrees are conservatively excluded as metadata sources while still counted toward the limits. Before extraction, `inline-style-visibility.ts` strips deterministic hidden content (inline styles, closed `dialog`/`details`, embedded CSS JSDOM can resolve locally) so genuinely source-visible content stays eligible. `applyReadabilityDetailed` reports structural evidence (article parsed vs. whole-body fallback, semantic containers, script count) so a miss can be classified instead of just returning empty text.
2. **Bounded JSON-LD rescue.** If Readability's output isn't usable, `extractJsonLdArticle` scans `<script type="application/ld+json">` for an `Article`/`NewsArticle`/`BlogPosting` node (recursing through arrays/`@graph` to a fixed depth) and pulls `headline` + `articleBody`/`description`. Scanning is capped to the first 1 MiB of metadata (visibility context is still validated across the full 5 MiB document), with block-count, per-block-byte, and per-field-character bounds. Documents with embedded CSS skip this route, since the lexical scan can't execute the CSS cascade and a source-hidden JSON-LD block shouldn't bypass the same visibility checks Readability gets.

If neither route produces usable output, the tool returns an error stating that browser retrieval may be needed — it does not retry the fetch, switch transport, or spawn a browser itself; escalation is left to the calling agent.

Explicit `strategy: "readability"` skips both adaptive routes and returns Readability's result as-is, even empty, but still runs behind the same complexity preflight and the same deterministic hidden-content stripping.

Each attempt is recorded as `{ route, outcome, reason }` on `details.extractionAttempts` in the tool result and persisted session record — the TUI preview and inspect replay still show only the extracted content or the final error message, not the attempt list.

The ordered try-then-validate-then-fallback shape took inspiration from [`fivetaku/insane-search`](https://github.com/fivetaku/insane-search); this is an independent, dependency-free implementation against Readability and schema.org, not a port or vendor of that project's code.

## What this does NOT do

- Does not add a second network call, a headless browser, or any change to `safe-http.ts` — this is pure post-processing on the single fetched body.
- Does not change behavior for explicit `strategy: "readability"` beyond the shared complexity preflight and hidden-content stripping — it still returns Readability's output as-is, even when empty.
- Does not claim to defeat every parser denial-of-service shape; the byte/tag/nesting/rule-budget limits guard against the known synchronous DOM-complexity hazards this change targets, not an exhaustive set.
- Does not use language-specific keywords or a universal text-length gate to judge whether Readability's output is usable — classification is structural (article-parsed vs. whole-body fallback, semantic containers, script count).

## Review notes

Load-bearing: the complexity preflight in `html-lexical.ts` running before any JSDOM construction (both adaptive-route and explicit-`readability` paths share it), and the embedded-CSS skip in the JSON-LD route (`adaptive-html.ts`) that prevents source-hidden structured data from bypassing DOM visibility checks. `strategies/readability.test.ts` and `adaptive-html.test.ts` are the primary coverage for the classification and rescue logic; `inline-style-visibility.test.ts` covers the hidden-content stripping in isolation.

## Verification

- `bun run lint` — 0 errors (baseline warnings only)
- `bun run format:check` — clean
- `bun run typecheck` — clean
- `bun run test` — 12,925 pass, 31 skip, 0 fail across 603 files
