### PR TITLE
Clone project work into the durable host-mounted workspace

### DIFF
--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 import { formatLocalDateTime, resolveLocalTimezoneName } from '@/shared'
 
@@ -67,26 +69,59 @@ describe('operator-owned dependencies', () => {
 
 describe('agent folder vs project repo', () => {
   // Guards the confusion where the agent treats its own backup repo as the
-  // project under development — tries to push it as a PR, or claims it has no
-  // remote so it "can't open the PR". Both prompts must keep the distinction:
-  // the agent folder is a private, remote-less backup repo; project work and PRs
-  // happen in a separate clone (e.g. /tmp/<repo>).
+  // project under development, or strands handoff-bound work in per-session
+  // /tmp. Both prompts must keep the project clone durable and split the two
+  // publication capabilities: a standalone push is brokered, `gh pr create` is
+  // host-stage only.
   test.each([
     ['default prompt', DEFAULT_SYSTEM_PROMPT],
     ['slim prompt', SLIM_SYSTEM_PROMPT],
   ])('states the agent folder is a backup repo, not a project checkout, in the %s', (_name, prompt) => {
     expect(prompt).toMatch(/no (github )?remote/i)
-    expect(prompt).toMatch(/clone[\s\S]*?\/tmp/i)
+    expect(prompt).toContain('`workspace/<repo>`')
+    expect(prompt).toMatch(/\/tmp[\s\S]*?per-session[\s\S]*?dies with the container/i)
+    expect(prompt).not.toMatch(/clone[\s\S]{0,80}?\/tmp\/<repo>/i)
     expect(prompt).toMatch(/not a (software )?project (checkout|you develop)|not a checkout of any project/i)
+  })
+
+  // The runtime brokers a per-repo credential for a standalone project push, so
+  // neither prompt may claim model-driven bash cannot push. `gh pr create` is
+  // the only host-stage-only step; conflating the two strands real work.
+  test.each([
+    ['default prompt', DEFAULT_SYSTEM_PROMPT],
+    ['slim prompt', SLIM_SYSTEM_PROMPT],
+  ])('splits brokered push from host-stage-only PR creation in the %s', (_name, prompt) => {
+    expect(prompt).toContain('git -C workspace/<repo> push -u origin <branch>')
+    expect(prompt).toMatch(/broker[\s\S]*?credential/i)
+    expect(prompt).toMatch(/gh pr create[\s\S]*?host-stage only/i)
+    expect(prompt).toMatch(/refuse it/i)
+    expect(prompt).not.toMatch(/cannot push or create a PR/i)
   })
 
   test('the default prompt explicitly tells the agent where project work and PRs happen', () => {
     const start = DEFAULT_SYSTEM_PROMPT.indexOf('it is your own private backup repo')
     expect(start).toBeGreaterThan(-1)
-    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 900)
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, DEFAULT_SYSTEM_PROMPT.indexOf('\n\n', start + 400))
     expect(section).toMatch(/not\*{0,2} a checkout of any project/i)
-    expect(section).toMatch(/open the PR from that clone/i)
+    expect(section).toMatch(/anything a human must act on later cannot live there alone/i)
+    expect(section).toMatch(/gitExfil/)
     expect(section).toMatch(/ask the user where it lives/i)
+  })
+
+  // The prompts and the two GitHub skills are mirrored guidance; the skills are
+  // what the agent actually loads for PR work, so a fix applied only to the
+  // prompts leaves the operative instruction contradicting itself.
+  test.each([
+    ['channel-github skill', 'typeclaw-channel-github'],
+    ['github-contributing skill', 'typeclaw-github-contributing'],
+  ])('mirrors the brokered-push / host-stage-PR split in the %s', (_name, slug) => {
+    const skill = readFileSync(join(import.meta.dir, '..', 'skills', slug, 'SKILL.md'), 'utf8')
+    expect(skill).toMatch(/push -u origin <branch>/)
+    expect(skill).toMatch(/broker[\s\S]*?credential/i)
+    expect(skill).toMatch(/gh pr create[\s\S]*?host-stage only/i)
+    expect(skill).toMatch(/refuse it/i)
+    expect(skill).not.toMatch(/cannot (push or create|create or push) a PR/i)
+    expect(skill).not.toMatch(/cannot run `gh pr checkout` or authenticated `git push`/i)
   })
 })
 

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -106,7 +106,7 @@ Use tmux only for work that belongs in your session. Delegate self-contained lon
 
 Your agent folder is a git repository, but **it is your own private backup repo — not a software project you develop.** ${branding ? 'TypeClaw snapshots' : 'The runtime snapshots'} identity files, \`sessions/\`, and \`memory/\` there over time. It normally has no remote, nothing is pushed, and it is **not a checkout of any project**. Commits here save your state, not a codebase contribution.
 
-For project work (bug, feature, PR), clone the project repo into \`/tmp/<repo>\`, work there, and open the PR from that clone with \`gh\`. Never \`git init\`, add a remote, or push your agent folder as the project. If there is no remote or you cannot find the repo, ask the user where it lives. Your agent folder is where you live; the clone is where you work.
+For project work (bug, feature, PR), clone the project repo into \`workspace/<repo>\` and work in that separate checkout. \`workspace/\` is part of the host-mounted agent folder, so the operator can reach the same checkout after your turn. Use \`/tmp\` only for disposable scratch: it is per-session and dies with the container, so anything a human must act on later cannot live there alone. Commit the project changes, then push the branch yourself with \`git -C workspace/<repo> push -u origin <branch>\` — the GitHub broker mints a per-repo credential for a standalone push like that. Name the remote and branch explicitly: a fresh PR branch has no upstream, and a bare \`git push\` fails on setup rather than on policy. Fix ordinary Git errors (missing upstream, stale ref, needs a rebase) yourself and retry. Only hand the exact push command to the operator when the broker or your permissions refuse it — no brokered credential for the repo, or your role lacks the \`gitExfil\` bypass. \`gh pr create\` is host-stage only: prepare the exact title, body, head branch and base branch, then ask the operator to run it from the agent folder's \`workspace/<repo>\` checkout. Never \`git init\`, add a remote, or push your agent folder as the project. If there is no remote or you cannot find the repo, ask the user where it lives. Your agent folder is where you live; the separate checkout is where you work.
 
 Commits to your agent folder (your own state):
 
@@ -114,7 +114,7 @@ Commits to your agent folder (your own state):
 - Use \`git add <paths>\`, not \`git add -A\`. Use imperative commit messages; explain why if non-obvious.
 - Never commit \`secrets.json\`, \`.env\`, or \`workspace/\`. Do not manually add runtime-managed \`sessions/\` or \`memory/\`.
 - ${PACKAGE_JSON_INSTALL_RULE}
-- Never \`git push\`, \`git reset --hard\`, \`git rebase\`, or rewrite remote history in this folder unless explicitly asked. Pushing a separate project clone for a requested PR is fine.
+- Never \`git push\`, \`git reset --hard\`, \`git rebase\`, or rewrite remote history in this folder unless explicitly asked. Pushing a separate project checkout for a requested PR is fine — that restriction is about this folder, not the project.
 
 ## How to behave
 
@@ -327,7 +327,7 @@ ${PACKAGE_JSON_INSTALL_RULE}
 
 Your free-write zone is \`workspace/\`. Do not create files at the root of the agent folder unless the prompt names another path. \`public/\` is the guest-visible zone — write there anything meant to be shared with an untrusted caller (a \`guest\`-role turn cannot read \`workspace/\` but can read \`public/\`). Do not edit \`memory/topics/\` directly — the dreaming subagent owns it; to capture something memorable, surface it in your reply or let the memory-logger append to \`memory/streams/\`. Never stage or commit \`secrets.json\`, \`.env\`, \`sessions/\`, \`memory/\`, or \`workspace/\` — those are runtime- or user-managed.
 
-The agent folder is a private backup repo with no remote, not a project checkout. To work on a software project (fix a bug, open a PR), clone its repo elsewhere (e.g. \`/tmp/<repo>\`) and work there — never push the agent folder as if it were the project.
+The agent folder is a private backup repo with no remote, not a project checkout. For software project work (bug, feature, PR), clone into \`workspace/<repo>\`, the durable checkout inside the host-mounted agent folder; never \`git init\`, add a remote, or push the agent folder as if it were the project. Use \`/tmp\` only for disposable scratch: it is per-session and dies with the container, so anything a human must act on later cannot live there alone. Commit the project changes, then push that branch yourself: \`git -C workspace/<repo> push -u origin <branch>\` — the broker mints a per-repo credential for a standalone push. Fix ordinary Git errors yourself; hand the command to the operator only when the broker or your permissions refuse it. \`gh pr create\` is host-stage only: prepare its title, body, head and base for the operator to run from that checkout. If the project repo location is unknown, ask the user where it lives.
 
 See the session-origin block below for what kind of session this is and what's expected of you.`
 }

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -74,19 +74,21 @@ The flow:
    gh api /repos/owner/repo/pulls/<N>/comments --jq '[.[] | {path, line, user: .user.login, body}]'
    ```
 
-2. **Update the PR's branch with host-stage help.** Model-driven bash cannot run `gh pr checkout` or authenticated `git push`: both may execute local hooks while carrying reusable credentials. Ask the operator to run the checkout from the host-stage repository directory:
+2. **Get the branch checked out, then push it yourself.** `gh pr checkout` is host-stage only — it may execute local hooks while carrying reusable credentials — so ask the operator to run it from the host-stage repository directory:
 
    ```sh
    gh pr checkout <N> --repo owner/repo
    ```
 
-   After the operator confirms the checkout, make the minimal fixes and commit them locally with `typeclaw-git` hygiene. Then ask the operator to push that same branch from the host stage:
+   After the operator confirms the checkout, make the minimal fixes and commit them locally with `typeclaw-git` hygiene. Pushing is **not** host-stage only: the broker mints a per-repo credential for a standalone push, so run it yourself from the accessible checkout, naming the remote and branch explicitly:
 
    ```sh
-   git push
+   git -C <checkout> push -u origin <branch>
    ```
 
-   Do **not** open a _new_ PR to fix your existing one; the operator pushes to the same branch so the open PR updates in place.
+   Fix ordinary Git errors (missing upstream, stale ref, needs a rebase) yourself and retry. Hand the operator that exact push command only when the broker or your permissions refuse it — no brokered credential for the repo, or your role lacks the `gitExfil` bypass.
+
+   Do **not** open a _new_ PR to fix your existing one; the push goes to the same branch so the open PR updates in place.
 
    If a point is a genuine disagreement (the reviewer is mistaken, or the behavior is intentional), don't silently change it — reply in the thread with your reasoning instead.
 
@@ -94,9 +96,9 @@ The flow:
    - **Do not resolve the threads.** On your own PR the open inline threads were authored by your **reviewer**, not by you — and the base principle is _whoever opened the thread closes it_. Resolving is the reviewer's call once they're satisfied; the runtime enforces this (it only lets you resolve threads whose root comment **you** authored). Push the fix, reply, and leave the thread for the reviewer to close.
    - **Do not post a verdict.** "LGTM", "Approved", "Request changes" are reviewer words. As the author you reply in plain prose; you never emit a review verdict on your own PR.
 
-4. **If CI is failing on your PR**, that's also contributor work: read the failing check, fix the cause on the checked-out branch, commit locally, then ask the operator to run `git push` from the host stage. You can't always read another system's CI logs — if you can't, say so and ask for the error rather than guessing.
+4. **If CI is failing on your PR**, that's also contributor work: read the failing check, fix the cause on the checked-out branch, commit locally, then push it yourself the same way. You can't always read another system's CI logs — if you can't, say so and ask for the error rather than guessing.
 
-That's the whole contributor loop: read feedback → operator checks out at the host stage → fix and commit locally → operator pushes at the host stage → reply. No subagent, no formal review, no thread resolution.
+That's the whole contributor loop: read feedback → operator checks out at the host stage → fix and commit locally → push the branch yourself → reply. No subagent, no formal review, no thread resolution.
 
 ### When you are being asked to review
 
@@ -307,7 +309,13 @@ gh issue create --repo owner/repo --title 'Bug: ...' --body '...'
 
 ```
 
-For a pull request, prepare the exact title, body, pushed head branch, and base branch, then ask the operator to run `gh pr create --repo owner/repo --title 'Fix: ...' --head my-branch --base main --body '...'` at the host stage from the repository checkout. Model-driven bash cannot push or create a PR because network Git and `gh pr create` may execute local Git hooks with reusable credentials.
+For a pull request from a project repo you cloned into `workspace/<repo>`, push the head branch yourself — the broker mints a per-repo credential for a standalone push. A fresh PR branch has no upstream, so name the remote and branch explicitly:
+
+```sh
+git -C workspace/<repo> push -u origin <branch>
+```
+
+Then prepare the exact title, body, head branch and base branch and ask the operator to run `gh pr create --repo owner/repo --title 'Fix: ...' --head my-branch --base main --body '...'` at the host stage from that same checkout: `gh pr create` is host-stage only because it may execute local Git hooks with reusable credentials. Fix ordinary Git errors yourself and retry; hand the operator the push command only when the broker or your permissions refuse it — no brokered credential, or your role lacks the `gitExfil` bypass. When you do hand off, name the host-accessible `workspace/<repo>` checkout; never direct them to a per-session `/tmp` path.
 
 For the supported issue form under App auth, TypeClaw mints a short-lived token for the explicit `--repo owner/repo` target and withholds it from sibling commands and shell expansions.
 

--- a/src/skills/typeclaw-github-contributing/SKILL.md
+++ b/src/skills/typeclaw-github-contributing/SKILL.md
@@ -98,11 +98,15 @@ The same applies to PRs: a quick `gh pr list --search` avoids opening a PR for s
    ```sh
    gh issue create --repo OWNER/REPO --title '<conventional title>' --body '<filled body>'
    ```
-   For a **pull request**, prepare the exact title, body, pushed head branch, and base branch, then ask the operator to run this at the host stage from the repository checkout:
+   For a **pull request**, push the head branch yourself first — from a project repo cloned into `workspace/<repo>`, the broker mints a per-repo credential for a standalone push. A fresh branch has no upstream, so name the remote and branch explicitly:
+   ```sh
+   git -C workspace/<repo> push -u origin <branch>
+   ```
+   Then prepare the exact title, body, head branch and base branch and ask the operator to run this at the host stage from that same checkout:
    ```sh
    gh pr create --repo OWNER/REPO --title '<conventional title>' --body '<filled body>' --head <branch> --base <branch>
    ```
-   Model-driven bash cannot create or push a PR: TypeClaw deliberately withholds reusable credentials from network Git and blocks `gh pr create` because it may invoke local Git hooks.
+   `gh pr create` is host-stage only: TypeClaw blocks it because it may invoke local Git hooks with reusable credentials. Pushing is different — it is brokered per repo. Fix ordinary Git errors yourself and retry; only hand the operator a push command when the broker or your permissions refuse it (no brokered credential, or your role lacks the `gitExfil` bypass). When you do hand off, name the host-accessible `workspace/<repo>` checkout; never direct the operator to a per-session `/tmp` path.
 5. **Verify it landed** as intended (`gh issue view` / `gh pr view`) — confirm the template rendered and nothing got truncated.
 
 ## Things you must not do


### PR DESCRIPTION
## Background

A production agent was asked in a GitHub PR thread to open a follow-up PR. It cloned the target repo, made the change, verified it, committed — and then told the reviewer, in effect:

> Push the branch at `/tmp/<repo>` from the host, then open the PR.

That path exists on neither stage. The operator had nowhere to go, and the commit was stranded.

The agent was following the system prompt, which said:

> For project work (bug, feature, PR), clone the project repo into `/tmp/<repo>`, work there, and open the PR from that clone with `gh`.

That instruction is wrong twice over.

**It promises a capability the runtime does not provide.** `gh pr create` is not in `SAFE_GH_OPERATIONS.pr`, so the broker never mints a credential for it — PR creation is host-stage only.

**It points at storage that is neither host-visible nor durable.** `src/sandbox/session-tmp.ts` binds `/tmp/typeclaw-session/<sessionId>` over `/tmp`, so a `/tmp/<repo>` clone is not at `/tmp/<repo>` outside the sandbox, does not exist on the host at all, and dies with the container. Any handoff naming a `/tmp` path is unactionable by construction.

## Summary

Project work moves to `workspace/<repo>`, and the publication guidance is split by what the runtime actually supports.

**The policy this PR encodes:**

- **Standalone per-repository push is brokered.** `parseMintablePush` mints a per-repo credential, including for `-u origin <branch>`. The agent pushes its own branch.
- **`gh pr checkout` and `gh pr create` remain host-stage only.** Neither is in the safe-operation set; both may execute local Git hooks with reusable credentials.
- **Operator push handoff is only for broker or permission refusal** — no brokered credential for the repo, or the role lacks the `gitExfil` bypass. Ordinary Git errors are the agent's to fix and retry, not grounds for a handoff.

`workspace/` is the already-documented free-write zone and lives inside the host-mounted agent folder, so the operator can reach the very checkout the agent used. It is gitignored, so a nested project clone does not pollute the agent's backup repo — the existing "never stage or commit `workspace/`" rule already covers it. No new directory convention is introduced.

The prescribed push is the explicit first-push form, `git -C workspace/<repo> push -u origin <branch>`. A fresh PR branch has no upstream, so a bare `git push` fails on Git setup rather than on policy — and the earlier draft then handed the operator that same unusable command.

**Why not translate the container path to a host path instead?** There is no such mapping. `/tmp/typeclaw-session/<sessionId>/…` is a container path; emitting it to a human is just as unusable as the original. The fix has to be *where the work happens*, not how the path is printed.

Both mirrored prompt sections (full and slim) and both GitHub skills carry the same split, including the contributor flow in `typeclaw-channel-github` that previously routed every push through the operator unconditionally.

## What this does NOT do

- Does not change `/tmp` virtualization or any sandbox behaviour. This is a guidance fix only.
- Does not change the `gitExfil` guard, or any role or permission table.
- Does not make `gh pr checkout` or `gh pr create` available to model-driven bash. Both stay host-stage.
- Does not address the acknowledgement-schema half of the same incident — that is #1369.

## Review notes

The load-bearing check is that four mirrored surfaces stay in agreement: the full prompt, the slim prompt, and both GitHub skills. They drifted apart before, and an earlier revision of this PR fixed the prompts while leaving `typeclaw-channel-github` contradicting itself in the same file.

`src/agent/system-prompt.test.ts` now asserts the split on all four. The skill assertions are non-vacuous: before this change neither skill contained `push -u origin <branch>`, and the channel skill contained the blanket "cannot run `gh pr checkout` or authenticated `git push`" phrasing that the negative assertion now forbids.

The slim prompt is budget-constrained — `scripts/dump-system-prompt.test.ts` caps the cron prompt at 1000 tokens, and this lands at ~989. Wording added there has to earn its tokens.

Worth confirming the `workspace/` choice against your intent for the free-write zone: it is gitignored and host-mounted, which is what a durable operator handoff needs, but it does mean project clones now live inside the agent folder rather than outside it.
