### PR TITLE
Open a new logical turn for an injected wakeup

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -15611,6 +15611,89 @@ describe('ChannelRouter more_work_this_turn:true empty-stop recovery (phrase-ind
     expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(1)
   })
 
+  test('does not carry tool activity into a finished-subagent completion wake', async () => {
+    // given: the production incident. A PR turn spawned a background reviewer (a
+    // tool call) and deliberately ended silent, per the subagent contract. The
+    // reviewer finished, and the completion wake carrying its verdict died on a
+    // provider overload WITHOUT touching a tool. Turn A's tool activity must not
+    // license silence for the wake, or the verdict is lost with no signal at all.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '이 PR 리뷰해줘' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(0)
+
+    // when: the completion wake arrives and its prompt dies on the provider
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'server_is_overloaded' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    router.injectSubagentCompletionReminder({
+      parentSessionId: 'ses_fake_1',
+      subagent: 'reviewer',
+      taskId: 'bg_reviewer',
+      ok: true,
+      durationMs: 5_000,
+    })
+    await waitFor(() => sent.some((t) => t.startsWith('⚠️')))
+
+    // then: the wake ran as its own logical turn and its death is visible
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain('bg_reviewer')
+    expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(1)
+    expect(logs.some((m) => /provider_error_notice_suppressed reason=tool_activity_this_turn/.test(m))).toBe(false)
+  })
+
+  test('still carries tool activity across a retry nudge in the same logical turn', async () => {
+    // given: the negative half of the contract above. A retry nudge is the SAME
+    // logical turn trying again, so the tool activity that already ran does still
+    // license silence. Resetting indiscriminately on every reminder-only
+    // iteration would strand a false "provider failed" notice above real work.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '이 PR 다시 봐줘' }))
+    let promptAttempt = 0
+    sessions[0]!.onPrompt = () => {
+      promptAttempt++
+      if (promptAttempt === 1) {
+        sessions[0]!.emit({ type: 'tool_execution_start' })
+        sessions[0]!.setAssistantMidTurn('', 'length')
+        return
+      }
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'server_is_overloaded' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(promptAttempt).toBeGreaterThan(1)
+    expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(0)
+    expect(logs.some((m) => /provider_error_notice_suppressed reason=tool_activity_this_turn/.test(m))).toBe(true)
+  })
+
   test('keeps the deferred warning latched when recovery queues an empty-continuation nudge', async () => {
     const dir = await tempDir()
     const sent: string[] = []
@@ -16509,6 +16592,107 @@ describe('ChannelRouter background-child await suppression', () => {
     expect(sent).toEqual([ACK])
     expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
   })
+
+  test('a completion wake stays suppressed while an older sibling child is still running', async () => {
+    // given: two background children spawned in the same turn. A finishes and its
+    // completion wake arrives while B is STILL running. The wake opens a new
+    // logical turn, but the await-suppression gate must keep seeing B — otherwise
+    // the recovery ladder manufactures a status post for a session that is still
+    // legitimately waiting, which is the duplicate-comment failure f1f36462 fixed.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const nowRef = { value: CHILD_STARTED_AT }
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      nowRef,
+      newestRunningChildSubagentStartedAt: runningChild,
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toEqual([])
+
+    // when: the clock advances and child A's completion wakes the session
+    nowRef.value = CHILD_STARTED_AT + 60_000
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    router.injectSubagentCompletionReminder({
+      parentSessionId: 'ses_fake_1',
+      subagent: 'reviewer',
+      taskId: 'bg_child_a',
+      ok: true,
+      durationMs: 5_000,
+    })
+    await waitFor(() => sessions[0]!.prompts.length >= 2)
+
+    // then: sibling B still mutes the ladder — no manufactured post
+    expect(sent).toEqual([])
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_suppressed cause=awaiting_background_child'))).toBe(true)
+  })
+
+  for (const wakeupFirst of [true, false]) {
+    const order = wakeupFirst ? 'wakeup-then-retry' : 'retry-then-wakeup'
+    test(`a NO_REPLY wake in a mixed ${order} batch does not post a willingness fallback`, async () => {
+      // given: a willingness nudge (retry) and a completion wake coalesce into one
+      // reminder-only iteration. The wake wins the logical-turn boundary and clears
+      // the nudge budget, so the willingness bookkeeping describes a superseded
+      // turn. A legitimate NO_REPLY from the wake must not be read as a dropped
+      // promise from that older turn.
+      const dir = await tempDir()
+      const logs: string[] = []
+      const sent: string[] = []
+      const { router, sessions } = makeRouter(dir, { logs })
+      router.registerOutbound('discord-bot', async (msg) => {
+        sent.push(msg.text ?? '')
+        return { ok: true }
+      })
+
+      await router.route(inbound({ text: 'PR 좀 리뷰해줘' }))
+      let promptAttempt = 0
+      sessions[0]!.onPrompt = async () => {
+        promptAttempt++
+        if (promptAttempt === 1) {
+          await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '살펴볼게.' })
+          // Queued mid-drain so both land in the SAME next iteration; the drain is
+          // already running, so the completion wake will not start its own.
+          const queueWake = (): void => {
+            router.injectSubagentCompletionReminder({
+              parentSessionId: 'ses_fake_1',
+              subagent: 'reviewer',
+              taskId: 'bg_reviewer',
+              ok: true,
+              durationMs: 5_000,
+            })
+          }
+          const queueRetry = (): void => router.__testing!.injectContinuationReminder(KEY, WILLINGNESS_NUDGE)
+          if (wakeupFirst) {
+            queueWake()
+            queueRetry()
+          } else {
+            queueRetry()
+            queueWake()
+          }
+          sessions[0]!.setAssistantText('')
+          return
+        }
+        sessions[0]!.setAssistantText('NO_REPLY')
+      }
+      await router.__testing!.flushDebounce(KEY)
+
+      // then: the wake's deliberate silence is honored, not converted to a fallback
+      expect(promptAttempt).toBe(2)
+      expect(sent).toEqual(['살펴볼게.'])
+      expect(sent).not.toContain(EMPTY_TURN_FALLBACK_TEXT)
+      expect(logs.some((m) => m.includes('no_reply_after_willingness_nudge'))).toBe(false)
+    })
+  }
 
   test('a child past the stuck backstop stops suppressing and the normal retry resumes', async () => {
     const dir = await tempDir()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -782,6 +782,37 @@ type TimedAttachment = { ts: number; attachment: InboundAttachment }
 
 type ChannelAgentSession = AgentSession & { getAbortReason?: () => string | undefined }
 
+// Provenance of a queued system reminder, which decides whether the
+// reminder-only drain iteration it drives CONTINUES the current logical turn or
+// OPENS a new one.
+//
+// `retry` — the router's own turn-recovery ladder asking the SAME logical turn
+// to try again (empty-turn, tool-leak, stranded-tooluse, cold-start,
+// empty-stop, willingness). Per-logical-turn attribution and the recovery
+// budgets must survive these, or the ladder would refill its own budget and
+// loop forever.
+//
+// `wakeup` — work injected from OUTSIDE the session's own turn machinery: a
+// finished background subagent, a restart resume, a PR-verdict stand-down.
+// These are a new episode that merely happens to arrive without a user
+// message, so carrying the previous turn's attribution into them is wrong.
+//
+// The todo/idle continuation is deliberately `retry`, not `wakeup`: it is the
+// same work episode continuing, and its turn must keep citing the durable work
+// already completed.
+//
+// Provenance is per ENTRY rather than a single session-level flag because both
+// kinds can coalesce into one iteration; a wakeup in the batch opens a new
+// logical turn regardless of what else it rode in with. Matching on reminder
+// TEXT was rejected: a wakeup body that happened to equal a nudge constant
+// would silently misclassify, and every future enqueue site would inherit the
+// default instead of being forced to choose.
+type PendingSystemReminder = { text: string; kind: 'retry' | 'wakeup' }
+
+const retryReminder = (text: string): PendingSystemReminder => ({ text, kind: 'retry' })
+
+const wakeupReminder = (text: string): PendingSystemReminder => ({ text, kind: 'wakeup' })
+
 type LiveSession = {
   key: ChannelKey
   keyId: string
@@ -963,7 +994,7 @@ type LiveSession = {
   // every `drain()` iteration alongside the regular promptQueue batch;
   // the drain loop's run condition checks BOTH queues so a system
   // reminder alone is enough to trigger a turn.
-  pendingSystemReminders: string[]
+  pendingSystemReminders: PendingSystemReminder[]
   // True only for the reminder-only iteration that consumed a willingness
   // nudge. `willingnessNudges` persists across the logical turn, so it remains
   // nonzero after a substantive result and would misclassify NO_REPLY from a
@@ -2935,7 +2966,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
               logger.info(`[channels] ${live.keyId}: dropping todo continuation reminder after user stop`)
               return
             }
-            live.pendingSystemReminders.push(text)
+            // Self-continuation of the SAME work episode, not external injection:
+            // `qualifyingWorkThisLogicalTurn` must survive it so a follow-up reply
+            // can still cite the durable work this turn already did.
+            live.pendingSystemReminders.push(retryReminder(text))
           },
         })
       } catch (err) {
@@ -3222,6 +3256,49 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  // Open a new logical turn for externally-injected work that arrived without a
+  // user message. Deliberately a SUBSET of the fresh-batch reset above: only
+  // state whose meaning is scoped to "the episode that just ended" is cleared.
+  //
+  // `promisedWorkOutstandingThisLogicalTurn` is the notable survivor. A
+  // completion wakeup usually exists BECAUSE the agent promised a later result,
+  // and that promise is exactly what makes a silent death user-visible harm —
+  // clearing it here would re-open the hole this fix closes. It is cleared
+  // authoritatively by a terminal send instead.
+  //
+  // Author identity is restored by the caller's existing reminder branch and
+  // must not be reset: role resolution for the wakeup's own channel_reply
+  // depends on it. `stagedFallbackCause` and the question signals also survive —
+  // a wakeup can be the recovery opportunity a staged fallback was waiting for.
+  //
+  // `logicalTurnStartedAt` deliberately does NOT advance here. It exists solely
+  // as the boundary `isAwaitingBackgroundChild` compares a child's `startedAt`
+  // against, and advancing it would hide an older SIBLING child that is still
+  // running: one child's completion wake would stop counting as "awaiting", and
+  // the recovery ladder, todo continuation and staged fallback would all re-fire
+  // while that sibling still works — exactly the duplicate-comment failure
+  // f1f36462 fixed. The wake for A must stay silent while B runs; B's own
+  // completion is what ends the wait.
+  const beginWakeupTurn = (live: LiveSession): void => {
+    live.pendingProviderError = null
+    live.consecutiveSends.clear()
+    live.lastSentText.clear()
+    live.lastSendLeafId = null
+    // Safe to refill precisely because retry nudges are `kind: 'retry'` and
+    // never reach here: the ladder this wakeup turn may itself queue cannot
+    // refill its own budget, so there is no unbounded loop.
+    live.emptyTurnRetries = 0
+    live.toolLeakRetries = 0
+    live.emptyStopAfterToolWorkArmed = false
+    live.willingnessNudges = 0
+    live.abortReasonThisTurn = null
+    live.userStoppedTurnSeq = null
+    live.nextPromptMaxTokens = undefined
+    live.githubReviewOutputTurn = null
+    live.toolExecutionThisLogicalTurn = false
+    live.qualifyingWorkThisLogicalTurn = false
+  }
+
   const drain = async (live: LiveSession): Promise<void> => {
     if (live.draining || live.destroyed) return
     live.draining = true
@@ -3250,8 +3327,27 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const observed = live.contextBuffer.splice(0, live.contextBuffer.length)
         const reminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
         live.currentTurnAttachments = collectTurnAttachments(observed, batch)
+        // A reminder-only iteration carrying externally-injected work opens a
+        // NEW logical turn. Without this, the completed-subagent wakeup that
+        // follows a turn which spawned it inherits that turn's
+        // `toolExecutionThisLogicalTurn`, and a provider failure on the wakeup
+        // is misread as "the turn already ran tools, so it wasn't silent" —
+        // suppressing the notice for a prompt that ran no tool and produced
+        // nothing. Observed in production as a review verdict lost with zero
+        // user-visible signal. Retry nudges deliberately do NOT trip this: they
+        // ARE the same logical turn retrying.
+        const wakeupTurn = batch.length === 0 && reminders.some((r) => r.kind === 'wakeup')
+        // Gated on `!wakeupTurn` because a willingness nudge can coalesce into the
+        // same iteration as a wakeup. The wakeup wins the boundary and clears the
+        // nudge budget, so the willingness bookkeeping now describes a superseded
+        // turn — and a legitimate NO_REPLY from the wake (a PR stand-down, say)
+        // would otherwise post a bogus `no_reply_after_willingness_nudge`
+        // fallback. Same defect the branch that reads this flag already guards
+        // against for later unrelated reminders.
         live.willingnessReminderIteration =
-          batch.length === 0 && reminders.some((r) => r === WILLINGNESS_NUDGE || r === SEND_WILLINGNESS_NUDGE)
+          !wakeupTurn &&
+          batch.length === 0 &&
+          reminders.some((r) => r.text === WILLINGNESS_NUDGE || r.text === SEND_WILLINGNESS_NUDGE)
 
         if (batch.length > 0) {
           // A fresh user batch starts a NEW logical turn. Drop any provider
@@ -3328,6 +3424,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         } else {
           live.currentTurnEngageReactions = []
         }
+        // After the author-identity restore above, which a wakeup turn still needs.
+        if (wakeupTurn) beginWakeupTurn(live)
 
         // Update the live origin holder so this turn's tool.before events
         // carry the current actor's id, and resolve the live role from it for
@@ -3343,7 +3441,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           adapter: live.key.adapter,
           loopGuardActive: live.loopGuardActive,
           groupChatNudge: live.multiHumanGroup,
-          systemReminders: reminders,
+          systemReminders: reminders.map((r) => r.text),
           role: liveRole,
         })
 
@@ -3585,7 +3683,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     key: ChannelKey,
     inbounds: QueuedInbound[],
     observed: ObservedInbound[],
-    reminders: string[],
+    reminders: PendingSystemReminder[],
   ): Promise<void> => {
     // Observed context alone is carried too: observe() can buffer post-reload
     // messages onto contextBuffer with no queued prompt, and dropping them would
@@ -4904,7 +5002,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     logger.info(
       `[channels] ${live.keyId} willingness_nudge attempt=${live.willingnessNudges}/${MAX_WILLINGNESS_NUDGES}`,
     )
-    live.pendingSystemReminders.push(WILLINGNESS_NUDGE)
+    live.pendingSystemReminders.push(retryReminder(WILLINGNESS_NUDGE))
   }
 
   const validateChannelTurn = async (live: LiveSession, successfulSendsBeforePrompt: number): Promise<void> => {
@@ -4995,7 +5093,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           `[channels] ${live.keyId}: suppressed plain_text_tool_call_leak (nudge ` +
             `attempt=${live.toolLeakRetries}/${MAX_TOOL_LEAK_RETRIES}) text_len=${leakedText.length}`,
         )
-        live.pendingSystemReminders.push(TOOL_CALL_LEAK_NUDGE)
+        live.pendingSystemReminders.push(retryReminder(TOOL_CALL_LEAK_NUDGE))
         return
       }
       logger.warn(
@@ -5051,7 +5149,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             `[channels] ${live.keyId} send_willingness_nudge attempt=${live.willingnessNudges}/${MAX_WILLINGNESS_NUDGES} ` +
               `cause=empty_stop_after_continue_reply`,
           )
-          live.pendingSystemReminders.push(SEND_WILLINGNESS_NUDGE)
+          live.pendingSystemReminders.push(retryReminder(SEND_WILLINGNESS_NUDGE))
         } else {
           stageEmptyTurnFallback('empty_stop_after_continue_reply_nudges_exhausted')
         }
@@ -5087,7 +5185,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             `[channels] ${live.keyId} send_willingness_nudge attempt=${live.willingnessNudges}/${MAX_WILLINGNESS_NUDGES} ` +
               `cause=empty_stop_after_send_ack`,
           )
-          live.pendingSystemReminders.push(SEND_WILLINGNESS_NUDGE)
+          live.pendingSystemReminders.push(retryReminder(SEND_WILLINGNESS_NUDGE))
         } else {
           stageEmptyTurnFallback('empty_stop_after_send_ack_nudges_exhausted')
         }
@@ -5124,7 +5222,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
               `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
                 `cause=stranded_toolUse_after_send abort_reason=${abortReason}`,
             )
-            live.pendingSystemReminders.push(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
+            live.pendingSystemReminders.push(retryReminder(STRANDED_TOOLUSE_CONTINUATION_NUDGE))
           } else {
             await postEmptyTurnFallback(live, 'stranded_toolUse_retries_exhausted')
           }
@@ -5239,7 +5337,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
             `max_tokens=${live.nextPromptMaxTokens ?? CHANNEL_MAX_OUTPUT_TOKENS}`,
         )
-        live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
+        live.pendingSystemReminders.push(retryReminder(EMPTY_TURN_RETRY_NUDGE))
         return
       }
       await postEmptyTurnFallback(live, attemptedSendThisTurn ? 'send_thrash' : 'retries_exhausted')
@@ -5274,7 +5372,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
               `cause=cold_start_solo_bare_empty`,
           )
-          live.pendingSystemReminders.push(COLD_START_REPLY_NUDGE)
+          live.pendingSystemReminders.push(retryReminder(COLD_START_REPLY_NUDGE))
           return
         }
         await postEmptyTurnFallback(live, 'cold_start_solo_bare_empty_retries_exhausted')
@@ -5310,7 +5408,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
               `cause=empty_stop_after_tool_work`,
           )
-          live.pendingSystemReminders.push(EMPTY_STOP_AFTER_TOOL_WORK_NUDGE)
+          live.pendingSystemReminders.push(retryReminder(EMPTY_STOP_AFTER_TOOL_WORK_NUDGE))
           return
         }
         await postEmptyTurnFallback(live, 'empty_stop_after_tool_work_retries_exhausted')
@@ -5865,7 +5963,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // either way. Still skip the generic synthetic wake.
         if (reservation.sawInbound) {
           if (handoff.interruptedSubagents !== undefined && handoff.interruptedSubagents.length > 0) {
-            live.pendingSystemReminders.push(buildInterruptedSubagentNotice(handoff.interruptedSubagents))
+            live.pendingSystemReminders.push(
+              wakeupReminder(buildInterruptedSubagentNotice(handoff.interruptedSubagents)),
+            )
             logger.info(
               `[channels] ${keyId}: restart-resume coalesced with a real inbound; delivering interrupted-subagent notice`,
             )
@@ -5886,7 +5986,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           logger.error(`[channels] ${keyId}: restart-resume clear abort suppression failed: ${describeError(err)}`),
         )
 
-        live.pendingSystemReminders.push(buildRestartResumeWakeReminder(handoff.interruptedSubagents))
+        live.pendingSystemReminders.push(wakeupReminder(buildRestartResumeWakeReminder(handoff.interruptedSubagents)))
         logger.info(`[channels] ${keyId}: restart-resume waking session ${live.sessionId}`)
         void drain(live)
       },
@@ -5994,7 +6094,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       channel: true,
       adapter,
     })
-    live.pendingSystemReminders.push(text)
+    live.pendingSystemReminders.push(wakeupReminder(text))
     // The reminder tells the agent to fetch this result now; clear the
     // subagent_output window so an earlier premature-polling streak can't
     // hard-block that legitimate fetch.
@@ -6061,7 +6161,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // stand down from its own legitimate review.
       if (live.sessionId === args.sessionId) continue
       const text = renderPrVerdictStandDownReminder({ prNumber: args.prNumber, verdict: args.verdict })
-      live.pendingSystemReminders.push(text)
+      live.pendingSystemReminders.push(wakeupReminder(text))
       logger.info(`[channels] ${live.keyId}: pr-verdict stand-down queued pr=${chat} verdict=${args.verdict}`)
       if (!live.draining) void drain(live)
       count++
@@ -6445,7 +6545,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       injectContinuationReminder: (key: ChannelKey, text: string): void => {
         const live = liveSessions.get(channelKeyId(key))
         if (!live) return
-        live.pendingSystemReminders.push(text)
+        live.pendingSystemReminders.push(retryReminder(text))
       },
       enqueueUserInbound: (key: ChannelKey, event: InboundMessage): void => {
         const live = liveSessions.get(channelKeyId(key))


### PR DESCRIPTION
## Background

A GitHub-channel PR session silently lost a completed code-review verdict in production, then spent ~30 minutes insisting it was still working.

The sequence, from container logs on one PR session key:

```
1) prompting batch=1 text_len=1641
   skipped_by_tool reason="PR reviewer is running; formal verdict will be posted on completion"
   skipping todo continuation while background child runs
2) subagent-completion reminder queued task=bg_<id> ok=true
3) prompting batch=0 text_len=2075
   LLM call failed: Codex error: {"code":"server_is_overloaded", ...}
   provider_error_turn deferring to provider-error notice
   provider_error_notice_suppressed reason=tool_activity_this_turn
4) (x2 more, same suppression)
5) stale-rollover (live: 964860ms idle, past grace cap) -> ensureLive (cold-start)
   stale-rollover (live: 533159ms idle, base=0B delta=0B) -> ensureLive (cold-start)
```

Net effect: a terminal provider failure produced **zero** user-visible signal. The reviewer had finished (`ok=true`, exactly one `bg_` id ever minted for that PR, no child process alive), but its verdict died with the turn. The cold-started successor then read its own earlier *"reviewer is running, verdict on completion"* comment out of `prefetched 1 context messages`, concluded a run was in flight, and posted more "still analyzing" comments — each reassurance becoming the evidence for the next.

**Root cause.** A reminder-only drain iteration skips the `batch.length > 0` reset block, so it inherits the previous turn's `toolExecutionThisLogicalTurn`. That is deliberate and correct for the recovery ladder's own nudges — a retry *is* the same logical turn trying again, and the comment at the reset site explicitly warns that refilling budgets there would loop forever.

But the same code path also carries work injected from *outside* the turn. Turn (1) called a tool (spawning the reviewer) and ended silent per the subagent contract. Turn (3) — the completion wakeup — executed **zero** tools, but inherited the flag, so `maybePostDeferredProviderError` hit `toolExecutionThisLogicalTurn && !promisedWorkOutstandingThisLogicalTurn` and swallowed the notice. That branch's rationale ("a side effect may already be public") is simply false for a prompt that ran no tool and produced nothing.

## Summary

Give each queued system reminder a provenance — `retry` or `wakeup` — and let a wakeup open a new logical turn.

**Why per-entry provenance and not a text match.** Matching reminder bodies against the seven nudge constants misclassifies any wakeup whose text coincidentally equals one, and silently opts every future enqueue site into the wrong default. A per-entry `kind` forces each call site to choose, and survives coalescing: when a wakeup and a retry land in the same iteration, the wakeup wins and opens the boundary.

**Why not a single `retryQueued` session flag.** It cannot represent a mixed queue, and it is one more thing that can go stale.

**Why the reset is a subset of the fresh-batch one.** `promisedWorkOutstandingThisLogicalTurn` deliberately survives — a completion wake usually exists *because* the agent promised a later result, and that promise is exactly what makes dying silently user-visible harm. Clearing it would re-open the hole this PR closes. Author identity, the staged fallback, and the question signals survive for the same "this is not a fresh user batch" reason. Recovery budgets refill safely precisely because the nudges a wakeup turn may itself queue are `retry`-kind and never re-enter the reset.

**Why the todo/idle continuation stays `retry`.** It is the same work episode continuing, and an existing contract (`records only successful non-communication, non-control work as completion evidence`) requires `qualifyingWorkThisLogicalTurn` to survive it so a follow-up reply can still cite the durable work already done. Classifying it `wakeup` broke that test — a good catch by the existing suite.

## What this does NOT do

- **Does not re-deliver the wakeup a dead turn consumed.** Reminders are spliced out of `pendingSystemReminders` and destroyed if the turn dies, so the finished subagent's result is still lost during an outage. This PR makes that loss *visible* instead of silent. Bounded replay needs its own scheduling (a naive re-queue hot-loops against a down provider, since the drain `while` re-checks the queue immediately), plus teardown/rollover transfer of the retry metadata — deferred to a follow-up.
- Does not change what counts as a durable side effect for suppression purposes; the `any tool` heuristic is untouched.
- Does not touch stale-rollover, history prefetch, or add heuristics against an agent believing its own earlier status comments.

## Review notes

The load-bearing change is `wakeupTurn` in the drain loop plus `beginWakeupTurn`. The invariant to verify is the **pair** of new tests, which encode both directions:

- `does not carry tool activity into a finished-subagent completion wake` — the incident. Fails without the fix (times out waiting for the notice that never arrives, which is exactly the production symptom).
- `still carries tool activity across a retry nudge in the same logical turn` — the negative guard. Passes with or without the fix by design; it exists to fail if someone "simplifies" the fix into resetting on *every* reminder-only iteration, which would strand false failure notices above real work.

Verified by disabling the guard (`if (false && wakeupTurn)`): 714 pass, 1 fail — only the incident test.

Worth a careful look: `beginWakeupTurn` now stamps `logicalTurnStartedAt`, which `isAwaitingBackgroundChild` compares against. Intended consequence — an older still-running sibling child no longer makes a completion wake look like it is waiting on that sibling, so one child can no longer mute another child's finished result. This interacts directly with `f1f36462`.

Full suite: 12978 pass, 31 skip, 0 fail. Lint warnings unchanged from `main` (71, all pre-existing).
