### PR TITLE
Keep turn recovery silent while a background child runs

### DIFF
--- a/src/agent/live-subagents.test.ts
+++ b/src/agent/live-subagents.test.ts
@@ -8,6 +8,7 @@ import {
   type SubagentProgressEvent,
   attachProgressCapture,
   coarsen,
+  newestRunningBackgroundChildStartedAt,
 } from './live-subagents'
 
 function makeLive(overrides: Partial<LiveSubagent> = {}): LiveSubagent {
@@ -330,5 +331,51 @@ describe('attachProgressCapture', () => {
     expect(tools).toHaveLength(1)
     expect((tools[0] as Extract<SubagentProgressEvent, { kind: 'tool' }>).name).toBe('read')
     unsub()
+  })
+})
+
+describe('newestRunningBackgroundChildStartedAt', () => {
+  function child(over: Partial<LiveSubagent>): LiveSubagent {
+    return {
+      taskId: 'bg_t',
+      sessionId: 'ses_child',
+      subagentName: 'reviewer',
+      startedAt: 1_000,
+      status: 'running',
+      background: true,
+      abort: async () => {},
+      ...over,
+    }
+  }
+
+  test('no children means nothing to wait for', () => {
+    expect(newestRunningBackgroundChildStartedAt([])).toBeNull()
+  })
+
+  test('ignores a running FOREGROUND child: it returns inline, so no parent waits on it', () => {
+    expect(newestRunningBackgroundChildStartedAt([child({ background: false })])).toBeNull()
+    expect(newestRunningBackgroundChildStartedAt([child({ background: undefined })])).toBeNull()
+  })
+
+  test('ignores finished children', () => {
+    const finished = [child({ status: 'completed' }), child({ status: 'failed' })]
+    expect(newestRunningBackgroundChildStartedAt(finished)).toBeNull()
+  })
+
+  test('returns the NEWEST running background child so an older sibling cannot unpin the parent', () => {
+    const children = [
+      child({ taskId: 'bg_old', startedAt: 1_000 }),
+      child({ taskId: 'bg_new', startedAt: 9_000 }),
+      child({ taskId: 'bg_mid', startedAt: 5_000 }),
+    ]
+    expect(newestRunningBackgroundChildStartedAt(children)).toBe(9_000)
+  })
+
+  test('a newer foreground child does not mask an older running background child', () => {
+    const children = [
+      child({ taskId: 'bg_bg', startedAt: 1_000 }),
+      child({ taskId: 'bg_fg', startedAt: 9_000, background: false }),
+    ]
+    expect(newestRunningBackgroundChildStartedAt(children)).toBe(1_000)
   })
 })

--- a/src/agent/live-subagents.ts
+++ b/src/agent/live-subagents.ts
@@ -38,6 +38,20 @@ export type LiveSubagent = {
 export const MAX_EVENTS_PER_SUBAGENT = 100
 export const MESSAGE_PREVIEW_CHARS = 200
 
+// Newest — not oldest — so a long-running child that crossed a caller's backstop
+// cannot unpin a parent while a more recently spawned sibling is still inside its
+// window. Foreground children are excluded on purpose: they return inline, so a
+// parent is never left waiting on one.
+export function newestRunningBackgroundChildStartedAt(children: readonly LiveSubagent[]): number | null {
+  return children.reduce<number | null>(
+    (newest, child) =>
+      child.status === 'running' && child.background === true && (newest === null || child.startedAt > newest)
+        ? child.startedAt
+        : newest,
+    null,
+  )
+}
+
 type AgentSessionEvent =
   | { type: 'message_update'; assistantMessageEvent: { type: string; delta?: string } }
   | { type: 'message_end'; message: unknown }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -16435,3 +16435,224 @@ describe('injectPrVerdictActivity (PR-keyed verdict liveness)', () => {
     expect(sessions.map((s) => s.prompts.length)).toEqual(before)
   })
 })
+
+describe('ChannelRouter background-child await suppression', () => {
+  const CHILD_STARTED_AT = 1000
+  const ACK = '변경사항을 검토 중입니다. 완료되는 대로 정식 리뷰로 남기겠습니다.'
+
+  const runningChild = (sessionId: string): number | null => (sessionId === 'ses_fake_1' ? CHILD_STARTED_AT : null)
+
+  function continueReplyAck(replyText: string): AfterToolCallContext {
+    return {
+      assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
+      toolCall: {
+        type: 'toolCall',
+        id: 'tc-ack',
+        name: 'channel_reply',
+        arguments: { text: replyText },
+      } as AfterToolCallContext['toolCall'],
+      args: { text: replyText },
+      result: {
+        content: [{ type: 'text' as const, text: 'ignored' }],
+        details: { ok: true, more_work_this_turn: true },
+      } as AfterToolCallContext['result'],
+      isError: false,
+      context: { systemPrompt: '', messages: [], tools: [] },
+    }
+  }
+
+  test('a bare-empty stop while a background child runs stays silent instead of retrying', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs, newestRunningChildSubagentStartedAt: runningChild })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // given: the model does tool work (spawning a background child), then ends the turn empty
+    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the recovery ladder does not manufacture a status message
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toEqual([])
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_suppressed cause=awaiting_background_child'))).toBe(true)
+  })
+
+  test('a more_work_this_turn ack is not re-nudged into a second status post while the child runs', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs, newestRunningChildSubagentStartedAt: runningChild })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // given: the production incident shape — one progress ack, then a fresh empty
+    // stop while the spawned reviewer is still running
+    await router.route(inbound({ text: 'PR 좀 리뷰해줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: ACK })
+      await sessions[0]!.agent.afterToolCall!(continueReplyAck(ACK))
+      emptyStopAfterToolWork(sessions[0]!)
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: exactly one ack reaches the channel — no duplicate
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toEqual([ACK])
+    expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
+  })
+
+  test('a child past the stuck backstop stops suppressing and the normal retry resumes', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const nowRef = { value: CHILD_STARTED_AT + SESSION_CHILD_STUCK_BACKSTOP_MS + 1 }
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      nowRef,
+      newestRunningChildSubagentStartedAt: runningChild,
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    // given: a wedged child that has outlived the backstop must not mute the channel
+    await router.route(inbound({ isBotMention: true, text: 'check this' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(logs.some((m) => m.includes('empty_turn_retry') && m.includes('cause=empty_stop_after_tool_work'))).toBe(
+      true,
+    )
+    expect(logs.some((m) => m.includes('empty_turn_suppressed cause=awaiting_background_child'))).toBe(false)
+  })
+
+  test('the deferred answer lands once the child completes and its reminder wakes the session', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    let childRunning = true
+    const { router, sessions } = makeRouter(dir, {
+      newestRunningChildSubagentStartedAt: (sessionId) =>
+        childRunning && sessionId === 'ses_fake_1' ? CHILD_STARTED_AT : null,
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // given: the turn goes silent while the child works
+    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toEqual([])
+
+    // when: the child finishes and the completion reminder wakes the parent
+    childRunning = false
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '리뷰 완료: APPROVE' })
+      sessions[0]!.setAssistantText('')
+    }
+    router.injectSubagentCompletionReminder({
+      parentSessionId: 'ses_fake_1',
+      subagent: 'reviewer',
+      taskId: 'bg_reviewer',
+      ok: true,
+      durationMs: 5_000,
+    })
+
+    // then: silence was delivery deferred, not delivery dropped
+    await waitFor(() => sent.length > 0)
+    expect(sent).toEqual(['리뷰 완료: APPROVE'])
+  })
+
+  test('a leaf carrying real text is still delivered while a background child runs', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs, newestRunningChildSubagentStartedAt: runningChild })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // given: a live child, but the model DID write user-facing prose (not NO_REPLY)
+    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('먼저 확인한 부분은 이렇습니다.')
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the documented exemption holds — an answer the model already wrote lands
+    expect(sent).toEqual(['먼저 확인한 부분은 이렇습니다.'])
+    expect(logs.some((m) => m.includes('empty_turn_suppressed cause=awaiting_background_child'))).toBe(false)
+  })
+
+  test("a later unrelated turn keeps ordinary recovery while an EARLIER turn's child runs", async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const nowRef = { value: CHILD_STARTED_AT }
+    // given: the child was spawned by turn N, and is still running
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      nowRef,
+      newestRunningChildSubagentStartedAt: runningChild,
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!, 'n')
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toEqual([])
+    const promptsAfterTurnN = sessions[0]!.prompts.length
+
+    // when: turn N+1 is unrelated work arriving while that child is STILL running
+    nowRef.value = CHILD_STARTED_AT + 1_000
+    logs.length = 0
+    let attempt = 0
+    sessions[0]!.onPrompt = () => {
+      attempt++
+      if (attempt === 1) emptyStopAfterToolWork(sessions[0]!, 'n1')
+      else sessions[0]!.setAssistantText('네, 그건 이렇게 하면 됩니다.')
+    }
+    await router.route(inbound({ isBotMention: true, text: '다른 질문인데 이거 어떻게 해?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the later turn is NOT suppressed — it retries and delivers its own answer
+    expect(logs.some((m) => m.includes('empty_turn_suppressed cause=awaiting_background_child'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_retry') && m.includes('cause=empty_stop_after_tool_work'))).toBe(
+      true,
+    )
+    expect(sessions[0]!.prompts.length).toBeGreaterThan(promptsAfterTurnN + 1)
+    expect(sent).toEqual(['네, 그건 이렇게 하면 됩니다.'])
+  })
+
+  test('todo continuation does not re-wake a session that is waiting on a background child', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    let continuationRuns = 0
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      newestRunningChildSubagentStartedAt: runningChild,
+      runIdleContinuation: async () => {
+        continuationRuns++
+        return false
+      },
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    // given: the pending todo is the very work the child was spawned to do
+    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(continuationRuns).toBe(0)
+    expect(logs.some((m) => m.includes('skipping todo continuation while background child runs'))).toBe(true)
+  })
+})

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -214,7 +214,12 @@ export function disengageReactionEmojiFor(adapter: AdapterId): string {
   return DISENGAGE_REACTION_EMOJI_OVERRIDES[adapter] ?? DISENGAGE_REACTION_EMOJI
 }
 
-type SilentAckReason = 'skip_response' | 'no_reply' | 'skip_response_text_leak' | 'github_review_output'
+type SilentAckReason =
+  | 'skip_response'
+  | 'no_reply'
+  | 'skip_response_text_leak'
+  | 'github_review_output'
+  | 'awaiting_background_child'
 
 // Wake nudge pushed into a resumed channel session at boot so drain() has a
 // non-empty batch and fires a turn. The substantive instruction the model acts
@@ -1004,6 +1009,13 @@ type LiveSession = {
   // counter is purely monotonic; the matching comparison is what protects
   // against stale state.
   turnSeq: number
+  // Clock time the current LOGICAL turn opened — stamped only on a real user
+  // batch, so the reminder-only iterations a retry queues stay inside the same
+  // logical turn. Unlike `turnSeq` (which increments per drain iteration) this
+  // gives background-child checks a boundary they can compare a child's
+  // `startedAt` against, to tell "this turn spawned it" from "it was already
+  // running when unrelated work arrived".
+  logicalTurnStartedAt: number
   // Snapshot of `successfulChannelSends` taken at turn start (same
   // moment `turnSeq` increments). Lets `markTurnSkipped` detect "a
   // channel send already landed in this turn" and reject the skip,
@@ -2050,6 +2062,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return false
   }
 
+  // Same question as the GC/rollover pin, asked for a different decision: while a
+  // background child is still working (and inside the stuck backstop), an empty
+  // completion from the parent is the subagent contract being honored, not the
+  // provider degeneration the turn-recovery ladder exists to repair.
+  //
+  // Turn-scoped, unlike the GC pin, which is deliberately session-scoped. Only
+  // the logical turn that spawned the child is waiting on it; a later inbound is
+  // unrelated work whose own recovery, todo continuation and staged fallback must
+  // still run. Session scope would let one long-running child silence every
+  // subsequent turn, and a wedged child would strand them with nothing to revisit
+  // them after the backstop expires.
+  const isAwaitingBackgroundChild = (live: LiveSession, label: string): boolean => {
+    const childStartedAt = newestRunningChildSubagentStartedAt(live.sessionId)
+    if (childStartedAt === null || childStartedAt < live.logicalTurnStartedAt) return false
+    return isPinnedByRunningChild(live.sessionId, live.keyId, label)
+  }
+
   const shouldRolloverLive = (live: LiveSession, idleMs: number): boolean => {
     // A session mid-prompt looks idle by lastInboundAt (only bumped on engaged
     // inbounds) while session.prompt() is still in flight; rolling it over aborts
@@ -2337,6 +2366,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         sendTimestamps: new Map(),
         successfulChannelSends: 0,
         turnSeq: 0,
+        logicalTurnStartedAt: now(),
         successfulSendsAtTurnStart: 0,
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
@@ -3258,6 +3288,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.toolLeakRetries = 0
           live.emptyStopAfterToolWorkArmed = false
           live.willingnessNudges = 0
+          live.logicalTurnStartedAt = now()
           // A fresh batch supersedes a still-pending staged fallback. That staged
           // turn produced no usable reply, so it must not leave the PRIOR turn's
           // committed lastQuestionSignal behind — otherwise the new question would
@@ -3487,10 +3518,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           logger.warn(`[channels] ${live.keyId}: skipping todo continuation after failed outcome write`)
         } else if (live.userStoppedTurnSeq === live.turnSeq) {
           logger.info(`[channels] ${live.keyId}: skipping todo continuation after user stop`)
+        } else if (isAwaitingBackgroundChild(live, 'todo-continuation')) {
+          // The outstanding todo is usually the very work the running child was
+          // spawned to do, so continuing here re-wakes a session that is
+          // deliberately waiting and asks the model to report progress it does
+          // not have yet. The child's completion reminder is the correct wake.
+          logger.info(`[channels] ${live.keyId}: skipping todo continuation while background child runs`)
         } else {
           await maybeContinueTodosChannel(live)
         }
-        await resolveStagedFallback(live)
+        if (!isAwaitingBackgroundChild(live, 'staged-fallback')) {
+          await resolveStagedFallback(live)
+        }
         live.lastTurnAuthorIds = new Set(live.currentTurnAuthorIds)
         if (live.currentTurnAuthorId !== null) {
           live.lastTurnAuthorId = live.currentTurnAuthorId
@@ -4915,6 +4954,32 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     ) {
       logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=github_review_output_this_turn`)
       armSilentTurnAck(live, 'github_review_output')
+      return
+    }
+
+    // A background child spawned by this session is still running, and the turn
+    // produced no user-facing output. That is `spawn_subagent`'s contract being
+    // honored ("you will receive a system-reminder when it completes"), not the
+    // empty-completion degeneration every branch below exists to repair — so the
+    // recovery ladder must not manufacture the status prose the model
+    // deliberately withheld. Each nudge re-enters with the child STILL running,
+    // so the budgets stack (MAX_EMPTY_TURN_RETRIES + MAX_WILLINGNESS_NUDGES) into
+    // several "still working…" messages for one request; on GitHub, where a
+    // channel reply IS a public PR comment, that shipped as duplicate review
+    // acknowledgements. The completion reminder re-wakes this session with the
+    // real result, so silence here is delivery deferred, not delivery dropped.
+    // Bounded by the same stuck-child backstop as GC/rollover: a wedged child
+    // stops pinning and the normal ladder resumes. A leaf carrying real text is
+    // deliberately NOT covered — recovering an answer the model already wrote is
+    // still correct while a child runs.
+    const awaitLeaf = recoverableAssistantText(live.session)
+    if (
+      live.currentTurnAuthorId !== null &&
+      (awaitLeaf === null || endsWithNoReplySignal(awaitLeaf.text)) &&
+      isAwaitingBackgroundChild(live, 'empty_turn_recovery')
+    ) {
+      logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=awaiting_background_child`)
+      armSilentTurnAck(live, 'awaiting_background_child')
       return
     }
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -5,7 +5,7 @@ import { SessionManager } from '@mariozechner/pi-coding-agent'
 import { createSession, createSessionWithDispose } from '@/agent'
 import { createProviderAuthReloadable } from '@/agent/auth-reloadable'
 import { LiveSessionRegistry } from '@/agent/live-sessions'
-import { LiveSubagentRegistry } from '@/agent/live-subagents'
+import { LiveSubagentRegistry, newestRunningBackgroundChildStartedAt } from '@/agent/live-subagents'
 import { requestContainerRestart } from '@/agent/restart'
 import { consumeRestartHandoff } from '@/agent/restart-handoff'
 import { sessionMetaPayload } from '@/agent/session-meta'
@@ -475,13 +475,7 @@ async function startAgentRuntime(
     githubTokenBridge,
     stream,
     newestRunningChildSubagentStartedAt: (sessionId) =>
-      liveSubagentRegistry
-        .list({ parentSessionId: sessionId })
-        .reduce<number | null>(
-          (newest, child) =>
-            child.status === 'running' && (newest === null || child.startedAt > newest) ? child.startedAt : newest,
-          null,
-        ),
+      newestRunningBackgroundChildStartedAt(liveSubagentRegistry.list({ parentSessionId: sessionId })),
     listRunningBackgroundSubagentNames: (sessionId) =>
       liveSubagentRegistry
         .list({ parentSessionId: sessionId })


### PR DESCRIPTION
## Background

An agent reviewing a pull request posted **two** "reviewing now, formal review to follow" comments eight seconds apart, in response to a single `pull_request.opened` webhook, from a single channel session. The two comments had different wording, so the outbound duplicate guard (which compares normalized text against `lastSentText`) did not catch them.

The session transcript and router logs show it was not a duplicate delivery, a reconcile replay, or a retry. It was the recovery ladder:

```
turn 1  tool work, spawns background reviewer subagent, ends turn empty   <- CORRECT
        empty_turn_retry attempt=1/2 cause=empty_stop_after_tool_work
turn 2  forced by the nudge -> posts ack #1 (channel_reply, more_work_this_turn: true)
        send_willingness_nudge attempt=1/1 cause=empty_stop_after_continue_reply
turn 3  forced by the nudge -> posts ack #2
turn 4  model calls skip_response: "waiting for reviewer, already posted status"
later   child completes -> completion reminder -> formal review posted
```

Ending a turn empty after spawning a **background** subagent is the documented contract — `spawn_subagent` replies *"You will receive a system-reminder when it completes"* — not the empty-completion degeneration the ladder exists to repair. The ladder could not distinguish the two.

Because every nudge re-entered with the child **still running**, two independent budgets stacked: `MAX_EMPTY_TURN_RETRIES` (2) manufactured a status message out of a turn that deliberately had none, that ack tripped continuation-willingness, and `MAX_WILLINGNESS_NUDGES` (1) manufactured a second one. Up to three forced posts per request. On GitHub a channel reply *is* a public PR comment, so this surfaced as duplicate review acknowledgements; the same log signature appears on three other PRs in the same deployment.

`SEND_WILLINGNESS_NUDGE` made it worse by asserting *"nothing reached the channel after your last message"* — which was false, ack #1 had landed three seconds earlier — so the model wrote a fresh message rather than staying quiet.

Todo continuation compounded it: the outstanding todo was the very work the child had been spawned to do, so it re-woke the session that was deliberately waiting.

## Summary

The router already knows when a background child is running — `newestRunningChildSubagentStartedAt`, used to pin a session against idle GC and stale-rollover — but the recovery ladder never consulted it.

**Classify the intentional await once, before every recovery branch**, rather than patching the three nudge sites individually. A local condition at each site would still leave the cold-start branch, the stranded-toolUse path, todo continuation, and staged-fallback resolution able to re-introduce the duplicate. The same predicate now also gates todo continuation and staged-fallback resolution.

**Why silence and not "exactly one status post":** allowing one ack requires synthesizing a turn the model chose not to produce. That costs another model call, produces model-dependent wording, and re-trips willingness detection — which is precisely how the two acks arose. The existing silent-ack reaction still fires, so the turn is acknowledged without manufacturing prose. The completion reminder guarantees a later turn, so this is delivery deferred, not delivery dropped.

**Why the same backstop as GC:** a wedged child must not mute a channel forever. Reusing `SESSION_CHILD_STUCK_BACKSTOP_MS` means a child past the backstop stops suppressing and the normal ladder resumes, with no new timer and no second notion of "stuck".

The first commit is a prerequisite bug found while wiring this up: `newestRunningChildSubagentStartedAt` is documented as background-only, but the runtime filtered on `status === 'running'` alone — unlike its sibling `listRunningBackgroundSubagentNames`. A running **foreground** child pinned its parent against GC for no reason, and would have falsely suppressed recovery here. The selection is now a tested pure function instead of an inline reduce that had already drifted from its contract.

## What this does NOT do

- Does not touch the nudge wording, budgets, or any recovery branch when no background child is running — the ladder is unchanged for the degeneration it was built for.
- Does not suppress recovery of a leaf that carries real text. An answer the model already wrote still lands, child or no child.
- Does not add a wake-up timer. If a child hangs and never fires its completion broadcast, that request stays unanswered until the next inbound, exactly as before; the backstop only stops the suppression, it does not re-drive the turn.
- Does not change the GitHub adapter, dedupe keys, or reconcile.

## Review notes

The load-bearing change is the early return in `validateChannelTurn`, placed immediately after the `skip_response` and GitHub-review-output suppressions and **before** every recovery branch. Its position is the invariant: moving it below any branch reopens the duplicate.

Worth verifying:

- The gate keys on "no user-facing output" (`recoverableAssistantText` returning `null`, or a leaf that ends with a NO_REPLY signal). A text-carrying leaf intentionally falls through.
- Omitted DI still means "no pin" — tests that do not inject `newestRunningChildSubagentStartedAt` keep today's behavior. All 706 pre-existing router tests pass unchanged, which is the regression guard for that default.
- Each new router test was confirmed to fail against the unpatched gate (4 of 5; the fifth asserts the *unsuppressed* backstop path, so it correctly passes both ways). Without the gate, the suppressed turn instead posts `⚠️ I got stuck putting together a reply and couldn't finish.` while the child is still working.
- Tests cover Korean acknowledgement text, per the multi-language rule in `AGENTS.md`.
