### PR TITLE
Broker GitHub auth for repos cloned under /tmp

### DIFF
--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 
-import { analyzeGitCommand, type GitResolvers, parseGithubRepoFromGitUrl } from './git-command'
+import {
+  analyzeGitCommand,
+  createSessionTmpGitResolvers,
+  type GitResolvers,
+  parseGithubRepoFromGitUrl,
+} from './git-command'
 
 const CWD = '/agent'
 
@@ -840,5 +845,120 @@ describe('analyzeGitCommand — clone-then-inspect (sanitized re-exec)', () => {
     // `git fetch origin main #` must not reach an inject decision through the
     // escape-blind tokenizer; the early gate blocks it before minting.
     expect((await analyze('git fetch origin main #', ghRemote)).kind).not.toBe('inject')
+  })
+})
+
+describe('createSessionTmpGitResolvers', () => {
+  const SESSION = 'ses-1'
+  const backingOf = (p: string): string => `/tmp/typeclaw-session/${SESSION}${p.slice('/tmp'.length)}`
+
+  function recordingResolvers(url: string | null = null): { seen: string[]; resolvers: GitResolvers } {
+    const seen: string[] = []
+    return {
+      seen,
+      resolvers: {
+        resolveRemoteUrl: async (cwd) => {
+          seen.push(cwd)
+          return url
+        },
+        resolveConfig: async (cwd) => {
+          seen.push(cwd)
+          return null
+        },
+        resolveCurrentBranch: async (cwd) => {
+          seen.push(cwd)
+          return null
+        },
+      },
+    }
+  }
+
+  test('probes the session backing dir for a model-facing /tmp path', async () => {
+    const base = recordingResolvers()
+    const mapped = createSessionTmpGitResolvers(CWD, SESSION, base.resolvers)
+
+    await mapped.resolveRemoteUrl('/tmp/clone', 'origin', true)
+    await mapped.resolveConfig('/tmp/clone', 'remote.pushDefault')
+    await mapped.resolveCurrentBranch('/tmp/clone')
+
+    expect(base.seen).toEqual([backingOf('/tmp/clone'), backingOf('/tmp/clone'), backingOf('/tmp/clone')])
+  })
+
+  test('leaves agent-dir paths untouched', async () => {
+    const base = recordingResolvers()
+    const mapped = createSessionTmpGitResolvers(CWD, SESSION, base.resolvers)
+
+    await mapped.resolveRemoteUrl('/agent/workspace/repo', 'origin', false)
+
+    expect(base.seen).toEqual(['/agent/workspace/repo'])
+  })
+
+  test('a repo cloned under /tmp resolves to its slug and mints', async () => {
+    // given a repo that exists ONLY at the session backing path
+    const base: GitResolvers = {
+      resolveRemoteUrl: async (cwd) => (cwd === backingOf('/tmp/clone') ? 'https://github.com/acme/widgets.git' : null),
+      resolveConfig: async () => null,
+      resolveCurrentBranch: async () => null,
+    }
+
+    const result = await analyzeGitCommand('git -C /tmp/clone push -u origin topic', {
+      cwd: CWD,
+      resolvers: createSessionTmpGitResolvers(CWD, SESSION, base),
+    })
+
+    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+
+  test('without the mapping the same command falls through unbrokered', async () => {
+    const base: GitResolvers = {
+      resolveRemoteUrl: async (cwd) => (cwd === backingOf('/tmp/clone') ? 'https://github.com/acme/widgets.git' : null),
+      resolveConfig: async () => null,
+      resolveCurrentBranch: async () => null,
+    }
+
+    const result = await analyzeGitCommand('git -C /tmp/clone push -u origin topic', {
+      cwd: CWD,
+      resolvers: base,
+    })
+
+    expect(result).toEqual({ kind: 'pass-through' })
+  })
+
+  test('a compound touching a /tmp repo still blocks', async () => {
+    // Evidence discovery shares these resolvers, so an unmapped /tmp would find no
+    // repo and downgrade a should-block compound into a silent pass-through.
+    const base: GitResolvers = {
+      resolveRemoteUrl: async (cwd) => (cwd === backingOf('/tmp/clone') ? 'https://github.com/acme/widgets.git' : null),
+      resolveConfig: async () => null,
+      resolveCurrentBranch: async () => null,
+    }
+
+    const result = await analyzeGitCommand('git -C /tmp/clone push origin main && ls', {
+      cwd: CWD,
+      resolvers: createSessionTmpGitResolvers(CWD, SESSION, base),
+    })
+
+    expect(result.kind).toBe('block')
+  })
+
+  test('rewrittenCommand keeps the model-facing /tmp path, not the backing dir', async () => {
+    // The rewritten command runs INSIDE the sandbox, where /tmp is the bind —
+    // emitting the backing path there would point at a directory that does not exist.
+    const base: GitResolvers = {
+      resolveRemoteUrl: async (cwd) => (cwd === backingOf('/tmp/clone') ? 'https://github.com/acme/widgets.git' : null),
+      resolveConfig: async () => null,
+      resolveCurrentBranch: async () => null,
+    }
+
+    const result = await analyzeGitCommand('cd /tmp/clone && git push', {
+      cwd: CWD,
+      resolvers: createSessionTmpGitResolvers(CWD, SESSION, base),
+    })
+
+    expect(result).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+      rewrittenCommand: "git -C '/tmp/clone' push",
+    })
   })
 })

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -1,6 +1,8 @@
 // Plain-`git` analog of analyzeGhCommand. Git names its target indirectly, so
 // this analyzer resolves configured remotes before selecting a per-repo token.
 
+import { mapVirtualTmpPath } from '@/sandbox'
+
 export type GitCommandDecision =
   | { kind: 'pass-through' }
   | { kind: 'block'; reason: string }
@@ -39,6 +41,27 @@ export const defaultGitResolvers: GitResolvers = {
     runGit(cwd, forPush ? ['remote', 'get-url', '--push', remote] : ['remote', 'get-url', remote]),
   resolveConfig: (cwd, key) => runGit(cwd, ['config', '--get', key]),
   resolveCurrentBranch: (cwd) => runGit(cwd, ['symbolic-ref', '--short', 'HEAD']),
+}
+
+// Sandboxed bash sees the per-session scratch dir bound over `/tmp`
+// (applyBashSandbox), but these resolvers spawn `git` from the runtime process
+// against the REAL container `/tmp` — so a repo the model cloned to `/tmp/foo`
+// resolves to nothing here and the command falls through UNBROKERED, leaving git
+// to die on a credential prompt it can never answer. Same class of bug the file
+// tools solve with TMP_REDIRECT_TOOLS. Only the filesystem probe is redirected:
+// the analyzer must keep reasoning in model-facing paths so `rewrittenCommand`
+// stays valid inside the sandbox.
+export function createSessionTmpGitResolvers(
+  agentDir: string,
+  sessionId: string,
+  base: GitResolvers = defaultGitResolvers,
+): GitResolvers {
+  const backing = (cwd: string): string => mapVirtualTmpPath(agentDir, sessionId, cwd) ?? cwd
+  return {
+    resolveRemoteUrl: (cwd, remote, forPush) => base.resolveRemoteUrl(backing(cwd), remote, forPush),
+    resolveConfig: (cwd, key) => base.resolveConfig(backing(cwd), key),
+    resolveCurrentBranch: (cwd) => base.resolveCurrentBranch(backing(cwd)),
+  }
 }
 
 const MULTI_OWNER_REASON =

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { spawnSync } from 'node:child_process'
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -1490,5 +1491,77 @@ describe('github-cli-auth plugin — review verdict lease is released on a tool.
     // then: the legitimate concurrent-duplicate guard still fires (only a BLOCKED
     // first submission releases early)
     expect(second).toMatchObject({ block: true })
+  })
+})
+
+describe('github-cli-auth plugin — git in the sandbox /tmp bind', () => {
+  // SESSION_TMP_ROOT is a real shared path, so a fixed id lets concurrent test
+  // processes delete each other's repo mid-run.
+  const sessionId = `ses-git-tmp-bind-${process.pid}-${randomUUID()}`
+  const sessionTmp = join('/tmp/typeclaw-session', sessionId)
+  const repoDir = join(sessionTmp, 'clone')
+  let askpassDir: string
+  let askpassPath: string
+
+  beforeEach(() => {
+    askpassDir = mkdtempSync(join(tmpdir(), 'tc-askpass-'))
+    askpassPath = join(askpassDir, 'typeclaw-git-askpass')
+    process.env.TYPECLAW_GIT_ASKPASS_PATH = askpassPath
+    resetGitAskPassHelperForTests()
+
+    rmSync(sessionTmp, { recursive: true, force: true })
+    mkdirSync(repoDir, { recursive: true })
+    spawnSync('git', ['init', '-q'], { cwd: repoDir })
+    spawnSync('git', ['remote', 'add', 'origin', 'https://github.com/acme/widgets.git'], { cwd: repoDir })
+  })
+
+  afterEach(() => {
+    delete process.env.TYPECLAW_GIT_ASKPASS_PATH
+    resetGitAskPassHelperForTests()
+    rmSync(askpassDir, { recursive: true, force: true })
+    rmSync(sessionTmp, { recursive: true, force: true })
+  })
+
+  // The model clones to /tmp/clone; bwrap binds the session dir over /tmp, so the
+  // repo really lives at <SESSION_TMP_ROOT>/<sid>/clone. The broker resolves repos
+  // from the runtime process, which sees the real /tmp — it must follow the bind or
+  // the push falls through unbrokered and git dies on an unanswerable prompt.
+  test('mints for a repo the model cloned under /tmp', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const seen: string[] = []
+    const hook = await hookFor(async (slug) => {
+      seen.push(slug)
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event: ToolBeforeEvent = {
+      tool: 'bash',
+      sessionId,
+      callId: 'c',
+      args: { command: 'git -C /tmp/clone push -u origin topic' },
+    }
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(seen).toEqual(['acme/widgets'])
+    const env = (event.args[TYPECLAW_INTERNAL_BASH_ENV] ?? {}) as Record<string, string>
+    expect(env.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(env.GIT_ASKPASS).toBe(askpassPath)
+  })
+
+  test('a /tmp path with no repo behind it still passes through', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event: ToolBeforeEvent = {
+      tool: 'bash',
+      sessionId,
+      callId: 'c',
+      args: { command: 'git -C /tmp/absent push -u origin topic' },
+    }
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -16,7 +16,12 @@ import {
   usesGhApiGraphqlEndpoint,
 } from './gh-command'
 import { ensureGitAskPassHelper, resolveSandboxGitAskPassPath } from './git-askpass'
-import { analyzeGitCommand, defaultGitResolvers, resolveGhDefaultRepoFromCwd } from './git-command'
+import {
+  analyzeGitCommand,
+  createSessionTmpGitResolvers,
+  defaultGitResolvers,
+  resolveGhDefaultRepoFromCwd,
+} from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
 import { classifyGhToken, shouldMintAppToken } from './token-class'
@@ -351,9 +356,13 @@ export default definePlugin({
       event: { args: Record<string, unknown> }
       command: string
       agentDir: string
+      sessionId: string
     }): Promise<HookResult> => {
-      const { event, command, agentDir } = params
-      const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
+      const { event, command, agentDir, sessionId } = params
+      const decision = await analyzeGitCommand(command, {
+        cwd: agentDir,
+        resolvers: createSessionTmpGitResolvers(agentDir, sessionId),
+      })
       if (decision.kind === 'pass-through') return
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
 
@@ -410,7 +419,7 @@ export default definePlugin({
           }
 
           if (command.includes('git')) {
-            return await handleGitCommand({ event, command, agentDir: ctx.agentDir })
+            return await handleGitCommand({ event, command, agentDir: ctx.agentDir, sessionId: event.sessionId })
           }
           return
         },


### PR DESCRIPTION
## Background

typeclaw's model-facing bash runs under bwrap with a per-session scratch dir bound over `/tmp` (`applyBashSandbox`, `src/agent/plugin-tools.ts:920`: `{ type: 'bind', source: sessionTmp, dest: '/tmp' }`, where `sessionTmp` is `/tmp/typeclaw-session/<sessionId>`).

The `github-cli-auth` plugin brokers a per-repo GitHub App token into `git` via `GIT_ASKPASS`. To decide which repo to mint a token for, its `tool.before` hook called `analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })`. `defaultGitResolvers` (`git-command.ts`) spawn `git -C <cwd> remote get-url --push origin` from the runtime process — which sees the real container `/tmp`, not the sandbox bind.

So for `git -C /tmp/clone push`, the analyzer probed a directory that doesn't exist there, resolved zero repos, returned `pass-through`, injected no credentials, and `git` died with `fatal: could not read Username for 'https://github.com': No such device or address`. Any repo the agent cloned under `/tmp` — the natural scratch location — could never be pushed, with no hint that a token was actually available.

Two secondary effects: compound-evidence discovery shares these resolvers, so the same gap could downgrade a should-block compound command into a silent pass-through — a security-relevant weakening, not just a UX bug. And the agent's own failure reports blamed missing GitHub auth, which sent operators chasing a nonexistent credential problem.

The identical bug class is already solved for the path-based file tools via `TMP_REDIRECT_TOOLS` + `mapVirtualTmpPath` (`src/agent/plugin-tools.ts:1143`). The git broker was simply a missed consumer of that same mapping.

## Summary

`createSessionTmpGitResolvers(agentDir, sessionId, base = defaultGitResolvers)` wraps a `GitResolvers` and maps only the `cwd` argument through `mapVirtualTmpPath` before calling the base resolver. `handleGitCommand` now takes `sessionId` from `event.sessionId` and passes the wrapped resolvers instead of `defaultGitResolvers` directly.

`options.cwd` passed to `analyzeGitCommand` deliberately stays model-facing, so `decision.rewrittenCommand` keeps emitting `/tmp/...` — the path that's actually valid once the command runs inside the sandbox. A test locks that in.

## What this does NOT do

- Does not change mint scope: the repo slug still comes from the resolved remote URL, and the existing repo allowlist still gates minting.
- Does not change push-URL resolution: `git remote get-url --push` still wins over the fetch URL when they differ.
- Does not touch the safe-cd or clone-then-inspect rewrite logic — both still emit sandbox-valid paths after the mapping.

## Review notes

Load-bearing: `createSessionTmpGitResolvers` maps `cwd` only, in `git-command.ts`. `mapVirtualTmpPath` itself is unchanged — it already handles `/tmp` exactly, paths inside `agentDir`, relative cwd, lexical `..`, and rejects lookalikes like `/tmpfoo`.

The new `createSessionTmpGitResolvers` describe block in `git-command.test.ts` includes a resolver set with a repo that exists *only* at the session backing path, and a companion test that reverts to `defaultGitResolvers` to confirm the same command resolves zero repos and falls through unbrokered without the mapping — i.e. the regression this closes is red without the fix.

A separate, pre-existing instance of the same bug class is out of scope here: `noteReviewCommand` (`src/bundled-plugins/github-cli-auth/index.ts:208`) passes no `agentDir`/`sessionId`, so `readInputFile` (`review-recorder.ts:173`) reads `gh ... --input /tmp/review.json` from the real container `/tmp`, which can miss the duplicate-review guard. Flagging as a follow-up, not part of this change.

## Verification

- `bun run test` — 12,960 pass, 0 fail
- `bun run lint` — 0 errors
- `bun run format` — clean
- `bun run typecheck` — clean
- Both commits independently typecheck and pass tests