### PR TITLE
Keep inspect session status truthful

### DIFF
--- a/src/cli/inspect.test.ts
+++ b/src/cli/inspect.test.ts
@@ -4,9 +4,25 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { sessionRowLabel } from './inspect'
 import { createTailScope } from './inspect-controller'
 
 const CLI_ENTRY = join(import.meta.dir, 'index.ts')
+
+test('registry-only session rows say live without claiming a reply is in flight', () => {
+  const label = sessionRowLabel({
+    sessionId: '0192abcd-1111-7000-8000-000000000001',
+    sessionFile: '',
+    basename: '',
+    mtimeMs: 1,
+    origin: { kind: 'tui' },
+    firstPrompt: null,
+    live: true,
+  })
+
+  expect(label).toContain('live')
+  expect(label).not.toContain('replying')
+})
 
 function tick(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -344,10 +344,10 @@ function itemHint(item: ViewerItem): { hint: string } {
   return { hint: '(no prompt)' }
 }
 
-function sessionRowLabel(s: SessionSummary): string {
+export function sessionRowLabel(s: SessionSummary): string {
   const id = shortSessionId(s.sessionId)
   const label = s.origin === null ? '(unknown origin)' : originLabel(s.origin)
-  const when = s.live === true ? c.green('live · replying') : c.dim(formatRelative(s.mtimeMs))
+  const when = s.live === true ? c.green('live') : c.dim(formatRelative(s.mtimeMs))
   return `${c.cyan(id)}  ${label}  ${when}`
 }
 

--- a/src/inspect/item-list.test.ts
+++ b/src/inspect/item-list.test.ts
@@ -24,6 +24,10 @@ const ID_A = '019ee000-aaaa-7000-9000-00000000aaaa'
 const ID_B = '019ee000-bbbb-7000-9000-00000000bbbb'
 const ID_C = '019ee000-cccc-7000-9000-00000000cccc'
 
+function numberedId(index: number): string {
+  return `019ee000-${index.toString().padStart(4, '0')}-7000-9000-${index.toString().padStart(12, '0')}`
+}
+
 function metaLine(origin: unknown): string {
   return JSON.stringify({
     type: 'custom',
@@ -155,6 +159,52 @@ describe('listViewerItems', () => {
     expect(rows).toHaveLength(1)
     if (rows[0]?.kind === 'logs') throw new Error('unreachable')
     expect(rows[0]?.summary.live).toBeUndefined()
+  })
+
+  test('a registry session below the disk summary limit stays disk-backed and does not expand the picker', async () => {
+    const diskIds: string[] = []
+    for (let index = 0; index < 21; index++) {
+      const id = numberedId(index)
+      diskIds.push(id)
+      await seed(`session_${id}.jsonl`, { kind: 'cron', jobId: `${index}`, jobKind: 'prompt' }, 1000 + index)
+    }
+
+    const { items } = await listViewerItems({
+      sessionsDir,
+      containerRunning: true,
+      interactive: true,
+      includeLogs: false,
+      limit: 20,
+      liveSessions: [{ sessionId: diskIds[0]!, origin: { kind: 'tui' }, registeredAtMs: 9_000_000 }],
+    })
+
+    expect(items).toHaveLength(20)
+    expect(items.some((item) => item.kind !== 'logs' && item.summary.sessionId === diskIds[0])).toBe(false)
+    expect(items.filter((item) => item.kind !== 'logs' && item.summary.live === true)).toHaveLength(0)
+  })
+
+  test('a registry-only session displaces the oldest selected history row within the requested limit', async () => {
+    const diskIds: string[] = []
+    for (let index = 0; index < 21; index++) {
+      const id = numberedId(index)
+      diskIds.push(id)
+      await seed(`session_${id}.jsonl`, { kind: 'cron', jobId: `${index}`, jobKind: 'prompt' }, 1000 + index)
+    }
+    const registryOnlyId = ID_A
+
+    const { items } = await listViewerItems({
+      sessionsDir,
+      containerRunning: true,
+      interactive: true,
+      includeLogs: false,
+      limit: 20,
+      liveSessions: [{ sessionId: registryOnlyId, origin: { kind: 'tui' }, registeredAtMs: 9_000_000 }],
+    })
+
+    expect(items).toHaveLength(20)
+    expect(items[0]).toMatchObject({ summary: { sessionId: registryOnlyId, live: true } })
+    expect(items.some((item) => item.kind !== 'logs' && item.summary.sessionId === diskIds[1])).toBe(false)
+    expect(items.some((item) => item.kind !== 'logs' && item.summary.sessionId === diskIds[20])).toBe(true)
   })
 
   test('non-TTY run classifies the most-recent tui-origin session read-only even with the container up', async () => {

--- a/src/inspect/item-list.ts
+++ b/src/inspect/item-list.ts
@@ -1,7 +1,5 @@
-import type { LiveSessionPayload } from '@/shared'
-
 import type { ViewerItem } from './item'
-import { listSessions, type ListSessionsOptions, mergeLiveSessions, type SessionSummary } from './session-list'
+import { listSessions, type ListSessionsOptions, type SessionSummary } from './session-list'
 
 export type ListViewerItemsOptions = ListSessionsOptions & {
   containerRunning: boolean
@@ -16,9 +14,6 @@ export type ListViewerItemsOptions = ListSessionsOptions & {
   // (most-recent) tui transcript — and any older tui transcript the heuristic
   // would otherwise promote — must NOT be offered as a writable live row.
   allowWritable?: boolean
-  // Registry sessions not yet flushed to disk, fetched by the CLI over the
-  // /inspect WS. The lib layer stays I/O-free; the caller owns the connection.
-  liveSessions?: LiveSessionPayload[]
 }
 
 export type ViewerList = {
@@ -34,11 +29,7 @@ export type ViewerList = {
 // `logs` row is appended last (container stdout, available offline) so it sits
 // below the divider in the picker.
 export async function listViewerItems(opts: ListViewerItemsOptions): Promise<ViewerList> {
-  const diskSessions = await listSessions(opts)
-  const sessions =
-    opts.liveSessions !== undefined && opts.liveSessions.length > 0
-      ? mergeLiveSessions(diskSessions, opts.liveSessions)
-      : diskSessions
+  const sessions = await listSessions(opts)
   const allowWritable = opts.interactive && opts.allowWritable !== false
   const writableSessionId = opts.containerRunning && allowWritable ? pickWritableSession(sessions) : null
 

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -14,10 +14,9 @@ export type SessionSummary = {
   mtimeMs: number
   origin: MinimalSessionOrigin | null
   firstPrompt: string | null
-  // True only for a registry-derived session with no .jsonl on disk yet (a
-  // reply is in flight). Disk sessions leave this undefined. Selecting one tails
-  // live-only: streamSessionEvents replays an empty file, then the WS delivers
-  // events as they happen.
+  // True only for a registered session with no .jsonl on disk yet. Registration
+  // means the session is warm, not that a reply is currently in flight. Disk
+  // sessions leave this undefined.
   live?: boolean
 }
 
@@ -26,6 +25,7 @@ export type ListSessionsOptions = {
   limit?: number
   sinceMs?: number
   onWarn?: (msg: string) => void
+  liveSessions?: LiveSessionPayload[]
 }
 
 // pi-coding-agent writes session files as `${ISO_TIMESTAMP}_${SESSION_ID}.jsonl`,
@@ -72,17 +72,23 @@ type StatEntry = { path: string; basename: string; sessionId: string; mtimeMs: n
 // Split from listSessions so resolveSession can match ids first and peek only the
 // candidates, instead of reading every file body on disk. Reads no file content.
 async function statSessionFiles(opts: ListSessionsOptions): Promise<StatEntry[]> {
+  return (await scanSessionFiles(opts)).eligible
+}
+
+async function scanSessionFiles(
+  opts: ListSessionsOptions,
+): Promise<{ eligible: StatEntry[]; onDiskSessionIds: Set<string> }> {
   const entries = await readSessionFiles(opts.sessionsDir, opts.onWarn)
   const withStats = await mapConcurrent(entries, SESSION_IO_CONCURRENCY, async (entry) => {
     const s = await safeStat(entry.path)
     if (s === null) return null
     const mtimeMs = s.mtimeMs
-    if (opts.sinceMs !== undefined && mtimeMs < opts.sinceMs) return null
     return { ...entry, mtimeMs }
   })
   const valid = withStats.filter((v): v is StatEntry => v !== null)
-  valid.sort((a, b) => b.mtimeMs - a.mtimeMs)
-  return valid
+  const eligible = opts.sinceMs === undefined ? valid : valid.filter((entry) => entry.mtimeMs >= opts.sinceMs!)
+  eligible.sort((a, b) => b.mtimeMs - a.mtimeMs)
+  return { eligible, onDiskSessionIds: new Set(valid.map((entry) => entry.sessionId)) }
 }
 
 async function summarizeEntry(entry: StatEntry, onWarn?: (msg: string) => void): Promise<SessionSummary> {
@@ -98,18 +104,25 @@ async function summarizeEntry(entry: StatEntry, onWarn?: (msg: string) => void):
 }
 
 export async function listSessions(opts: ListSessionsOptions): Promise<SessionSummary[]> {
-  const valid = await statSessionFiles(opts)
-  const limited = opts.limit !== undefined ? valid.slice(0, opts.limit) : valid
-  return mapConcurrent(limited, SESSION_IO_CONCURRENCY, (entry) => summarizeEntry(entry, opts.onWarn))
+  const { eligible, onDiskSessionIds } = await scanSessionFiles(opts)
+  const limited = opts.limit !== undefined ? eligible.slice(0, opts.limit) : eligible
+  const disk = await mapConcurrent(limited, SESSION_IO_CONCURRENCY, (entry) => summarizeEntry(entry, opts.onWarn))
+  if (opts.liveSessions === undefined || opts.liveSessions.length === 0) return disk
+  return mergeLiveSessions(disk, opts.liveSessions, { onDiskSessionIds, limit: opts.limit })
 }
 
 // Overlay container-registry sessions onto the disk listing. A live session
-// already flushed to disk (post-reply) is dropped from the overlay — the disk
+// already flushed to disk is dropped from the overlay — the disk
 // summary wins, carrying its real mtime and prompt preview. Only sessions with
 // no .jsonl yet become synthetic live rows, sorted to the top by registration
-// time so an in-flight reply surfaces above settled history.
-export function mergeLiveSessions(disk: SessionSummary[], live: LiveSessionPayload[]): SessionSummary[] {
-  const onDisk = new Set(disk.map((s) => s.sessionId))
+// time. The final limit applies after merging, so registry-only rows displace
+// older history rather than expanding the picker.
+export function mergeLiveSessions(
+  disk: SessionSummary[],
+  live: LiveSessionPayload[],
+  opts: { onDiskSessionIds?: ReadonlySet<string>; limit?: number } = {},
+): SessionSummary[] {
+  const onDisk = opts.onDiskSessionIds ?? new Set(disk.map((s) => s.sessionId))
   const liveOnly = live
     .filter((l) => !onDisk.has(l.sessionId))
     .map(
@@ -123,7 +136,8 @@ export function mergeLiveSessions(disk: SessionSummary[], live: LiveSessionPaylo
         live: true,
       }),
     )
-  return [...liveOnly, ...disk].sort((a, b) => b.mtimeMs - a.mtimeMs)
+  const merged = [...liveOnly, ...disk].sort((a, b) => b.mtimeMs - a.mtimeMs)
+  return opts.limit !== undefined ? merged.slice(0, opts.limit) : merged
 }
 
 export type ResolveResult =


### PR DESCRIPTION
## Background

`typeclaw inspect` merged registry-only (in-memory) sessions onto the disk-backed listing, but the disk side was gathered under the *final* row limit before the merge happened. Any registered session outside that bounded top-N looked diskless to the merge step and was re-added as a synthetic "live" row, pushing the picker past its intended row count. The same rows were also labeled `live · replying`, but registry membership only means the session is warm (registered), not that a reply is currently in flight — a session can sit in the registry well after its last reply completed.

## Summary

- `scanSessionFiles` (`src/inspect/session-list.ts`) now returns the full set of on-disk session IDs alongside the `sinceMs`-filtered, unlimited-count eligible list, so membership checks aren't blind to sessions that exist on disk but fall outside the display limit.
- `listSessions` summarizes only the bounded (post-limit) disk history — no extra I/O — then calls `mergeLiveSessions` with the full on-disk ID set for correct dedup and applies the row limit again after the registry-only rows are merged in, so real disk history is not silently displaced past the requested count.
- `mergeLiveSessions` accepts an optional `onDiskSessionIds` set and `limit`, keeping its existing signature usable by direct/CLI callers (`src/inspect/item-list.ts`, `src/cli/inspect.ts`) that already have their own disk listing and registry payload.
- `sessionRowLabel` now renders registered-but-diskless rows as `live` instead of `live · replying` — the label states presence in the registry, not reply activity, which is the only thing this code can actually observe.

## What this does NOT do

- Does not make `live` mean "actively replying" — it did not before either; this only makes the label stop implying something the data can't support.
- Does not change the disk-listing I/O path or add new reads; the fix is purely about which sessions are counted as "already on disk" before the registry overlay runs.

## Review notes

Load-bearing: `onDiskSessionIds` in `scanSessionFiles` must reflect the unfiltered (pre-`sinceMs`, pre-limit) disk scan, since a session missing from disk-listing history because it's outside the limit is still a real disk session and must not be resurrected as a synthetic live row. `mergeLiveSessions`'s new `limit` param is applied after the registry-only rows are prepended, so a full registry can't inflate the picker beyond its configured row count.

## Testing

- Targeted (`src/inspect/session-list.test.ts`, `src/inspect/item-list.test.ts`, `src/cli/inspect.test.ts`): 54 pass
- `bun run test` — 12,932 pass, 31 skip, 0 fail
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
