### PR TITLE
Retry a capacity outage when no fallback ref remains

### DIFF
--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -210,7 +210,12 @@ const NETWORK_OR_5XX =
 // session drops, observer stalls, and network/5xx blips. It intentionally EXCLUDES
 // throttle/overload (429/503) — those mean "this ref is out of capacity now", so
 // they should fail OVER to another ref rather than burn same-ref retries — and
-// account-wide faults (auth/billing/quota/cyber_policy), which must surface. It
+// account-wide faults (auth/billing/quota/cyber_policy), which must surface.
+// NOTE the overload exclusion assumes a ref to fail over to EXISTS. When one does
+// not (last usable ref, or a single-ref chain), the callers apply their own
+// capacity backoff on top of this predicate rather than widening it — see
+// overloadRetryBudget in retry-same-ref.ts. Widening it here instead would make
+// every ref in a healthy chain burn retries before failing over. It
 // does NOT match context-overflow: that stays on the SDK compaction path and must
 // never be treated as a retryable provider failure.
 export function isRetryableSameRef(raw: string): boolean {

--- a/src/agent/retry-same-ref.test.ts
+++ b/src/agent/retry-same-ref.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import type { AgentSession } from './index'
 import {
   promptWithSameRefRetryOnly,
+  RESPONSIVE_OVERLOAD_RETRIES,
   retryBackoffMs,
   retryTurnAfterCompletedToolResult,
   retryTurnOnPersistentSession,
@@ -146,6 +147,26 @@ describe('retryTurnAfterCompletedToolResult', () => {
     expect(order).toEqual(['backoff-start', 'random', 'authorize', 'continue'])
   })
 
+  test('honors an explicit delay instead of the ordinary jitter curve', async () => {
+    const order: string[] = []
+    const { session } = sessionWith([{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }], async () => {
+      order.push('continue')
+    })
+
+    expect(
+      await retryTurnAfterCompletedToolResult(session, {
+        attempt: 0,
+        delayMs: 0,
+        random: () => {
+          order.push('random')
+          return 0
+        },
+        authorize: () => true,
+      }),
+    ).toBe(true)
+    expect(order).toEqual(['continue'])
+  })
+
   test('fails closed without mutation for unsafe transcript tails', async () => {
     const unsafeTails = [
       [{ role: 'toolResult' }],
@@ -232,7 +253,7 @@ describe('RETRIES_PER_REF', () => {
   })
 })
 
-type PromptScript = Array<'soft-transient' | 'hard-transient' | 'hard-auth' | 'success'>
+type PromptScript = Array<'soft-transient' | 'soft-overload' | 'hard-transient' | 'hard-auth' | 'success'>
 
 function promptFake(script: PromptScript) {
   const listeners = new Set<(event: { type: string; message?: unknown }) => void>()
@@ -247,10 +268,11 @@ function promptFake(script: PromptScript) {
       messages.push({ role: 'assistant', stopReason: 'error' })
       throw new Error('socket hang up')
     }
-    if (behavior === 'soft-transient') {
+    if (behavior === 'soft-transient' || behavior === 'soft-overload') {
       messages.push({ role: 'assistant', stopReason: 'error' })
+      const errorMessage = behavior === 'soft-overload' ? 'server_is_overloaded' : 'ECONNRESET'
       for (const cb of listeners)
-        cb({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: 'ECONNRESET' } })
+        cb({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage } })
       return
     }
     messages.push({ role: 'assistant', stopReason: 'stop' })
@@ -302,6 +324,21 @@ describe('promptWithSameRefRetryOnly', () => {
     const fake = promptFake(['success'])
     await promptWithSameRefRetryOnly(fake.session, 'hi')
     expect(fake.attempts()).toBe(1)
+  })
+
+  test('rides out an overload on the default policy — there is no ref to fail over to', async () => {
+    const fake = promptFake(['soft-overload', 'success'])
+    const result = await promptWithSameRefRetryOnly(fake.session, 'hi', undefined, { overloadBackoffMs: () => 0 })
+    expect(result.success).toBe(true)
+    expect(fake.attempts()).toBe(2)
+    expect(fake.userMessages()).toBe(1)
+  })
+
+  test('gives up on a sustained overload once the responsive budget is spent', async () => {
+    const fake = promptFake(['soft-overload'])
+    const result = await promptWithSameRefRetryOnly(fake.session, 'hi', undefined, { overloadBackoffMs: () => 0 })
+    expect(result.success).toBe(false)
+    expect(fake.attempts()).toBe(RESPONSIVE_OVERLOAD_RETRIES + 1)
   })
 
   test('surfaces the original hard error when the retry recipe cannot apply (no phantom success)', async () => {

--- a/src/agent/retry-same-ref.ts
+++ b/src/agent/retry-same-ref.ts
@@ -15,24 +15,28 @@ const MAX_DELAY_MS = 5_000
 // How much added latency a call site can absorb before the caller would rather
 // see a failure. Deliberately NOT the model-profile name: the retry layer cares
 // about latency tolerance, not which tier the operator configured. 'responsive'
-// is every interactive path (channel chat, TUI, slash commands, cron) and keeps
-// the historical fast-fail behavior; 'patient' is a background path where a
-// human is already waiting minutes for a considered answer. Today the only
-// producer is a subagent whose REQUESTED profile is `deep` (reviewer,
-// researcher) — see resolveRetryPolicy in subagents.ts.
+// is every interactive path (channel chat, TUI, slash commands, multimodal
+// look-at); 'patient' is a background path where a human is already waiting
+// minutes for a considered answer. Today the only producer of 'patient' is a
+// subagent whose REQUESTED profile is `deep` (reviewer, researcher) — see
+// subagents.ts. Cron does NOT flow through here: it rebuilds a fresh session per
+// attempt via promptWithFallback (model-fallback.ts), so a capacity wait can't
+// push one scheduled run into the next.
 export type RetryPolicy = 'responsive' | 'patient'
 
-// Capacity backoff, used ONLY for throttle/overload under the 'patient' policy.
-// Kept separate from retryBackoffMs above on purpose: that curve (1–5s) is sized
-// for a one-off socket blip, and widening it globally would add dead air to the
-// TUI, slash commands, multimodal look-at, cron, and ordinary network errors.
-// An overload is a capacity outage measured in minutes, not milliseconds — the
-// incident that motivated this burned every retry in 4 seconds against a ~60s
-// outage — so it gets its own, much longer curve.
+// Capacity backoff, used ONLY for throttle/overload and ONLY on the last usable
+// ref. Kept separate from retryBackoffMs above on purpose: that curve (1–5s) is
+// sized for a one-off socket blip, and widening it globally would add dead air
+// to ordinary network errors too.
 //
-// Nominal delays are 10s, 20s, 30s, 30s, 30s, 30s (±20% jitter), so six retries
-// span roughly 120–180s of waiting and place the last attempt late enough to
-// outlive a two-minute blip.
+// Overload is normally handled by failing OVER (isRetryableSameRef excludes it),
+// so this curve only exists for the case where there is no other ref to reach:
+// a single-ref chain, or the tail of an exhausted one. Both policies get a
+// curve; they differ in how long the caller can stand to wait.
+//
+// 'patient': nominal 10s, 20s, 30s, 30s, 30s, 30s (±20% jitter), so six retries
+// span roughly 120–180s and place the last attempt late enough to outlive a
+// two-minute blip.
 export const PATIENT_OVERLOAD_RETRIES = 6
 const PATIENT_OVERLOAD_BASE_MS = 10_000
 const PATIENT_OVERLOAD_CAP_MS = 30_000
@@ -42,13 +46,61 @@ const PATIENT_OVERLOAD_CAP_MS = 30_000
 // inside the 30m reviewer/researcher spawn timeout.
 export const PATIENT_OVERLOAD_WINDOW_MS = 180_000
 
+// 'responsive': nominal 5s then 10s (±20% jitter), so two retries add at most
+// ~18s of scheduled waiting. Sized against a LIVE chat turn, where the channel
+// is already showing a typing indicator: short enough to read as thinking rather
+// than as a hang (and far inside the 120s typing-silence cap), long enough to
+// clear the intermittent capacity dips that make up the common case — the
+// incident that motivated this saw ~14% of turns fail while 85% succeeded around
+// them, so most single failures had a healthy provider seconds later.
+//
+// It deliberately does NOT try to outlive a sustained multi-minute outage. That
+// is what failing over to another ref is for; when no such ref exists, surfacing
+// the notice a few seconds later beats holding a chat thread for minutes.
+export const RESPONSIVE_OVERLOAD_RETRIES = 2
+const RESPONSIVE_OVERLOAD_BASE_MS = 5_000
+const RESPONSIVE_OVERLOAD_CAP_MS = 10_000
+export const RESPONSIVE_OVERLOAD_WINDOW_MS = 25_000
+
 // Proportional (±20%) rather than full jitter: full jitter can return ~0ms,
 // which against a capacity outage means retrying instantly into the same wall.
 // The floor keeps every wait meaningful while still decorrelating concurrent
-// subagents recovering from one upstream blip.
+// callers recovering from one upstream blip.
+function proportionalJitter(nominalMs: number, random: () => number): number {
+  return Math.floor(nominalMs * (0.8 + random() * 0.4))
+}
+
 export function patientOverloadBackoffMs(attempt: number, random: () => number = Math.random): number {
-  const nominal = Math.min(PATIENT_OVERLOAD_CAP_MS, PATIENT_OVERLOAD_BASE_MS * 2 ** attempt)
-  return Math.floor(nominal * (0.8 + random() * 0.4))
+  return proportionalJitter(Math.min(PATIENT_OVERLOAD_CAP_MS, PATIENT_OVERLOAD_BASE_MS * 2 ** attempt), random)
+}
+
+export function responsiveOverloadBackoffMs(attempt: number, random: () => number = Math.random): number {
+  return proportionalJitter(Math.min(RESPONSIVE_OVERLOAD_CAP_MS, RESPONSIVE_OVERLOAD_BASE_MS * 2 ** attempt), random)
+}
+
+export type OverloadRetryBudget = {
+  retries: number
+  windowMs: number
+  backoffMs: (attempt: number, random?: () => number) => number
+}
+
+// Single source of truth for "how long may this caller wait out a capacity
+// outage it cannot fail over from". An omitted policy resolves to 'responsive':
+// the safe default is the short curve, so a new call site that never thought
+// about retries still recovers from a blip instead of dropping the turn.
+export function overloadRetryBudget(policy: RetryPolicy | undefined): OverloadRetryBudget {
+  if (policy === 'patient') {
+    return {
+      retries: PATIENT_OVERLOAD_RETRIES,
+      windowMs: PATIENT_OVERLOAD_WINDOW_MS,
+      backoffMs: (attempt, random) => patientOverloadBackoffMs(attempt, random ?? Math.random),
+    }
+  }
+  return {
+    retries: RESPONSIVE_OVERLOAD_RETRIES,
+    windowMs: RESPONSIVE_OVERLOAD_WINDOW_MS,
+    backoffMs: (attempt, random) => responsiveOverloadBackoffMs(attempt, random ?? Math.random),
+  }
 }
 
 // Full-jitter exponential backoff: random in [0, min(cap, base·2^attempt)].
@@ -131,6 +183,12 @@ export async function retryTurnAfterCompletedToolResult(
     random?: () => number
     authorize: () => boolean
     onBackoffStart?: () => void
+    // Overrides the ordinary jittered backoff, exactly as in
+    // retryTurnOnPersistentSession. A capacity retry has already chosen its
+    // delay from the policy budget; without this the post-tool path would fall
+    // back to the 1–5s blip curve (which can jitter to ~0ms) and start
+    // hammering an overloaded ref far sooner than the budget advertises.
+    delayMs?: number
   },
 ): Promise<boolean> {
   const agent = (session as { agent?: ContinuableAgent }).agent
@@ -138,7 +196,7 @@ export async function retryTurnAfterCompletedToolResult(
   if (!hasCompletedToolResultErrorTail(agent.state?.messages)) return false
 
   opts.onBackoffStart?.()
-  await sleep(retryBackoffMs(opts.attempt, opts.random), opts.signal)
+  await sleep(opts.delayMs ?? retryBackoffMs(opts.attempt, opts.random), opts.signal)
   if (opts.signal?.aborted) return false
 
   // Re-read after the backoff: another actor may have advanced the transcript
@@ -202,10 +260,11 @@ export async function promptWithSameRefRetryOnly(
     retryPolicy?: RetryPolicy
     random?: () => number
     now?: () => number
-    patientBackoffMs?: (attempt: number) => number
+    overloadBackoffMs?: (attempt: number) => number
   } = {},
 ): Promise<SameRefPromptResult> {
   const now = opts.now ?? (() => performance.now())
+  const overloadBudget = overloadRetryBudget(opts.retryPolicy)
   let softError: Error | undefined
   // Feature-detect subscribe: some lightweight call sites / test fakes pass a
   // session without an event stream. Without it we simply can't observe soft
@@ -223,7 +282,7 @@ export async function promptWithSameRefRetryOnly(
     let priorHardError: Error | undefined
     let lastError: Error | undefined
     let overloadRetries = 0
-    let patientWindowStartedAt: number | undefined
+    let overloadWindowStartedAt: number | undefined
     let nextDelayMs: number | undefined
     for (let attempt = 0; ; attempt++) {
       softError = undefined
@@ -249,25 +308,25 @@ export async function promptWithSameRefRetryOnly(
       const error = hardError ?? softError
       if (error === undefined) return { success: true }
       lastError = error
-      // A patient call site rides out a capacity outage on the same ref: there is
-      // no cross-ref failover on this path, so declining to retry an overload
+      // Every call site here rides out a capacity outage on the same ref: there
+      // is no cross-ref failover on this path, so declining to retry an overload
       // (isRetryableSameRef excludes it, expecting failover to handle it) would
-      // leave it with no recovery at all.
+      // leave it with no recovery at all. How long it may wait comes from the
+      // policy's budget — see overloadRetryBudget.
       // The delay is budgeted BEFORE the retry is accepted: an elapsed-only check
       // would let a retry taken just under the deadline sleep past it.
       const nowMs = now()
-      const patientDelayMs =
-        opts.retryPolicy === 'patient' && isThrottleOrOverload(error.message)
-          ? (opts.patientBackoffMs ?? ((n: number) => patientOverloadBackoffMs(n, opts.random)))(overloadRetries)
-          : undefined
-      const patientElapsedMs = patientWindowStartedAt === undefined ? 0 : nowMs - patientWindowStartedAt
-      const patientOverload =
-        patientDelayMs !== undefined &&
-        overloadRetries < PATIENT_OVERLOAD_RETRIES &&
-        patientElapsedMs + patientDelayMs <= PATIENT_OVERLOAD_WINDOW_MS
-      if (patientOverload) {
-        patientWindowStartedAt ??= nowMs
-        nextDelayMs = patientDelayMs
+      const overloadDelayMs = isThrottleOrOverload(error.message)
+        ? (opts.overloadBackoffMs ?? ((n: number) => overloadBudget.backoffMs(n, opts.random)))(overloadRetries)
+        : undefined
+      const overloadElapsedMs = overloadWindowStartedAt === undefined ? 0 : nowMs - overloadWindowStartedAt
+      const overloadRetry =
+        overloadDelayMs !== undefined &&
+        overloadRetries < overloadBudget.retries &&
+        overloadElapsedMs + overloadDelayMs <= overloadBudget.windowMs
+      if (overloadRetry) {
+        overloadWindowStartedAt ??= nowMs
+        nextDelayMs = overloadDelayMs
         overloadRetries++
       } else if (attempt < RETRIES_PER_REF && isRetryableSameRef(error.message)) {
         nextDelayMs = undefined

--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -4,7 +4,12 @@ import type { ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
 import { isFailoverWorthy } from './provider-error'
-import { PATIENT_OVERLOAD_RETRIES, PATIENT_OVERLOAD_WINDOW_MS } from './retry-same-ref'
+import {
+  PATIENT_OVERLOAD_RETRIES,
+  PATIENT_OVERLOAD_WINDOW_MS,
+  RESPONSIVE_OVERLOAD_RETRIES,
+  RESPONSIVE_OVERLOAD_WINDOW_MS,
+} from './retry-same-ref'
 import { ThrottleCircuit } from './throttle-circuit'
 import { promptPersistentTurnWithFallback } from './turn-runner'
 
@@ -906,6 +911,68 @@ describe('promptPersistentTurnWithFallback same-ref retry', () => {
     expect(messages.filter((message) => message.role === 'user')).toHaveLength(1)
   })
 
+  test('an authorized post-tool capacity retry waits the selected overload delay', async () => {
+    // given: an overload arriving right after a completed tool result, and a
+    // retryRandom that would make the ORDINARY blip curve sleep its 1000ms max.
+    // The overload budget picks 0ms, so consulting retryRandom at all means the
+    // post-tool path fell back to the wrong curve.
+    const listeners = new Set<(event: FakeEvent) => void>()
+    const messages: Array<{ role: string; stopReason?: string }> = []
+    let continueCalls = 0
+    let randomCalls = 0
+    const session = {
+      prompt: async () => {
+        messages.push(
+          { role: 'user' },
+          { role: 'assistant', stopReason: 'toolUse' },
+          { role: 'toolResult' },
+          { role: 'assistant', stopReason: 'error' },
+        )
+        for (const cb of listeners) cb({ type: 'tool_execution_start' })
+        for (const cb of listeners) cb({ type: 'tool_execution_end' })
+        for (const cb of listeners) {
+          cb({
+            type: 'message_end',
+            message: { role: 'assistant', stopReason: 'error', errorMessage: 'server_is_overloaded' },
+          })
+        }
+      },
+      subscribe: (cb: (event: FakeEvent) => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+      agent: {
+        state: { messages },
+        continue: async () => {
+          continueCalls++
+          messages.push({ role: 'assistant', stopReason: 'stop' })
+        },
+      },
+    } as unknown as AgentSession
+
+    const startedAt = performance.now()
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      authorizeRetryAfterCompletedToolResult: () => true,
+      overloadBackoffMs: () => 0,
+      retryRandom: () => {
+        randomCalls++
+        return 1
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(continueCalls).toBe(1)
+    expect(randomCalls).toBe(0)
+    expect(performance.now() - startedAt).toBeLessThan(500)
+  })
+
   test('authorization alone cannot retry an unsafe transcript tail', async () => {
     const listeners = new Set<(event: FakeEvent) => void>()
     const messages = [{ role: 'user' }, { role: 'assistant', stopReason: 'error' }]
@@ -1161,12 +1228,12 @@ describe('promptPersistentTurnWithFallback same-ref retry', () => {
   })
 })
 
-describe('promptPersistentTurnWithFallback patient overload retry', () => {
+describe('promptPersistentTurnWithFallback overload retry on the last usable ref', () => {
   const patientOpts = {
     circuit: new ThrottleCircuit(),
     shouldFailover: (err: Error) => isFailoverWorthy(err.message),
     setModelForRef: async () => {},
-    patientBackoffMs: () => 0,
+    overloadBackoffMs: () => 0,
   }
 
   test('rides out a capacity outage on a single-ref chain and recovers', async () => {
@@ -1185,8 +1252,40 @@ describe('promptPersistentTurnWithFallback patient overload retry', () => {
     expect(fake.attempts()).toBe(4)
   })
 
-  test('a responsive call site still fails fast on the same outage', async () => {
-    const fake = retryableFakeSession(['soft-throttle', 'soft-throttle', 'soft-throttle', 'success'])
+  test('a responsive call site rides out a brief dip on a single-ref chain', async () => {
+    const fake = retryableFakeSession(['soft-throttle', 'soft-throttle', 'success'])
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'hi',
+      retryPolicy: 'responsive',
+    })
+
+    expect(result.success).toBe(true)
+    expect(fake.attempts()).toBe(3)
+    expect(fake.userMessages()).toBe(1)
+  })
+
+  test('omitting retryPolicy still recovers, on the responsive budget', async () => {
+    const fake = retryableFakeSession(['soft-throttle', 'success'])
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'hi',
+    })
+
+    expect(result.success).toBe(true)
+    expect(fake.attempts()).toBe(2)
+  })
+
+  test('gives up once the responsive retry budget is exhausted', async () => {
+    const fake = retryableFakeSession(['soft-throttle'])
 
     const result = await promptPersistentTurnWithFallback({
       ...patientOpts,
@@ -1198,22 +1297,33 @@ describe('promptPersistentTurnWithFallback patient overload retry', () => {
     })
 
     expect(result.success).toBe(false)
-    expect(fake.attempts()).toBe(1)
+    expect(fake.attempts()).toBe(RESPONSIVE_OVERLOAD_RETRIES + 1)
   })
 
-  test('omitting retryPolicy keeps the historical fast-fail behavior', async () => {
+  test('a responsive turn waits far less than a patient one', async () => {
+    expect(RESPONSIVE_OVERLOAD_RETRIES).toBeLessThan(PATIENT_OVERLOAD_RETRIES)
+    expect(RESPONSIVE_OVERLOAD_WINDOW_MS).toBeLessThan(PATIENT_OVERLOAD_WINDOW_MS)
+  })
+
+  test('a responsive non-terminal ref fails OVER instead of waiting', async () => {
     const fake = retryableFakeSession(['soft-throttle', 'success'])
+    const attemptedRefs: ModelRef[] = []
 
     const result = await promptPersistentTurnWithFallback({
       ...patientOpts,
-      refs: [ANTHROPIC_REF],
-      currentModelRef: ANTHROPIC_REF,
+      refs: [REF_A, ANTHROPIC_REF],
+      currentModelRef: REF_A,
       session: fake.session,
       text: 'hi',
+      retryPolicy: 'responsive',
+      beforeAttempt: (ref) => {
+        attemptedRefs.push(ref)
+      },
     })
 
-    expect(result.success).toBe(false)
-    expect(fake.attempts()).toBe(1)
+    expect(result.success).toBe(true)
+    expect(attemptedRefs).toEqual([REF_A, ANTHROPIC_REF])
+    expect(fake.attempts()).toBe(2)
   })
 
   test('gives up once the patient retry budget is exhausted', async () => {
@@ -1270,7 +1380,7 @@ describe('promptPersistentTurnWithFallback patient overload retry', () => {
       session: fake.session,
       text: 'review this',
       retryPolicy: 'patient',
-      patientBackoffMs: () => BACKOFF_MS,
+      overloadBackoffMs: () => BACKOFF_MS,
       now: () => clock,
     })
 

--- a/src/agent/turn-runner.ts
+++ b/src/agent/turn-runner.ts
@@ -9,9 +9,7 @@ import {
   subscribeProviderErrors,
 } from './provider-error'
 import {
-  PATIENT_OVERLOAD_RETRIES,
-  PATIENT_OVERLOAD_WINDOW_MS,
-  patientOverloadBackoffMs,
+  overloadRetryBudget,
   RETRIES_PER_REF,
   retryTurnAfterCompletedToolResult,
   retryTurnOnPersistentSession,
@@ -61,7 +59,7 @@ export async function promptPersistentTurnWithFallback(opts: {
   detectSoftErrorFromLeaf?: boolean
   authorizeRetryAfterCompletedToolResult?: () => boolean
   retryRandom?: () => number
-  patientBackoffMs?: (attempt: number) => number
+  overloadBackoffMs?: (attempt: number) => number
   onRetryBackoffStart?: () => void
   beforeAttempt?: (ref: ModelRef) => void
   onAttemptFailed?: (attempt: PersistentTurnAttempt) => void
@@ -80,6 +78,7 @@ export async function promptPersistentTurnWithFallback(opts: {
   // NTP/system-clock correction the way Date.now() can, which would otherwise
   // prematurely trip or stall the 60s cap.
   const now = opts.now ?? (() => performance.now())
+  const overloadBudget = overloadRetryBudget(opts.retryPolicy)
   const hasNonCodexFallback = opts.refs.some((ref) => !isCodexRef(ref))
   let noHeaderAttempts = 0
   let cumulativeNoProgressMs = 0
@@ -127,7 +126,7 @@ export async function promptPersistentTurnWithFallback(opts: {
       let outcome: AttemptOutcome | undefined
       let retryAfterCompletedToolResult = false
       let overloadRetries = 0
-      let patientWindowStartedAt: number | undefined
+      let overloadWindowStartedAt: number | undefined
       let nextDelayMs: number | undefined
       for (let retry = 0; ; retry++) {
         softError = undefined
@@ -175,23 +174,28 @@ export async function promptPersistentTurnWithFallback(opts: {
         // is to fail OVER rather than burn same-ref retries — which is why
         // isRetryableSameRef excludes it. But on the LAST usable ref there is
         // nothing to fail over to, and a single-ref chain is all last, so that
-        // policy leaves a capacity outage with no recovery whatsoever. A patient
-        // call site rides it out here instead; a responsive one still fails fast.
+        // policy would leave a capacity outage with no recovery whatsoever: the
+        // turn dies on its first attempt in seconds and the caller drops the
+        // user's message. Both policies therefore ride it out here, differing
+        // only in how long (see overloadRetryBudget) — patient for minutes,
+        // responsive for a live-chat-sized handful of seconds.
         // Budget the delay BEFORE accepting the retry. Testing only the elapsed
         // window lets a retry accepted just under the deadline sleep past it, so
         // the next provider attempt would START after the window we advertise.
         const nowMs = now()
-        const patientDelayMs =
-          opts.retryPolicy === 'patient' && isLast && isThrottleOrOverload(outcome.error.message)
-            ? (opts.patientBackoffMs ?? ((n: number) => patientOverloadBackoffMs(n, opts.retryRandom)))(overloadRetries)
+        const overloadDelayMs =
+          isLast && isThrottleOrOverload(outcome.error.message)
+            ? (opts.overloadBackoffMs ?? ((n: number) => overloadBudget.backoffMs(n, opts.retryRandom)))(
+                overloadRetries,
+              )
             : undefined
-        const patientElapsedMs = patientWindowStartedAt === undefined ? 0 : nowMs - patientWindowStartedAt
-        const patientOverload =
-          patientDelayMs !== undefined &&
-          overloadRetries < PATIENT_OVERLOAD_RETRIES &&
-          patientElapsedMs + patientDelayMs <= PATIENT_OVERLOAD_WINDOW_MS
+        const overloadElapsedMs = overloadWindowStartedAt === undefined ? 0 : nowMs - overloadWindowStartedAt
+        const overloadRetry =
+          overloadDelayMs !== undefined &&
+          overloadRetries < overloadBudget.retries &&
+          overloadElapsedMs + overloadDelayMs <= overloadBudget.windowMs
         const retryableWithinBudget =
-          patientOverload || (retry < RETRIES_PER_REF && isRetryableSameRef(outcome.error.message))
+          overloadRetry || (retry < RETRIES_PER_REF && isRetryableSameRef(outcome.error.message))
         const mayRetryWithoutActivity = !activity.producedAssistantOutput && !activity.startedToolExecution
         retryAfterCompletedToolResult =
           retryableWithinBudget &&
@@ -199,9 +203,9 @@ export async function promptPersistentTurnWithFallback(opts: {
           opts.authorizeRetryAfterCompletedToolResult?.() === true
         const mayRetry = retryableWithinBudget && (mayRetryWithoutActivity || retryAfterCompletedToolResult)
         if (!mayRetry) break
-        if (patientOverload) {
-          patientWindowStartedAt ??= nowMs
-          nextDelayMs = patientDelayMs
+        if (overloadRetry) {
+          overloadWindowStartedAt ??= nowMs
+          nextDelayMs = overloadDelayMs
           overloadRetries++
         } else {
           nextDelayMs = undefined


### PR DESCRIPTION
## Background

An agent configured against a single provider (all model refs on one provider) took 39 `server_is_overloaded` soft errors over 12h — 14% of 269 turns, 17 in the final 20 minutes. Each failed channel turn died on its first attempt in 2.4–3.6s and posted a user-visible notice, `:warning: The upstream LLM provider failed.`, discarding the user's message with no retry and no queue. Two consecutive messages in one thread each got the notice 7s apart. Crucially, 85% of turns succeeded throughout that window, so these were intermittent capacity dips and nearly every failure had a healthy provider seconds later.

The overload arrives as an in-stream SSE error frame (HTTP status 200, `retry_after: null`), so no transport-level retry or Retry-After handling can ever fire — it has to be handled at the turn-runner layer.

**Root cause.** Overload (429/503/`server_is_overloaded`) is deliberately excluded from same-ref retry (`isRetryableSameRef`), because the standing policy is to fail OVER to another ref rather than hammer one that is out of capacity. That policy silently assumed a ref to fail over to exists. `turn-runner.ts` already computed `isLast` for exactly the no-failover-target case, but gated the capacity backoff on `retryPolicy === 'patient'`, which only deep subagents use — every interactive caller fast-failed an overload it could not fail over from. `promptWithSameRefRetryOnly` (TUI, slash commands, multimodal look-at, subagent drains) has no chain at all, so it was in this position permanently.

## Summary

Give both retry policies a capacity-outage budget on the last usable ref, differing only in how long.

**Why not just configure a cross-provider fallback chain?** That works, but it's a per-agent config workaround; the code defect is that "don't retry, fail over" degrades to "do nothing" whenever the chain has one usable ref. Any single-provider agent hits it.

**Why not give channels the existing `patient` policy?** Its window is 180s — up to three minutes of dead air in a live chat thread. Wrong tool.

**Why not a third `immediate` RetryPolicy value** (seriously considered)? Its main justification was that cron needs to stay fast-fail so a capacity wait can't push one scheduled run into the next — but cron does not flow through these APIs at all. It rebuilds a fresh session per attempt via `promptWithFallback` (model-fallback.ts) and never passes a retryPolicy. With that premise gone, a third value would mean renaming an existing documented concept and re-pointing five call sites across a module already shaped by two prior incidents — more regression risk than the behavior change itself. Every remaining `responsive` consumer (channel router, TUI x2, slash commands, multimodal look-at, non-deep subagents) is a human-waiting path where ~15s beats an error notice.

**Why 2 retries / nominal 5s then 10s / 25s window?** Sized against a live chat turn that is already showing a typing indicator: worst case ~18s of scheduled waiting, far inside the 120s typing-silence cap, enough to clear the intermittent dips that are the common case. It deliberately does not try to outlive a sustained multi-minute outage — that's what failover is for.

## What this does NOT do

- Does not change cron (untouched by design; a capacity wait there could overlap the next scheduled run).
- Does not change failover: a non-terminal ref still advances immediately instead of waiting.
- Does not change circuit-breaker semantics: throttle is still recorded once per abandoned ref, so one turn cannot self-trip it.
- Does not re-enqueue or replay a message whose turn ultimately fails; an exhausted budget still surfaces exactly one provider-error notice.
- Does not widen `isRetryableSameRef` (see the third commit for why that would be wrong).
- Does not touch any agent's configuration.

## Review notes

The load-bearing change is one condition in `src/agent/turn-runner.ts`: dropping `opts.retryPolicy === 'patient' &&` from the overload-backoff guard. Everything else is the budget lookup and renames.

Invariant to verify: overload must still fail over immediately when a usable next ref exists — only the last usable ref waits. Covered by "a responsive non-terminal ref fails OVER instead of waiting".

Two existing tests pinned the old fast-fail behavior verbatim and were rewritten; that's the intended behavior change, not collateral.

`subscribeProviderErrors` calls `session.abortRetry()` on overload — that kills the SDK's reaction to the current SSE frame; the typeclaw-owned `agent.continue()` replay is separate and unaffected.

Full suite: 12990 pass, 0 fail, 13021 tests across 604 files. `bun run typecheck`, `bun run lint` (0 errors), and `bun run format` all clean.
