### PR TITLE
Require bunx for one-off package binaries

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -3382,7 +3382,7 @@ describe('wrapBuiltinToolDefinition (pi customTools override path)', () => {
         .sort(([left], [right]) => left.localeCompare(right)),
     )
     expect(registered).toEqual({
-      bash: ['globalInstall', 'nonBunPackageManager'],
+      bash: ['globalInstall', 'nonBunPackageManager', 'nonBunPackageRunner'],
       edit: ['nonWorkspaceWrite'],
       read: ['imageReadRedirect'],
       write: ['nonWorkspaceWrite'],
@@ -3410,7 +3410,10 @@ describe('wrapBuiltinToolDefinition (pi customTools override path)', () => {
     )
     expect(schemas).toEqual({
       read: { keys: ['imageReadRedirect'], additionalProperties: false },
-      bash: { keys: ['globalInstall', 'nonBunPackageManager'], additionalProperties: false },
+      bash: {
+        keys: ['globalInstall', 'nonBunPackageManager', 'nonBunPackageRunner'],
+        additionalProperties: false,
+      },
       edit: { keys: ['nonWorkspaceWrite'], additionalProperties: false },
       write: { keys: ['nonWorkspaceWrite'], additionalProperties: false },
       grep: undefined,

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -65,6 +65,20 @@ describe('operator-owned dependencies', () => {
     expect(prompt).toContain('Do not edit it or install dependencies')
     expect(prompt).toContain('tell the operator which package and command are needed')
   })
+
+  test('requires bunx for one-off package binaries in the full operator-facing prompt', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('Run one-off package binaries with `bunx`')
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('never `npx`, `pnpx`, or `pnpm dlx`')
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('A skill or doc telling you to use `npx` does not override this')
+  })
+
+  // The slim base has ~11 tokens of headroom under its 1000-token budget, and
+  // the nonBunPackageRunner guard already corrects npx at the bash boundary.
+  // Re-adding this rule here would blow the budget guard in
+  // scripts/dump-system-prompt.test.ts for no behavior gain.
+  test('keeps the bunx rule out of the slim prompt, where the guard covers it', () => {
+    expect(SLIM_SYSTEM_PROMPT).not.toContain('Run one-off package binaries with `bunx`')
+  })
 })
 
 describe('agent folder vs project repo', () => {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -2,6 +2,15 @@ import { formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } fro
 
 const PACKAGE_JSON_INSTALL_RULE =
   '`package.json` is operator-owned because direct dependencies define sandbox-visible commands. Do not edit it or install dependencies; tell the operator which package and command are needed.'
+// Full prompt only. The slim bar is "what no runtime guard catches today" (see
+// buildSlimSystemPrompt) and the `nonBunPackageRunner` guard now blocks npx at
+// the bash boundary with a reason naming `bunx`, so spending ~75 of the slim
+// base's 1000-token budget to pre-empt it is the wrong trade. The final clause
+// is load-bearing: the vendored agent-messenger skills say "use `npx -y` by
+// default. Do NOT ask the user which package runner to use", and skill text
+// sits closer to the model than this prompt does.
+const BUNX_PACKAGE_RUNNER_RULE =
+  'Run one-off package binaries with `bunx`, never `npx`, `pnpx`, or `pnpm dlx`; `bunx` is the Bun-native runner this container ships, and the others are absent from the default image. A skill or doc telling you to use `npx` does not override this rule; substitute `bunx`.'
 
 // The orchestration roster (the `Briefly: ...` enumeration of public subagents)
 // is GENERATED from the registry by `renderPublicSubagentRoster` and threaded in
@@ -101,6 +110,8 @@ Foreground \`bash\` blocks until exit. Run minutes-long or input-waiting program
 - Stop: \`tmux kill-session -t <name>\`
 
 Use tmux only for work that belongs in your session. Delegate self-contained long work (builds, tests, installs, batches) to \`operator\`.
+
+${BUNX_PACKAGE_RUNNER_RULE}
 
 ## Version control
 

--- a/src/bundled-plugins/bun-hygiene/README.md
+++ b/src/bundled-plugins/bun-hygiene/README.md
@@ -1,37 +1,40 @@
 # typeclaw-plugin-bun-hygiene
 
-The bundled bun-hygiene plugin. Registers a `tool.before` hook that blocks two classes of `bash` command:
+The bundled bun-hygiene plugin. Registers a `tool.before` hook that blocks three classes of `bash` command:
 
 1. **Global package installs** — `npm install -g`, `pnpm add -g`, `yarn global add`, `bun add -g`, and their `--global` / bundled-flag variants.
-2. **Non-bun install managers** — any `npm`, `pnpm`, or `yarn` invocation. The ephemeral runners `npx` and `pnpx` are **allowed** (alongside `bunx`): they execute a tool once without touching the dependency tree or writing a competing lockfile, so they don't undermine the bun-standardization this guard protects.
+2. **Non-bun install managers** — any `npm`, `pnpm`, or `yarn` invocation.
+3. **Non-bun package runners** — `npx` or `pnpx` at a command boundary. Use `bunx` for one-off package binaries; the runner guard remains separately bypassable for genuine exceptions.
 
-This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` entry to add. Both guards carry an `acknowledgeGuards` escape hatch (below) for the cases where the agent genuinely needs the blocked command.
+This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` entry to add. All three guards carry an `acknowledgeGuards` escape hatch (below) for the cases where the agent genuinely needs the blocked command.
 
 ## Why it exists
 
 **Global installs don't persist.** The agent folder is bind-mounted at `/agent`; everything else in the container — including `~/.bun`, `~/.npm`, and the global `node_modules` a global install writes to — is ephemeral and wiped on every `typeclaw restart`. An agent that runs `npm install -g some-cli` gets a tool that works for the rest of the session and silently vanishes on the next boot, leading to confusing "command not found" failures that look like regressions. The fix is to either add the dependency to `package.json` (`bun add <pkg>`, which lives in the bind-mounted folder and survives) or run it once without installing (`bunx <pkg>`).
 
-**The container standardizes on bun for dependency management.** TypeClaw is Bun-native end to end (see the root README). Mixing in `npm`/`pnpm`/`yarn` installs produces competing lockfiles and install trees, so those are steered to bun. Ephemeral runners (`npx`/`pnpx`/`bunx`) are not install managers — they run a tool once and leave no lockfile or `node_modules` behind — so they're allowed for one-off execution.
+**The container standardizes on bun for package execution.** TypeClaw is Bun-native end to end (see the root README). Mixing in `npm`/`pnpm`/`yarn` installs produces competing lockfiles and install trees, so those are steered to bun. For one-off package binaries, `bunx` is the Bun-native equivalent and the only package runner the default image ships: `oven/bun:1-slim` provides `bun`, the `bunx` symlink, and a `node` fallback shim, but no `npm`, `npx`, `pnpm`, or `pnpx`. Reaching for one of those either fails outright or, in a custom image that supplies them, runs with npm/pnpm semantics rather than bun's — so the guard steers them to `bunx` instead of treating them as equivalent spellings.
 
-Both guards **block with guidance** rather than silently rewriting the command — the agent sees exactly why the command was rejected and what to run instead, the same UX as the bundled `security` and `guard` policies.
+All three guards **block with guidance** rather than silently rewriting the command — the agent sees exactly why the command was rejected and what to run instead, the same UX as the bundled `security` and `guard` policies.
 
 ## Guards
 
-| Guard                  | Triggers on                                                                                       | Guidance in the block reason                                           |
-| ---------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `globalInstall`        | `npm`/`pnpm` install/add with `-g`/`--global`, `yarn global add`, `bun add -g` / `bun install -g` | Use `bun add <pkg>` (persists) or `bunx <pkg>` (ephemeral run).        |
-| `nonBunPackageManager` | `npm`, `pnpm`, `yarn` at a command boundary (`npx`/`pnpx`/`bunx` are allowed)                     | Use `bun install` / `bun add <pkg>`. Ephemeral runners are fine as-is. |
+| Guard                  | Triggers on                                                                                       | Guidance in the block reason                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `globalInstall`        | `npm`/`pnpm` install/add with `-g`/`--global`, `yarn global add`, `bun add -g` / `bun install -g` | Use `bun add <pkg>` (persists) or `bunx <pkg>` (ephemeral run). |
+| `nonBunPackageManager` | `npm`, `pnpm`, `yarn` at a command boundary                                                       | Use `bun install` / `bun add <pkg>`; use `bunx` for one-offs.   |
+| `nonBunPackageRunner`  | `npx`, `pnpx` at a command boundary                                                               | Use `bunx <pkg>` for one-off package binaries.                  |
 
-A global install (e.g. `npm install -g x`) trips **only** `globalInstall`, not both — the global install is the more specific violation, so acknowledging `globalInstall` lets the command through without a second acknowledgement for `nonBunPackageManager`.
+A global install (e.g. `npm install -g x`) trips **only** `globalInstall`, not both — the global install is the more specific violation, so acknowledging `globalInstall` lets that install through without a second acknowledgement for `nonBunPackageManager`. That subsumption is scoped to the segment the global install appears in: in `bun add -g foo && npx tsc`, acknowledging `globalInstall` still leaves the `npx` segment blocked on `nonBunPackageRunner`.
 
 ## Bypass
 
-Both guards follow the repo-wide `acknowledgeGuards` convention (shared with the `security` and `guard` plugins). To run a blocked command intentionally, pass the matching flag in the `bash` tool arguments:
+All three guards follow the repo-wide `acknowledgeGuards` convention (shared with the `security` and `guard` plugins). To run a blocked command intentionally, pass the matching flag in the `bash` tool arguments:
 
 ```jsonc
 // bash tool args
 { "command": "npm install", "acknowledgeGuards": { "nonBunPackageManager": true } }
 { "command": "npm install -g some-cli", "acknowledgeGuards": { "globalInstall": true } }
+{ "command": "npx tsc", "acknowledgeGuards": { "nonBunPackageRunner": true } }
 ```
 
 ## How it works
@@ -45,13 +48,14 @@ For each segment, the guard strips leading **preamble wrappers** (`sudo`, `env`,
 
 1. command word is `npm`/`pnpm`/`yarn` (or `bun`) **and** the segment has an install subcommand **and** a global flag → `globalInstall` (for `yarn`, the `global add` sequence must appear adjacent and in command position, so `yarn add global foo` — a local install of a package named `global` — is not misflagged);
 2. command word is a non-bun install manager `npm`/`pnpm`/`yarn` (not via global) → `nonBunPackageManager`;
-3. otherwise (including the ephemeral runners `npx`/`pnpx`/`bunx`) → allowed.
+3. command word is a non-bun package runner `npx`/`pnpx` → `nonBunPackageRunner`;
+4. otherwise (including `bunx` and `bun x`) → allowed.
 
-A `globalInstall` verdict on any segment wins over a plain non-bun verdict. This is a command-position detector, not a full shell parser — it doesn't interpret redirections or expansions beyond boundary marking — but it is linear-time and closes the structural gaps a single regex left open.
+Every segment is classified and the verdicts are returned in precedence order — `globalInstall`, then `nonBunPackageManager`, then `nonBunPackageRunner` — with the guard blocking on the first one that is not acknowledged. A global install suppresses the manager verdict for **its own segment only**, so acknowledging one verdict surfaces the next rather than clearing violations elsewhere in the command. This is a command-position detector, not a full shell parser — it doesn't interpret redirections or expansions beyond boundary marking — but it is linear-time and closes the structural gaps a single regex left open.
 
 ## Scope: not a security boundary
 
-This guard is a **hygiene nudge**, not an isolation mechanism. It deliberately does not chase manager invocations hidden inside a wrapper's code payload — `sh -c 'npm install'`, `bash -lc "pnpm add foo"`, `python -c '...os.system("npx tsc")'`, `node -e`, `eval`, `base64 | sh`, etc. That set is unbounded (any interpreter can reach any binary), and inspecting arbitrary `-c`/`-e` payloads is an arms race with diminishing returns and rising false-positive risk. An agent that genuinely wants a package manager can always reach one; the guard's job is to steer the common, direct invocations toward bun and to stop accidental global installs. The real isolation boundary is the per-tool **bwrap sandbox** (see `/docs/internals/sandbox`), not this policy. Optioned preamble _wrappers_ (`env -i`, `sudo -u`, `nice -n`) are handled because they prefix a real command word that the tokenizer can still see; code-payload wrappers are not, by design.
+This guard is a **hygiene nudge**, not an isolation mechanism. It deliberately does not chase manager or runner invocations hidden inside a wrapper's code payload — `sh -c 'npm install'`, `bash -lc "pnpm add foo"`, `python -c '...os.system("npx tsc")'`, `node -e`, `eval`, `base64 | sh`, etc. That set is unbounded (any interpreter can reach any binary), and inspecting arbitrary `-c`/`-e` payloads is an arms race with diminishing returns and rising false-positive risk. An agent that genuinely needs another package command can still reach one through the acknowledgement escape hatch; the guard's job is to steer common, direct invocations toward bun and to stop accidental global installs. The real isolation boundary is the per-tool **bwrap sandbox** (see `/docs/internals/sandbox`), not this policy. Optioned preamble _wrappers_ (`env -i`, `sudo -u`, `nice -n`) are handled because they prefix a real command word that the tokenizer can still see; code-payload wrappers are not, by design.
 
 ## Why a tokenizer, not a regex
 
@@ -70,8 +74,7 @@ Because classification scans a segment's words as a set (after preamble strippin
 ## What is NOT blocked
 
 - `bun`, `bunx`, `bun run`, `bun add`, `bun install` (local) — the intended package commands. (`bun add -g` / `bun install -g` are still blocked as global installs: bun globals live in `~/.bun`, outside `/agent`, and are wiped on restart.)
-- `npx`, `pnpx` — ephemeral runners, allowed for one-off tool execution (they leave no lockfile or install tree). A global install through them is still nothing to block since they don't install into the dependency tree at all.
-- A non-bun manager name appearing as a substring or argument: `my-npm-wrapper`, `./npm`, `cat npm-debug.log`, `git commit -m "drop npm"`, `grep -rn npx src/`, `echo "npm install -g foo"`. Only the **command word** of a segment is classified, so a manager name inside an argument, path, quoted string, or longer token never trips the guard.
+- A non-bun manager or runner name appearing as a substring or argument: `my-npm-wrapper`, `./npm`, `cat npm-debug.log`, `git commit -m "drop npm"`, `grep -rn npx src/`, `echo "npm install -g foo"`. Only the **command word** of a segment is classified, so a package command name inside an argument, path, quoted string, or longer token never trips the guard.
 
 ## Ordering against other bundled plugins
 
@@ -79,5 +82,5 @@ Registered after `guard` in `src/run/bundled-plugins.ts`. It guards a disjoint s
 
 ## Tests
 
-- `policy.test.ts` — pure-function unit tests for the detection logic: every global-install form, every non-bun install manager, the ephemeral-runner allowance (`npx`/`pnpx`/`bunx`, including behind preamble wrappers), the allowed-command set (bun/bunx, substrings, paths, quoted text), both bypasses, the global-install-takes-precedence rule, escaped/quoted evasions, leading-assignment preambles, newline-as-separator scoping, falsy `--global=`, option placement, and subshell/substitution detection.
-- `index.test.ts` — composition tests: the plugin registers the `tool.before` hook and wires it to the policy (block on global install, block on `npm install`, allow `bunx`/`npx`, honor the bypass).
+- `policy.test.ts` — pure-function unit tests for the detection logic: every global-install form, every non-bun install manager, `npx`/`pnpx` runner blocking (including behind preamble wrappers), the allowed-command set (`bunx`, `bun x`, substrings, paths, quoted text), all bypasses, guard precedence, escaped/quoted evasions, leading-assignment preambles, newline-as-separator scoping, falsy `--global=`, option placement, and subshell/substitution detection.
+- `index.test.ts` — composition tests: the plugin registers the `tool.before` hook and wires it to the policy (block on global install, `npm install`, and `npx`; allow `bunx`; honor the bypass).

--- a/src/bundled-plugins/bun-hygiene/index.test.ts
+++ b/src/bundled-plugins/bun-hygiene/index.test.ts
@@ -17,17 +17,18 @@ describe('bun-hygiene plugin', () => {
     expect(result?.reason).toContain('globalInstall')
   })
 
-  test('blocks non-bun install managers and allows bun + ephemeral runners through the hook', async () => {
+  test('blocks non-bun install managers and runners while allowing bunx through the hook', async () => {
     const hook = await toolBeforeHook()
 
     const blocked = await hook(toolEvent('bash', { command: 'npm install' }), hookContext())
     const allowedBunx = await hook(toolEvent('bash', { command: 'bunx create-next-app' }), hookContext())
-    const allowedNpx = await hook(toolEvent('bash', { command: 'npx create-next-app' }), hookContext())
+    const blockedNpx = await hook(toolEvent('bash', { command: 'npx create-next-app' }), hookContext())
 
     expect(blocked?.block).toBe(true)
     expect(blocked?.reason).toContain('nonBunPackageManager')
     expect(allowedBunx).toBeUndefined()
-    expect(allowedNpx).toBeUndefined()
+    expect(blockedNpx?.block).toBe(true)
+    expect(blockedNpx?.reason).toContain('nonBunPackageRunner')
   })
 
   test('respects the acknowledgeGuards bypass', async () => {

--- a/src/bundled-plugins/bun-hygiene/index.ts
+++ b/src/bundled-plugins/bun-hygiene/index.ts
@@ -1,11 +1,17 @@
 import { definePlugin } from '@/plugin'
 
-import { GUARD_GLOBAL_INSTALL, GUARD_NON_BUN_PACKAGE_MANAGER, checkBunHygieneGuard } from './policy'
+import {
+  GUARD_GLOBAL_INSTALL,
+  GUARD_NON_BUN_PACKAGE_MANAGER,
+  GUARD_NON_BUN_PACKAGE_RUNNER,
+  checkBunHygieneGuard,
+} from './policy'
 
 export default definePlugin({
   guardAcknowledgements: [
     { key: GUARD_GLOBAL_INSTALL, tools: ['bash'] },
     { key: GUARD_NON_BUN_PACKAGE_MANAGER, tools: ['bash'] },
+    { key: GUARD_NON_BUN_PACKAGE_RUNNER, tools: ['bash'] },
   ],
   plugin: async () => ({
     hooks: {

--- a/src/bundled-plugins/bun-hygiene/policy.test.ts
+++ b/src/bundled-plugins/bun-hygiene/policy.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
 import { ACKNOWLEDGE_GUARDS } from '../guard/policy'
-import { GUARD_GLOBAL_INSTALL, GUARD_NON_BUN_PACKAGE_MANAGER, checkBunHygieneGuard } from './policy'
+import {
+  GUARD_GLOBAL_INSTALL,
+  GUARD_NON_BUN_PACKAGE_MANAGER,
+  GUARD_NON_BUN_PACKAGE_RUNNER,
+  checkBunHygieneGuard,
+} from './policy'
 
 function bash(command: string, extra: Record<string, unknown> = {}) {
   return checkBunHygieneGuard({ tool: 'bash', args: { command, ...extra } })
@@ -57,12 +62,12 @@ describe('checkBunHygieneGuard — non-bun package managers', () => {
     expect(result?.reason).toContain(GUARD_NON_BUN_PACKAGE_MANAGER)
   })
 
-  // npx/pnpx are ephemeral runners: allowed for one-off tool execution because
-  // they don't touch the dependency tree or write a competing lockfile.
   test.each(['npx create-next-app', 'pnpx cowsay hi', 'cd app && npx tsc', 'echo done; npx tsc'])(
-    'allows ephemeral runner %p',
+    'blocks non-bun runner %p',
     (command) => {
-      expect(bash(command)).toBeUndefined()
+      const result = bash(command)
+      expect(result?.block).toBe(true)
+      expect(result?.reason).toContain(GUARD_NON_BUN_PACKAGE_RUNNER)
     },
   )
 
@@ -81,6 +86,65 @@ describe('checkBunHygieneGuard — non-bun package managers', () => {
       [ACKNOWLEDGE_GUARDS]: { [GUARD_GLOBAL_INSTALL]: true },
     })
     expect(acknowledged).toBeUndefined()
+  })
+
+  // The global-install verdict subsumes the manager verdict only within its own
+  // segment. Regression guard: classify() used to return early on the first
+  // global install, which dropped every later segment's verdict — so a lone
+  // globalInstall acknowledgement silently ran the runner segment too.
+  test('acknowledging a compound command global install still surfaces its runner violation', () => {
+    expect(bash('bun add -g foo && npx tsc')?.reason).toContain(GUARD_GLOBAL_INSTALL)
+
+    const globalAcknowledged = bash('bun add -g foo && npx tsc', {
+      [ACKNOWLEDGE_GUARDS]: { [GUARD_GLOBAL_INSTALL]: true },
+    })
+    expect(globalAcknowledged?.reason).toContain(GUARD_NON_BUN_PACKAGE_RUNNER)
+
+    const bothAcknowledged = bash('bun add -g foo && npx tsc', {
+      [ACKNOWLEDGE_GUARDS]: { [GUARD_GLOBAL_INSTALL]: true, [GUARD_NON_BUN_PACKAGE_RUNNER]: true },
+    })
+    expect(bothAcknowledged).toBeUndefined()
+  })
+
+  // Same scoping rule for a manager in a different segment: the global install
+  // clears its own segment, not the separate `pnpm install`.
+  test('acknowledging a global install still surfaces a manager violation elsewhere', () => {
+    const globalAcknowledged = bash('npm install -g typescript && pnpm install', {
+      [ACKNOWLEDGE_GUARDS]: { [GUARD_GLOBAL_INSTALL]: true },
+    })
+    expect(globalAcknowledged?.reason).toContain(GUARD_NON_BUN_PACKAGE_MANAGER)
+  })
+
+  test('non-bun manager takes precedence over a non-bun runner', () => {
+    expect(bash('npm install && npx tsc')?.reason).toContain(GUARD_NON_BUN_PACKAGE_MANAGER)
+
+    const managerAcknowledged = bash('npm install && npx tsc', {
+      [ACKNOWLEDGE_GUARDS]: { [GUARD_NON_BUN_PACKAGE_MANAGER]: true },
+    })
+    expect(managerAcknowledged?.reason).toContain(GUARD_NON_BUN_PACKAGE_RUNNER)
+  })
+})
+
+describe('checkBunHygieneGuard — non-bun package runners', () => {
+  test('block reason explains bunx and the exact bypass', () => {
+    const result = bash('npx tsc')
+    expect(result?.reason).toContain(GUARD_NON_BUN_PACKAGE_RUNNER)
+    expect(result?.reason).toContain('Bun-native equivalent')
+    expect(result?.reason).toContain('absent from the default image')
+    expect(result?.reason).toContain('`bunx <pkg>`')
+    expect(result?.reason).toContain(`${ACKNOWLEDGE_GUARDS}.${GUARD_NON_BUN_PACKAGE_RUNNER}: true`)
+  })
+
+  test('acknowledging nonBunPackageRunner lets it through', () => {
+    expect(
+      bash('npx tsc', {
+        [ACKNOWLEDGE_GUARDS]: { [GUARD_NON_BUN_PACKAGE_RUNNER]: true },
+      }),
+    ).toBeUndefined()
+  })
+
+  test.each(['\\npx tsc', '"npx" tsc', 'FOO=bar npx tsc', 'sudo npx tsc'])('blocks obfuscated runner %p', (command) => {
+    expect(bash(command)?.reason).toContain(GUARD_NON_BUN_PACKAGE_RUNNER)
   })
 })
 
@@ -148,16 +212,19 @@ describe('checkBunHygieneGuard — leading assignment / preamble words', () => {
 
   // The wrapper's consumed argument must not be mistaken for the command word:
   // `sudo -u nobody ls` runs ls (allowed), not a manager.
-  test.each([
-    'nice -n 10 echo hi',
-    'sudo -u nobody ls -g',
-    'env -i sh',
-    'stdbuf -oL cat x',
-    'nice -n 10 npx create-next-app',
-    'sudo -u nobody pnpx cowsay hi',
-  ])('does not block wrapped non-manager command %p', (command) => {
-    expect(bash(command)).toBeUndefined()
-  })
+  test.each(['nice -n 10 echo hi', 'sudo -u nobody ls -g', 'env -i sh', 'stdbuf -oL cat x'])(
+    'does not block wrapped non-manager command %p',
+    (command) => {
+      expect(bash(command)).toBeUndefined()
+    },
+  )
+
+  test.each(['nice -n 10 npx create-next-app', 'sudo -u nobody pnpx cowsay hi'])(
+    'blocks wrapped non-bun runner %p',
+    (command) => {
+      expect(bash(command)?.reason).toContain(GUARD_NON_BUN_PACKAGE_RUNNER)
+    },
+  )
 })
 
 describe('checkBunHygieneGuard — newline is a command separator', () => {
@@ -267,9 +334,7 @@ describe('checkBunHygieneGuard — allowed commands', () => {
     'bun add -d typescript',
     'bunx tsc',
     'bunx create-next-app my-app',
-    'npx tsc',
-    'npx create-next-app my-app',
-    'pnpx cowsay hi',
+    'bun x cowsay hi',
     'bun run build',
     'ls -g',
     './npm-wrapper.sh',
@@ -280,6 +345,10 @@ describe('checkBunHygieneGuard — allowed commands', () => {
     'grep -rn npx src/',
   ])('allows %p', (command) => {
     expect(bash(command)).toBeUndefined()
+  })
+
+  test.each(['npx tsc', 'npx create-next-app my-app', 'pnpx cowsay hi'])('blocks non-bun runner %p', (command) => {
+    expect(bash(command)?.reason).toContain(GUARD_NON_BUN_PACKAGE_RUNNER)
   })
 })
 

--- a/src/bundled-plugins/bun-hygiene/policy.ts
+++ b/src/bundled-plugins/bun-hygiene/policy.ts
@@ -2,13 +2,21 @@ import { ACKNOWLEDGE_GUARDS, type GuardBlock, isGuardAcknowledged } from '../gua
 
 export const GUARD_GLOBAL_INSTALL = 'globalInstall'
 export const GUARD_NON_BUN_PACKAGE_MANAGER = 'nonBunPackageManager'
+export const GUARD_NON_BUN_PACKAGE_RUNNER = 'nonBunPackageRunner'
 
-// Only install managers are blocked. The ephemeral runners npx/pnpx (and bunx,
-// which is `bun`) are intentionally absent: they run a tool once without
-// touching the dependency tree or writing a competing lockfile, so they don't
-// undermine the bun-standardization this set protects. classify() skips any
-// command word not in here, so leaving them out is what allows them.
+// Install managers write competing lockfiles and install trees, so they are
+// steered to bun.
 const NON_BUN_MANAGERS = new Set(['npm', 'pnpm', 'yarn'])
+// The runners were previously allowed on the argument that they leave no
+// lockfile or install tree behind. True, but that argument only covers
+// dependency-tree pollution — it says nothing about which command word runs,
+// and in practice "allowed" became "default": the vendored agent-messenger
+// skills instruct the agent to use `npx -y` and explicitly not to deliberate
+// about the runner, so nothing downstream ever got to prefer bunx. They stay
+// reachable through their own acknowledgement rather than being allowed
+// outright. `pnpm dlx` and `bun x` are two-word forms: the former already
+// blocks as a manager, the latter is bun and is fine.
+const NON_BUN_RUNNERS = new Set(['npx', 'pnpx'])
 const INSTALL_SUBCOMMANDS = new Set(['install', 'i', 'add'])
 
 export function checkBunHygieneGuard(options: { tool: string; args: Record<string, unknown> }): GuardBlock | undefined {
@@ -18,13 +26,23 @@ export function checkBunHygieneGuard(options: { tool: string; args: Record<strin
   const command = args.command
   if (typeof command !== 'string') return undefined
 
-  const verdict = classify(command)
-  if (verdict === undefined) return undefined
-  if (verdict.kind === 'global-install') return blockGlobalInstall(verdict.label, args)
-  return blockNonBunManager(verdict.manager, args)
+  for (const verdict of classify(command)) {
+    const block = blockFor(verdict, args)
+    if (block !== undefined) return block
+  }
+  return undefined
 }
 
-type Verdict = { kind: 'global-install'; label: string } | { kind: 'non-bun'; manager: string }
+function blockFor(verdict: Verdict, args: Record<string, unknown>): GuardBlock | undefined {
+  if (verdict.kind === 'global-install') return blockGlobalInstall(verdict.label, args)
+  if (verdict.kind === 'non-bun') return blockNonBunManager(verdict.manager, args)
+  return blockNonBunRunner(verdict.runner, args)
+}
+
+type Verdict =
+  | { kind: 'global-install'; label: string }
+  | { kind: 'non-bun'; manager: string }
+  | { kind: 'non-bun-runner'; runner: string }
 
 // Why a segment model instead of one big regex: every gap in a raw-string match
 // is a shell-structure gap. Splitting into segments first means a global flag on
@@ -33,24 +51,44 @@ type Verdict = { kind: 'global-install'; label: string } | { kind: 'non-bun'; ma
 // stripped uniformly, and `--global=false` is inspected as a real token. The
 // global-install verdict wins over the plain non-bun verdict (it's the more
 // specific violation, and acknowledging it is meant to let the whole thing run).
-function classify(command: string): Verdict | undefined {
-  let fallback: Verdict | undefined
+// Verdicts come back in precedence order and the caller stops at the first one
+// that is not acknowledged. Falling through matters: `npm install && npx tsc`
+// has two independent problems, so acknowledging the manager must still leave
+// the runner blocked rather than clearing the whole command.
+function classify(command: string): Verdict[] {
+  let globalVerdict: Verdict | undefined
+  let managerVerdict: Verdict | undefined
+  let runnerVerdict: Verdict | undefined
   for (const segment of splitSegments(command)) {
     const words = segment.map(normalizeWord)
-    const manager = leadingCommandWord(words)
-    if (manager === undefined) continue
+    const commandWord = leadingCommandWord(words)
+    if (commandWord === undefined) continue
+
+    if (NON_BUN_RUNNERS.has(commandWord)) {
+      runnerVerdict ??= { kind: 'non-bun-runner', runner: commandWord }
+      continue
+    }
 
     // `bun` is the allowed manager, but a `bun add -g` still installs to ~/.bun
     // (outside /agent) and is wiped on restart, so it is a global install too —
     // just never a plain non-bun violation.
-    const isBun = manager === 'bun'
-    if (!isBun && !NON_BUN_MANAGERS.has(manager)) continue
+    const isBun = commandWord === 'bun'
+    if (!isBun && !NON_BUN_MANAGERS.has(commandWord)) continue
 
-    const label = globalInstallLabel(manager, words)
-    if (label !== undefined) return { kind: 'global-install', label }
-    if (!isBun) fallback ??= { kind: 'non-bun', manager }
+    // A global install subsumes the manager verdict for ITS OWN segment only:
+    // acknowledging `npm install -g x` is meant to let that install run without
+    // demanding a second acknowledgement for the same words. Scoping it to the
+    // segment is what stops it from clearing violations elsewhere in the
+    // command — an early return here let `bun add -g foo && npx tsc` through on
+    // a lone globalInstall acknowledgement.
+    const label = globalInstallLabel(commandWord, words)
+    if (label !== undefined) {
+      globalVerdict ??= { kind: 'global-install', label }
+      continue
+    }
+    if (!isBun) managerVerdict ??= { kind: 'non-bun', manager: commandWord }
   }
-  return fallback
+  return [globalVerdict, managerVerdict, runnerVerdict].filter((verdict): verdict is Verdict => verdict !== undefined)
 }
 
 // Split on real command separators (`;`, `&&`, `||`, `|`, `&`, newline, `\r`)
@@ -316,8 +354,22 @@ function blockNonBunManager(manager: string, args: Record<string, unknown>): Gua
     block: true,
     reason: [
       `Guard \`${GUARD_NON_BUN_PACKAGE_MANAGER}\` blocked \`${manager}\`. This container standardizes on bun for dependency management.`,
-      'Use `bun install` / `bun add <pkg>` instead of npm/pnpm/yarn. Ephemeral runners (`bunx`, `npx`, `pnpx`) are allowed for one-off tool execution.',
+      'Use `bun install` / `bun add <pkg>` instead of npm/pnpm/yarn, and use `bunx <pkg>` for one-off tool execution.',
       `Retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_NON_BUN_PACKAGE_MANAGER}: true\` if this package manager is genuinely required (e.g. a project pinned to a different lockfile).`,
+    ].join(' '),
+  }
+}
+
+function blockNonBunRunner(runner: string, args: Record<string, unknown>): GuardBlock | undefined {
+  if (isGuardAcknowledged(args, GUARD_NON_BUN_PACKAGE_RUNNER)) return undefined
+
+  return {
+    block: true,
+    reason: [
+      `Guard \`${GUARD_NON_BUN_PACKAGE_RUNNER}\` blocked \`${runner}\`.`,
+      'This container standardizes on bun for package execution: `bunx` is the Bun-native equivalent and the package runner the image actually ships. `npx`/`pnpx` are absent from the default image, and where a custom image supplies them they carry npm/pnpm semantics rather than bun ones.',
+      'Use `bunx <pkg>` for one-off package binaries.',
+      `Retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_NON_BUN_PACKAGE_RUNNER}: true\` only if this non-bun runner is genuinely required.`,
     ].join(' '),
   }
 }


### PR DESCRIPTION
## Background

An agent session reached for `npx -y agent-messenger slack ...` instead of
`bunx`, then admitted in a PR comment that it had picked the wrong CLI path.
Root-cause analysis found three independent layers, none of which steered it
to bun:

1. **The vendored agent-messenger skills default to the npm runner.** All 17
   skills in the pinned `agent-messenger` release do. Eight say verbatim:
   "use `npx -y` by default. Do NOT ask the user which package runner to
   use — just run it." Four more say "run it directly with `npx -y`" with
   only a soft note about other runners. The remaining four never show
   `bunx` in a positive example at all — the only place it appears is
   inside a "NEVER run bunx agent-instagram" warning. These skills are
   hash-locked from an upstream repo, so they can't be fixed here; editing
   them locally is overwritten on the next skills update.
2. **The `bun-hygiene` guard explicitly allowed the runners.** Its README
   argued the case in five separate places: the runners leave no lockfile
   or install tree behind, so they don't undermine bun-standardization.
   True, but that argument only covers dependency-tree pollution — it says
   nothing about which command word runs.
3. **The system prompt carried no bun preference at all.** `git log
   -S"bunx" --all` on the prompt file returns zero commits — it was never
   removed, it never existed. The only bunx guidance in the repo lived in
   the `typeclaw-skills` skill, which loads lazily and so is absent from
   context during ordinary channel work.

Layer 1 is unfixable in this repo and is the strongest signal the model
sees — skill text sits closer to the model than the system prompt — which
is why a prompt line alone was judged insufficient and the guard needed to
change too.

## Summary

Blocks the npm-style runners **by default** while keeping them
**reachable** for genuine exceptions, via the existing repo-wide
`acknowledgeGuards` bash param — no new bypass mechanism.

Before, the guard's own block reason said the runners were fine as-is:

```
Guard nonBunPackageManager blocked npm. ... Ephemeral runners
(bunx, npx, pnpx) are allowed for one-off tool execution.
```

Now running the npm-style runner trips a dedicated guard:

```
Guard nonBunPackageRunner blocked npx. This container standardizes on
bun for package execution: bunx is the Bun-native equivalent and the
package runner the image actually ships. npx/pnpx are absent from the
default image, and where a custom image supplies them they carry
npm/pnpm semantics rather than bun ones. Use bunx <pkg> for one-off
package binaries. Retry with acknowledgeGuards.nonBunPackageRunner:
true only if this non-bun runner is genuinely required.
```

Key decisions:

- **A separate `nonBunPackageRunner` guard, not folded into the existing
  manager guard.** The rationale differs (runner consistency vs. competing
  lockfiles) and so does the guidance text. Folding them would mean
  acknowledging one `npm install` silently permits every runner call in
  the same command.
- **Tool param, not an env-var bypass.** `policy.ts` deliberately strips
  leading `VAR=val` preambles so a leading assignment can't evade the
  manager guard; a recognized-assignment bypass for the runner guard would
  carve a hole in the exact mechanism built to close that one.
- **Detection reuses the existing segment tokenizer.** No new regex.
  Escaped, quoted, and preamble-wrapped invocations are caught for free,
  and a `grep` for the runner name in source stays allowed — it's an
  argument, not a command word.
- **`classify()` returns verdicts in precedence order**
  (global-install > manager > runner), and the caller stops at the first
  unacknowledged one. Acknowledging one verdict surfaces the next instead
  of letting the whole command through. A global install subsumes the
  manager verdict for **its own segment only**, so acknowledging the
  global install in a compound command still leaves a runner or manager
  violation in another segment blocked — an earlier revision early-returned
  here and had a bypass hole, now covered by two regression tests.
- **The prompt rule is full-prompt only, deliberately.** The slim prompt
  (cron) has a hard 1000-token budget enforced by
  `scripts/dump-system-prompt.test.ts`, and its documented inclusion bar
  is "what no runtime guard catches today." The guard now corrects the
  command at the bash boundary, so spending ~75 tokens of the slim base's
  budget to pre-empt it is the wrong trade. A test pins the exclusion so
  it isn't re-added later. Cron stays at 989 tokens, unchanged.
- **The prompt rule's final clause is load-bearing:** it says a skill or
  doc pointing at the npm runner does not override this rule, and to
  substitute bunx instead. It exists specifically to beat layer 1.

## What this does NOT do

- Does not touch the vendored agent-messenger skill text — that's fixed at
  the source or not at all from this repo.
- Does not add an env-var or other new bypass path; the only escape hatch
  is the existing `acknowledgeGuards` param.
- Does not change `pnpm dlx` — already blocked as a manager — or the bun
  two-word form, which is allowed since it's bun.
- Does not fix `unwrapBunx`, the sandbox helper that unwraps a bun-runner
  invocation for the credential broker. It only unwraps the bun form, so
  the npm-style runner is still classified as its own executable, and
  broker logic keyed on the real executable can't see through it.
  Harmless today since `git` is the only broker, but a latent asymmetry,
  left untouched here.

## Review notes

Load-bearing precedence test is in `policy.test.ts`: a compound command
with only the manager acknowledged must still block on the runner. The
README's guard table and "what is NOT blocked" list were rewritten in the
same commit as the code change so they don't drift out of sync again.

An upstream fix to the agent-messenger skills themselves (layer 1) is out
of scope for this repo and tracked separately.

## Verification

- `bun run lint` — 0 errors (71 pre-existing warnings)
- `bun run format:check` — all files correctly formatted
- `bun run typecheck` — clean
- `bun run test` — 13004 pass, 31 skip, 0 fail, 604 files
- `bun run debug:prompt` — cron 989 tok (unchanged, under its 1000 budget);
  tui 4264, channel 5800, subagent 276

