### PR TITLE
Broker declared PATs to GitHub push

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -56,7 +56,9 @@ import {
   buildSandboxEnvPolicy,
   defaultBuiltinPiToolDefinitions,
   forgetSharedLoopGuardTool,
+  sanitizeBashSpawnEnvironment,
   TYPECLAW_INTERNAL_BASH_ENV,
+  TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV,
   wrapBuiltinToolDefinition,
   wrapPluginTool,
   wrapSystemTool,
@@ -4802,6 +4804,128 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     )
     expect(seenInHook).toBeUndefined()
   })
+
+  test('a client-supplied env withhold list is stripped before hooks run', async () => {
+    const record: { command?: string } = {}
+    let seenInHook: unknown = 'unset'
+    const hooks = createHookBus()
+    hooks.registerAll('observer', '/agent', noopLogger, {
+      'tool.before': (event) => {
+        seenInHook = (event.args as Record<string, unknown>)[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]
+      },
+    })
+    const args: Record<string, unknown> = {
+      command: 'echo hi',
+      [TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]: ['SERVICE_TOKEN'],
+    }
+    const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
+      agentDir: '/agent',
+      sessionId: 's',
+      hooks,
+      getOrigin: () => tui,
+    })
+
+    await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow(
+      /permission service/i,
+    )
+    expect(seenInHook).toBeUndefined()
+    expect(args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]).toBeUndefined()
+  })
+
+  test('a hook-set env withhold removes an ambient name from sandbox inherit and spawn env', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-withhold-env-boundary-'))
+    const name = 'TYPECLAW_COMMAND_TOKEN'
+    process.env[name] = 'ambient-token'
+    try {
+      await writeFile(path.join(agentDir, '.env'), `${name}=operator-token\n`)
+      const hooks = createHookBus()
+      hooks.registerAll('env-withholder', agentDir, noopLogger, {
+        'tool.before': (event) => {
+          ;(event.args as Record<string, unknown>)[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV] = [name]
+        },
+      })
+      const bash = defaultBuiltinPiToolDefinitions(agentDir).find((tool) => tool.name === 'bash')
+      if (bash === undefined) throw new Error('bash tool definition not found')
+      const wrapped = wrapBuiltinToolDefinition(bash, {
+        agentDir,
+        sessionId: 'withhold-env-boundary',
+        hooks,
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+        bashSandboxBoundary: {
+          ensureAvailable: async () => {},
+          buildCommand(command, options) {
+            if (options === undefined) throw new Error('sandbox options were not provided')
+            expect(options.env?.inherit ?? []).not.toContain(name)
+            expect(options.env?.set?.[name]).toBeUndefined()
+            expect(options.env?.withhold).toContain(name)
+            return { ...buildSandboxedCommand(command, options), commandString: command }
+          },
+        },
+      })
+
+      const result = await wrapped.execute(
+        'c',
+        { command: `printf '%s' "\${${name}:-missing}"` },
+        undefined,
+        undefined,
+        {} as never,
+      )
+
+      expect(textOfFirstContent(result)).toBe('missing')
+    } finally {
+      delete process.env[name]
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a hook overlay wins when it also withholds the ambient name', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-withhold-overlay-boundary-'))
+    const name = 'TYPECLAW_COMMAND_TOKEN'
+    process.env[name] = 'ambient-token'
+    try {
+      await writeFile(path.join(agentDir, '.env'), `${name}=operator-token\n`)
+      const hooks = createHookBus()
+      hooks.registerAll('env-replacer', agentDir, noopLogger, {
+        'tool.before': (event) => {
+          const args = event.args as Record<string, unknown>
+          args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV] = [name]
+          args[TYPECLAW_INTERNAL_BASH_ENV] = { [name]: 'injected-token' }
+        },
+      })
+      const bash = defaultBuiltinPiToolDefinitions(agentDir).find((tool) => tool.name === 'bash')
+      if (bash === undefined) throw new Error('bash tool definition not found')
+      const wrapped = wrapBuiltinToolDefinition(bash, {
+        agentDir,
+        sessionId: 'withhold-overlay-boundary',
+        hooks,
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+        bashSandboxBoundary: {
+          ensureAvailable: async () => {},
+          buildCommand(command, options) {
+            if (options === undefined) throw new Error('sandbox options were not provided')
+            expect(options.env?.inherit).toContain(name)
+            expect(options.env?.withhold ?? []).not.toContain(name)
+            return { ...buildSandboxedCommand(command, options), commandString: command }
+          },
+        },
+      })
+
+      const result = await wrapped.execute(
+        'c',
+        { command: `printf '%s' "$${name}"` },
+        undefined,
+        undefined,
+        {} as never,
+      )
+
+      expect(textOfFirstContent(result)).toBe('injected-token')
+    } finally {
+      delete process.env[name]
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('buildSandboxEnvPolicy exposable .env names', () => {
@@ -4820,6 +4944,43 @@ describe('buildSandboxEnvPolicy exposable .env names', () => {
   test('deduplicates a name that is both a secret-pattern overlay and an exposable name', () => {
     const policy = buildSandboxEnvPolicy({ FOO_TOKEN: 'x' }, undefined, ['FOO_TOKEN'])
     expect(policy.inherit).toEqual(['FOO_TOKEN'])
+  })
+
+  test('withhold wins over privileged runtime set and exposable inheritance', () => {
+    const policy = buildSandboxEnvPolicy(
+      undefined,
+      { SERVICE_TOKEN: 'runtime-token' },
+      ['SERVICE_TOKEN'],
+      ['SERVICE_TOKEN'],
+    )
+
+    expect(policy.inherit ?? []).not.toContain('SERVICE_TOKEN')
+    expect(policy.set?.SERVICE_TOKEN).toBeUndefined()
+    expect(policy.withhold).toEqual(['SERVICE_TOKEN'])
+  })
+
+  test('overlay wins over a withhold request for the same name', () => {
+    const policy = buildSandboxEnvPolicy(
+      { SERVICE_TOKEN: 'injected-token' },
+      { SERVICE_TOKEN: 'runtime-token' },
+      ['SERVICE_TOKEN'],
+      ['SERVICE_TOKEN'],
+    )
+
+    expect(policy.inherit).toEqual(['SERVICE_TOKEN'])
+    expect(policy.set?.SERVICE_TOKEN).toBeUndefined()
+    expect(policy.withhold).toBeUndefined()
+  })
+
+  test('fallback spawn env removes withheld ambient values before applying the overlay', () => {
+    const env = sanitizeBashSpawnEnvironment(
+      { AMBIENT_TOKEN: 'ambient', REPLACED_TOKEN: 'ambient' },
+      { REPLACED_TOKEN: 'injected' },
+      ['AMBIENT_TOKEN', 'REPLACED_TOKEN'],
+    )
+
+    expect(env.AMBIENT_TOKEN).toBeUndefined()
+    expect(env.REPLACED_TOKEN).toBe('injected')
   })
 
   test('inherits runtime-injected Git identity by name so values stay out of argv', () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -109,8 +109,10 @@ let sharedLoopGuard: LoopGuard = createLoopGuard()
 // is stripped from client-supplied args before tool.before so only trusted
 // hooks can set it.
 export const TYPECLAW_INTERNAL_BASH_ENV = '__typeclawBashEnv'
+export const TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV = '__typeclawBashWithholdEnv'
 
 type BashEnvOverlay = Record<string, string>
+type BashEnvWithhold = string[]
 const SECRET_BASH_ENV_NAMES = new Set(['GH_TOKEN', 'GITHUB_TOKEN'])
 
 // Transport classifier for the TRUSTED hook-injected overlay only (e.g.
@@ -125,6 +127,7 @@ function isOverlaySecretName(name: string): boolean {
 
 type BashSpawnEnvContext = {
   overlay?: BashEnvOverlay
+  withhold?: BashEnvWithhold
   // Exact env for the outer bwrap process on a sandboxed call. When present, the
   // spawn hook uses it verbatim rather than the live inherited env, so a secret
   // that appears in process.env between policy build and spawn stays out of the
@@ -144,18 +147,29 @@ function readBashEnvOverlay(args: Record<string, unknown>): BashEnvOverlay | und
   return Object.keys(overlay).length > 0 ? overlay : undefined
 }
 
+function readBashEnvWithhold(args: Record<string, unknown>): BashEnvWithhold | undefined {
+  const raw = args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]
+  if (!Array.isArray(raw) || !raw.every((name) => typeof name === 'string')) return undefined
+  const names = [...new Set(raw)]
+  return names.length > 0 ? names : undefined
+}
+
 function bashSpawnHookWithOverlay(context: BashSpawnContext): BashSpawnContext {
   const store = bashEnvStore.getStore()
   if (store?.sandboxSpawnEnv !== undefined) return { ...context, env: { ...store.sandboxSpawnEnv } }
-  return { ...context, env: sanitizeBashSpawnEnvironment(context.env, store?.overlay) }
+  return { ...context, env: sanitizeBashSpawnEnvironment(context.env, store?.overlay, store?.withhold) }
 }
 
 export function sanitizeBashSpawnEnvironment(
   inherited: NodeJS.ProcessEnv | undefined,
   overlay: BashEnvOverlay | undefined,
+  withhold: readonly string[] = [],
 ): NodeJS.ProcessEnv {
   const env = { ...inherited }
   for (const name of SECRET_BASH_ENV_NAMES) delete env[name]
+  for (const name of withhold) delete env[name]
+  // A trusted overlay deliberately replaces ambient state for this command, so
+  // it wins when the same name is also withheld.
   if (overlay !== undefined) Object.assign(env, overlay)
   return env
 }
@@ -586,9 +600,10 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
         tool.name === 'bash' && typeof mutableArgs.command === 'string' ? mutableArgs.command : undefined
       normalizeDefaultTreeRoot(tool.name, mutableArgs)
       const liveOrigin = opts.getOrigin?.()
-      // Defense-in-depth: strip any pre-existing internal env-overlay key
-      // before hooks run so only trusted tool.before hooks can set it.
+      // Defense-in-depth: strip pre-existing internal env-control keys before
+      // hooks run so only trusted tool.before hooks can set them.
       delete mutableArgs[TYPECLAW_INTERNAL_BASH_ENV]
+      delete mutableArgs[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]
       const blockResult = await opts.hooks.runToolBefore({
         tool: tool.name,
         sessionId: opts.sessionId,
@@ -604,7 +619,9 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
       // the bash tool destructures them, so the overlay never reaches logs,
       // loop-detection state, or pi's execute.
       const bashEnvOverlay = readBashEnvOverlay(mutableArgs)
+      const bashEnvWithhold = readBashEnvWithhold(mutableArgs)
       delete mutableArgs[TYPECLAW_INTERNAL_BASH_ENV]
+      delete mutableArgs[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]
       const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs, opts.getLoopGuardTurn?.(), opts.agentDir)
       if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort, 'loop_guard:block')
@@ -667,6 +684,7 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
               opts.agentDir,
               opts.sessionId,
               bashEnvOverlay,
+              bashEnvWithhold,
               sandboxBoundary,
             )
           }
@@ -691,9 +709,12 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
           })
           await preparedSandboxRuntime?.verify()
           const spawnEnvContext: BashSpawnEnvContext | undefined =
-            bashEnvOverlay !== undefined || preparedSandboxRuntime?.spawnEnv !== undefined
+            bashEnvOverlay !== undefined ||
+            bashEnvWithhold !== undefined ||
+            preparedSandboxRuntime?.spawnEnv !== undefined
               ? {
                   ...(bashEnvOverlay !== undefined ? { overlay: bashEnvOverlay } : {}),
+                  ...(bashEnvWithhold !== undefined ? { withhold: bashEnvWithhold } : {}),
                   ...(preparedSandboxRuntime?.spawnEnv !== undefined
                     ? { sandboxSpawnEnv: preparedSandboxRuntime.spawnEnv }
                     : {}),
@@ -892,6 +913,7 @@ async function applyBashSandbox(
   agentDir: string,
   sessionId: string,
   envOverlay: BashEnvOverlay | undefined,
+  envWithhold: BashEnvWithhold | undefined,
   boundary: BashSandboxBoundary,
 ): Promise<PreparedBashSandbox> {
   const command = mutableArgs.command
@@ -906,6 +928,7 @@ async function applyBashSandbox(
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
   const envNames = resolveExposableBashEnvNames(agentDir)
   const sandboxEnvOverlay = buildRoleScopedConfigEnv(agentDir, dirs, envOverlay)
+  const effectiveEnvWithhold = (envWithhold ?? []).filter((name) => !Object.hasOwn(sandboxEnvOverlay ?? {}, name))
   const maskTargets = await ensureHiddenMaskTargets({ dirs, files })
   await boundary.ensureAvailable()
   const sessionTmp = await ensureSessionTmpDir(sessionId)
@@ -959,7 +982,9 @@ async function applyBashSandbox(
       cwd: agentDir,
       proc,
       procSelfExe: resolveProcSelfExe(),
-      ...spreadSandboxEnv(buildSandboxEnvPolicy(sandboxEnvOverlay, privilegedRuntime?.env, envNames.exposable)),
+      ...spreadSandboxEnv(
+        buildSandboxEnvPolicy(sandboxEnvOverlay, privilegedRuntime?.env, envNames.exposable, envWithhold),
+      ),
     })
     mutableArgs.command = commandString
     // The overlay carries command-scoped secret VALUES (e.g. a per-repo GH_TOKEN)
@@ -973,7 +998,7 @@ async function applyBashSandbox(
       cleanup,
       spawnEnv: mergedSpawnEnv,
       dependencyBins,
-      withheld: { paths: maskTargets, envNames: envNames.withheld },
+      withheld: { paths: maskTargets, envNames: [...new Set([...envNames.withheld, ...effectiveEnvWithhold])] },
     }
   } catch (error) {
     await cleanup()
@@ -1022,12 +1047,19 @@ export function buildSandboxEnvPolicy(
   overlay: BashEnvOverlay | undefined,
   runtimeEnv: Record<string, string> | undefined,
   exposableEnvNames: readonly string[] = [],
-): { inherit?: string[]; set?: Record<string, string> } {
-  const set = { ...runtimeEnv }
+  withhold: readonly string[] = [],
+): { inherit?: string[]; set?: Record<string, string>; withhold?: string[] } {
+  const requestedWithhold = new Set(withhold)
+  const overlayNames = new Set(Object.keys(overlay ?? {}))
+  // The overlay is a deliberate command-scoped replacement, while withholding
+  // only removes ambient values; an overlay therefore wins for the same name.
+  const effectiveWithhold = [...requestedWithhold].filter((name) => !overlayNames.has(name))
+  const effectiveWithholdSet = new Set(effectiveWithhold)
+  const set = Object.fromEntries(Object.entries(runtimeEnv ?? {}).filter(([key]) => !requestedWithhold.has(key)))
   const inherit: string[] = []
   const inheritSeen = new Set<string>()
   const pushInherit = (key: string): void => {
-    if (Object.hasOwn(set, key) || inheritSeen.has(key)) return
+    if (effectiveWithholdSet.has(key) || Object.hasOwn(set, key) || inheritSeen.has(key)) return
     inheritSeen.add(key)
     inherit.push(key)
   }
@@ -1048,12 +1080,19 @@ export function buildSandboxEnvPolicy(
   // /tmp/.X11-unix bind is needed: Chrome reaches Xvfb over the netns-scoped
   // abstract X11 socket while bash keeps network:'inherit'.
   const display = process.env['DISPLAY']
-  if (display !== undefined && display !== '' && !Object.hasOwn(set, 'DISPLAY') && !inheritSeen.has('DISPLAY')) {
+  if (
+    display !== undefined &&
+    display !== '' &&
+    !effectiveWithholdSet.has('DISPLAY') &&
+    !Object.hasOwn(set, 'DISPLAY') &&
+    !inheritSeen.has('DISPLAY')
+  ) {
     set['DISPLAY'] = display
   }
   return {
     ...(inherit.length > 0 ? { inherit } : {}),
     ...(Object.keys(set).length > 0 ? { set } : {}),
+    ...(effectiveWithhold.length > 0 ? { withhold: effectiveWithhold } : {}),
   }
 }
 

--- a/src/bundled-plugins/backup/git-auth.test.ts
+++ b/src/bundled-plugins/backup/git-auth.test.ts
@@ -19,7 +19,15 @@ describe('resolveBackupPushAuthEnv', () => {
       GIT_ASKPASS: '/usr/local/bin/typeclaw-git-askpass',
       TYPECLAW_GIT_TOKEN: 'ghs_minted',
       GIT_TERMINAL_PROMPT: '0',
+      GIT_ALLOW_PROTOCOL: 'https',
     })
+
+    const count = Number(env?.GIT_CONFIG_COUNT ?? '0')
+    const pairs = Array.from({ length: count }, (_, i) => [
+      env?.[`GIT_CONFIG_KEY_${i}`],
+      env?.[`GIT_CONFIG_VALUE_${i}`],
+    ])
+    expect(pairs).toContainEqual(['credential.helper', ''])
   })
 
   test('live App resolver takes precedence over an ambient classic PAT', async () => {
@@ -105,6 +113,6 @@ describe('resolveBackupPushAuthEnv', () => {
       resolveOriginPushUrl: async () => 'git@github.com:acme/widgets.git',
     })
     expect(env).not.toBeNull()
-    expect(env?.GIT_CONFIG_COUNT).toBe('2')
+    expect(env?.GIT_CONFIG_COUNT).toBe('3')
   })
 })

--- a/src/bundled-plugins/backup/git-auth.ts
+++ b/src/bundled-plugins/backup/git-auth.ts
@@ -47,11 +47,14 @@ export async function resolveBackupPushAuthEnv(
     GIT_ASKPASS: askpass,
     TYPECLAW_GIT_TOKEN: token.token,
     GIT_TERMINAL_PROMPT: '0',
-    GIT_CONFIG_COUNT: '2',
-    GIT_CONFIG_KEY_0: 'url.https://github.com/.insteadOf',
-    GIT_CONFIG_VALUE_0: 'git@github.com:',
+    GIT_ALLOW_PROTOCOL: 'https',
+    GIT_CONFIG_COUNT: '3',
+    GIT_CONFIG_KEY_0: 'credential.helper',
+    GIT_CONFIG_VALUE_0: '',
     GIT_CONFIG_KEY_1: 'url.https://github.com/.insteadOf',
-    GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
+    GIT_CONFIG_VALUE_1: 'git@github.com:',
+    GIT_CONFIG_KEY_2: 'url.https://github.com/.insteadOf',
+    GIT_CONFIG_VALUE_2: 'ssh://git@github.com/',
   }
 }
 

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -6,6 +6,7 @@ import {
   type GitResolvers,
   parseGithubRepoFromGitUrl,
 } from './git-command'
+import { buildGitCredentialEnv } from './git-credential-env'
 
 const CWD = '/agent'
 
@@ -718,7 +719,7 @@ describe('analyzeGitCommand — clone-then-inspect (sanitized re-exec)', () => {
   // forced git config), so the fresh shell inherits none of them.
   const STRIP =
     'exec /usr/bin/env -u TYPECLAW_GIT_TOKEN -u GIT_ASKPASS -u GH_TOKEN -u GITHUB_TOKEN ' +
-    '-u GIT_TERMINAL_PROMPT -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 ' +
+    '-u GIT_TERMINAL_PROMPT -u GIT_ALLOW_PROTOCOL -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 ' +
     '-u GIT_CONFIG_KEY_1 -u GIT_CONFIG_VALUE_1 -u GIT_CONFIG_KEY_2 -u GIT_CONFIG_VALUE_2 ' +
     '-u GIT_CONFIG_KEY_3 -u GIT_CONFIG_VALUE_3 /bin/bash -c'
 
@@ -726,6 +727,16 @@ describe('analyzeGitCommand — clone-then-inspect (sanitized re-exec)', () => {
   // an absolute /usr/bin/git and separately single-quoted url + destination, so
   // nothing attacker-controlled reaches the appended `&& exec` boundary.
   const HEAD = "/usr/bin/git clone 'https://github.com/acme/widgets.git' '/tmp/x'"
+
+  test('the sanitized tail unsets every injected credential env key', async () => {
+    const result = await analyze('git clone https://github.com/acme/widgets.git /tmp/x && cat /tmp/x/README.md')
+    expect(result.kind).toBe('inject')
+    const command = (result as { rewrittenCommand: string }).rewrittenCommand
+
+    for (const key of Object.keys(buildGitCredentialEnv('', ''))) {
+      expect(command).toContain(`-u ${key}`)
+    }
+  })
 
   test('clone && grep is injected with a canonical head and the tail re-exec under a token-stripped shell', async () => {
     const result = await analyze('git clone https://github.com/acme/widgets.git /tmp/x && cd /tmp/x && grep -r foo .')

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -3,6 +3,8 @@
 
 import { mapVirtualTmpPath } from '@/sandbox'
 
+import { GIT_CREDENTIAL_ENV_KEYS } from './git-credential-env'
+
 // GitHub refuses anonymous writes, so a `write` decision the broker cannot fund
 // is already doomed — the caller turns that into a block with guidance rather
 // than letting git die on a credential prompt. Reads stay fundable-but-optional:
@@ -84,11 +86,11 @@ const COMPOSITION_REASON =
   'which is rewritten to `git -C <path> …`. Run local Git commands separately, ' +
   'then retry the remote operation as a standalone `git -C <path> …` command.'
 
-const TAIL_STRIP_PREFIX =
-  'exec /usr/bin/env -u TYPECLAW_GIT_TOKEN -u GIT_ASKPASS -u GH_TOKEN -u GITHUB_TOKEN ' +
-  '-u GIT_TERMINAL_PROMPT -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 ' +
-  '-u GIT_CONFIG_KEY_1 -u GIT_CONFIG_VALUE_1 -u GIT_CONFIG_KEY_2 -u GIT_CONFIG_VALUE_2 ' +
-  '-u GIT_CONFIG_KEY_3 -u GIT_CONFIG_VALUE_3 /bin/bash -c'
+const AMBIENT_GITHUB_TOKEN_ENV_KEYS = ['GH_TOKEN', 'GITHUB_TOKEN'] as const
+const TAIL_STRIP_ENV_KEYS = GIT_CREDENTIAL_ENV_KEYS.flatMap((key) =>
+  key === 'GIT_ASKPASS' ? [key, ...AMBIENT_GITHUB_TOKEN_ENV_KEYS] : [key],
+)
+const TAIL_STRIP_PREFIX = `exec /usr/bin/env ${TAIL_STRIP_ENV_KEYS.map((key) => `-u ${key}`).join(' ')} /bin/bash -c`
 
 type RemoteSubcommand = 'push' | 'fetch' | 'pull' | 'clone' | 'ls-remote'
 

--- a/src/bundled-plugins/github-cli-auth/git-credential-env.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-credential-env.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { buildGitCredentialEnv } from './git-credential-env'
+
+const git = Bun.which('git')
+const gitExecutable = git ?? 'git'
+
+// Linux-only by design, not convenience: the control case proves the leak by
+// having git-remote-ext run `sh -c … > <path>`, and a Windows path through that
+// redirection never lands the side-effect file, so the control would assert
+// nothing. Brokered git runs only in the Linux container stage anyway.
+const unsupportedHost = git === null || process.platform === 'win32'
+
+test.skipIf(unsupportedHost)('blocks local https-to-ext rewrites from inheriting the brokered token', () => {
+  const root = mkdtempSync(join(tmpdir(), 'typeclaw-git-protocol-'))
+  const repo = join(root, 'repo')
+  const pwned = join(root, 'pwned')
+  const run = (args: string[], credentialEnv?: Record<string, string>) => {
+    const env = { ...process.env, ...credentialEnv }
+    if (credentialEnv !== undefined && !('GIT_ALLOW_PROTOCOL' in credentialEnv)) delete env.GIT_ALLOW_PROTOCOL
+    return Bun.spawnSync([gitExecutable, ...args], { cwd: repo, env, stderr: 'pipe', stdout: 'pipe' })
+  }
+
+  try {
+    expect(Bun.spawnSync([gitExecutable, 'init', repo], { stderr: 'pipe', stdout: 'pipe' }).exitCode).toBe(0)
+    expect(run(['config', '--local', 'protocol.ext.allow', 'always']).exitCode).toBe(0)
+    expect(
+      run(['config', '--local', `url.ext::sh -c echo% PWNED% >% ${pwned} ignored-.insteadOf`, 'https://github.com/'])
+        .exitCode,
+    ).toBe(0)
+
+    const protectedEnv = buildGitCredentialEnv('tok', '/nonexistent-askpass')
+    const blocked = run(['ls-remote', 'https://github.com/acme/widgets.git'], protectedEnv)
+    expect(blocked.exitCode).not.toBe(0)
+    expect(new TextDecoder().decode(blocked.stderr)).toMatch(/transport ['"]ext['"] not allowed/i)
+    expect(existsSync(pwned)).toBe(false)
+
+    const controlEnv = buildGitCredentialEnv('tok', '/nonexistent-askpass')
+    delete controlEnv.GIT_ALLOW_PROTOCOL
+    run(['ls-remote', 'https://github.com/acme/widgets.git'], controlEnv)
+    expect(existsSync(pwned)).toBe(true)
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})

--- a/src/bundled-plugins/github-cli-auth/git-credential-env.ts
+++ b/src/bundled-plugins/github-cli-auth/git-credential-env.ts
@@ -1,0 +1,21 @@
+export function buildGitCredentialEnv(token: string, askpassPath: string): Record<string, string> {
+  return {
+    TYPECLAW_GIT_TOKEN: token,
+    GIT_ASKPASS: askpassPath,
+    GIT_TERMINAL_PROMPT: '0',
+    // Git applies local insteadOf rewrites after analysis; HTTPS-only blocks ext:: from inheriting the token.
+    GIT_ALLOW_PROTOCOL: 'https',
+    GIT_CONFIG_COUNT: '4',
+    GIT_CONFIG_KEY_0: 'core.hooksPath',
+    GIT_CONFIG_VALUE_0: '/dev/null',
+    GIT_CONFIG_KEY_1: 'credential.helper',
+    GIT_CONFIG_VALUE_1: '',
+    GIT_CONFIG_KEY_2: 'url.https://github.com/.insteadOf',
+    GIT_CONFIG_VALUE_2: 'git@github.com:',
+    GIT_CONFIG_KEY_3: 'url.https://github.com/.insteadOf',
+    GIT_CONFIG_VALUE_3: 'ssh://git@github.com/',
+  }
+}
+
+// Injection and clone-tail stripping share these keys so a new credential variable cannot leak into the tail shell.
+export const GIT_CREDENTIAL_ENV_KEYS: readonly string[] = Object.freeze(Object.keys(buildGitCredentialEnv('', '')))

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -9,6 +9,7 @@ import {
   defaultBuiltinPiToolDefinitions,
   sanitizeBashSpawnEnvironment,
   TYPECLAW_INTERNAL_BASH_ENV,
+  TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV,
   wrapBuiltinToolDefinition,
 } from '@/agent/plugin-tools'
 import { __resetReviewVerdictGuardForTest } from '@/channels/github-review-verdict-coordinator'
@@ -1320,7 +1321,7 @@ describe('github-cli-auth plugin — git path', () => {
 
     expect(result).toMatchObject({ block: true })
     const reason = (result as { reason: string }).reason
-    // The operator remedy, and the two wrong turns this failure historically caused.
+    // The operator remedy, plus the two blocked retries the reason must steer off.
     expect(reason).toContain('channels.github')
     expect(reason).toContain('gh auth setup-git')
     expect(reason).toContain('not a stale')
@@ -1343,6 +1344,144 @@ describe('github-cli-auth plugin — git path', () => {
 
       expect(result).toBeUndefined()
       expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    }
+  })
+
+  test('.env PAT + no App minter: brokers a github push through askpass and suppresses ambient aliases', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'tc-git-pat-'))
+    const pat = 'ghp_declared_push'
+    try {
+      writeFileSync(join(agentDir, '.env'), `GH_TOKEN=${pat}\n`)
+      process.env.GH_TOKEN = pat
+      const hook = await hookFor(tokenResolver('ghs_unused'), false, {
+        agentDir,
+        permissions: privilegedPermissions,
+      })
+      const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+      const result = await hook(event, { ...hookCtx, agentDir })
+
+      expect(result).toBeUndefined()
+      const env = gitEnv(event)
+      expect(env.TYPECLAW_GIT_TOKEN).toBe(pat)
+      expect(env.GIT_ASKPASS).toBe(askpassPath)
+      expect(event.args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]).toEqual(['GH_TOKEN', 'GITHUB_TOKEN'])
+      expect(String(event.args.command)).not.toContain(pat)
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('declared name, runtime-replaced value: blocks — a name does not authenticate a value', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'tc-git-pat-mismatch-'))
+    try {
+      // given `.env` declares one PAT but something at runtime (PAT-mode channel
+      // auth seeds process.env.GH_TOKEN) replaced the live value with another
+      writeFileSync(join(agentDir, '.env'), 'GH_TOKEN=ghp_declared_value\n')
+      process.env.GH_TOKEN = 'ghp_runtime_only_value'
+      const hook = await hookFor(tokenResolver('ghs_unused'), false, {
+        agentDir,
+        permissions: privilegedPermissions,
+      })
+      const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+      const result = await hook(event, { ...hookCtx, agentDir })
+
+      expect(result).toMatchObject({ block: true })
+      expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+      expect(event.args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]).toBeUndefined()
+      expect(JSON.stringify(result)).not.toContain('ghp_runtime_only_value')
+      expect(JSON.stringify(result)).not.toContain('ghp_declared_value')
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('declared GITHUB_TOKEN with a runtime-replaced value also blocks', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'tc-git-pat-mismatch-alias-'))
+    try {
+      writeFileSync(join(agentDir, '.env'), 'GITHUB_TOKEN=ghp_declared_alias\n')
+      delete process.env.GH_TOKEN
+      process.env.GITHUB_TOKEN = 'ghp_runtime_alias'
+      const hook = await hookFor(tokenResolver('ghs_unused'), false, {
+        agentDir,
+        permissions: privilegedPermissions,
+      })
+      const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+      const result = await hook(event, { ...hookCtx, agentDir })
+
+      expect(result).toMatchObject({ block: true })
+      expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('.env PAT + no App minter: github reads remain unbrokered pass-through', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'tc-git-pat-read-'))
+    try {
+      writeFileSync(join(agentDir, '.env'), 'GH_TOKEN=ghp_declared_read\n')
+      process.env.GH_TOKEN = 'ghp_declared_read'
+      const hook = await hookFor(tokenResolver('ghs_unused'), false, {
+        agentDir,
+        permissions: privilegedPermissions,
+      })
+
+      for (const command of [
+        'git clone https://github.com/acme/widgets.git',
+        'git fetch https://github.com/acme/widgets.git main',
+      ]) {
+        const event = bashEvent(command)
+        const result = await hook(event, { ...hookCtx, agentDir })
+
+        expect(result).toBeUndefined()
+        expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+        expect(event.args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]).toBeUndefined()
+      }
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('.env PAT + no App minter: a role without PAT permission still blocks push', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'tc-git-pat-denied-'))
+    const pat = 'ghp_declared_denied'
+    try {
+      writeFileSync(join(agentDir, '.env'), `GH_TOKEN=${pat}\n`)
+      process.env.GH_TOKEN = pat
+      const hook = await hookFor(tokenResolver('ghs_unused'), false, { agentDir })
+      const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+      const result = await hook(event, { ...hookCtx, agentDir })
+
+      expect(result).toMatchObject({ block: true })
+      expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+      expect(event.args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]).toBeUndefined()
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('.env token with an unrecognized class is never brokered to git push', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'tc-git-token-unknown-'))
+    const token = 'unrecognized_declared_token'
+    try {
+      writeFileSync(join(agentDir, '.env'), `GH_TOKEN=${token}\n`)
+      process.env.GH_TOKEN = token
+      const hook = await hookFor(tokenResolver('ghs_unused'), false, {
+        agentDir,
+        permissions: privilegedPermissions,
+      })
+      const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+      const result = await hook(event, { ...hookCtx, agentDir })
+
+      expect(result).toMatchObject({ block: true })
+      expect(JSON.stringify(event.args[TYPECLAW_INTERNAL_BASH_ENV] ?? {})).not.toContain(token)
+      expect(event.args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]).toBeUndefined()
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
     }
   })
 
@@ -1381,17 +1520,27 @@ describe('github-cli-auth plugin — git path', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
-  test('classic PAT is never brokered to git; an App token is minted instead', async () => {
-    process.env.GH_TOKEN = 'ghp_classic'
-    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: privilegedPermissions })
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+  test('.env PAT + App minter: a github push uses the App token instead', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'tc-git-app-wins-'))
+    try {
+      writeFileSync(join(agentDir, '.env'), 'GH_TOKEN=ghp_declared\n')
+      process.env.GH_TOKEN = 'ghp_declared'
+      const hook = await hookFor(tokenResolver('ghs_minted'), true, {
+        agentDir,
+        permissions: privilegedPermissions,
+      })
+      const event = bashEvent('git push https://github.com/acme/widgets.git main')
 
-    const result = await hook(event, hookCtx)
+      const result = await hook(event, { ...hookCtx, agentDir })
 
-    expect(result).toBeUndefined()
-    const env = gitEnv(event)
-    expect(env.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
-    expect(JSON.stringify(env)).not.toContain('ghp_classic')
+      expect(result).toBeUndefined()
+      const env = gitEnv(event)
+      expect(env.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+      expect(JSON.stringify(env)).not.toContain('ghp_declared')
+      expect(event.args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV]).toBeUndefined()
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
   })
 
   test('PAT with no App minter: authenticated git passes through, PAT never reaches git', async () => {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -1,10 +1,10 @@
-import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
+import { TYPECLAW_INTERNAL_BASH_ENV, TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV } from '@/agent/plugin-tools'
 import type { SessionOrigin } from '@/agent/session-origin'
 import {
   configureReviewVerdictCoordinator,
   createSharedReviewVerdictGuard,
 } from '@/channels/github-review-verdict-coordinator'
-import { hasEnvKey } from '@/init/env-file'
+import { hasEnvKey, readEnvFile } from '@/init/env-file'
 import { CORE_PERMISSIONS } from '@/permissions/builtins'
 import { definePlugin } from '@/plugin'
 
@@ -22,6 +22,7 @@ import {
   defaultGitResolvers,
   resolveGhDefaultRepoFromCwd,
 } from './git-command'
+import { buildGitCredentialEnv } from './git-credential-env'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
 import { classifyGhToken, shouldMintAppToken } from './token-class'
@@ -77,6 +78,23 @@ export default definePlugin({
       return undefined
     }
 
+    // Stricter than sandboxInheritedGhToken(), and deliberately not merged with it.
+    // `gh` only needs to know WHICH token the sandbox will hand it, so the live
+    // value is the right answer there. Brokering to git asserts something stronger
+    // — that the operator deliberately exposed THIS value — and a declared NAME
+    // does not authenticate a live VALUE: PAT-mode channel auth overwrites
+    // process.env.GH_TOKEN at runtime (channels/adapters/github/index.ts), so a
+    // declared name can carry a credential the operator never wrote to `.env`.
+    // Compare against the same literal `readEnvFile` parse Docker's --env-file
+    // injects, and fail closed on any mismatch.
+    const declaredGhTokenForGitBroker = (): { envName: 'GH_TOKEN' | 'GITHUB_TOKEN'; value: string } | undefined => {
+      const inherited = sandboxInheritedGhToken()
+      if (inherited === undefined) return undefined
+      const declared = readEnvFile(ctx.agentDir).get(inherited.envName)
+      if (declared === undefined || declared === '' || declared !== inherited.value) return undefined
+      return inherited
+    }
+
     // A process-only PAT (runtime/App-seeded process.env, NOT declared in `.env`)
     // is stripped by --clearenv for this role, and a PAT is not re-mintable per
     // repo, so there is no token to inject. Tell the AGENT (model-visible block)
@@ -95,16 +113,14 @@ export default definePlugin({
     // Deliberately claims only what this process can prove: a resolver is absent.
     // It cannot tell PAT-configured from App-configured-but-adapter-down, so it
     // names both remedies instead of guessing one. The closing lines exist because
-    // the mute version of this failure sent an agent chasing `gh auth setup-git`
-    // and then telling its operator a nonexistent upstream fix needed deploying.
+    // a mute refusal here is indistinguishable from broken auth, so the caller
+    // retries credential-management commands that are themselves blocked.
     const missingAppAuthForPushReason =
       'Pushing to github.com needs a credential and this runtime has no live GitHub App token minter, ' +
-      'so TypeClaw has nothing to give git. A GitHub PAT is never brokered to git by design (git runs ' +
-      'repo-local hooks and credential helpers, and a PAT is not repo-confined), so `GH_TOKEN` in `.env` ' +
-      'does NOT enable push even though it authenticates `gh`. Operator remedy: set ' +
-      '`secrets.json#channels.github.auth` to `{"type":"app", "appId":…, "privateKey":…}`, install that App ' +
-      'on the target repo, list the repo in `typeclaw.json#channels.github.repos[]`, and restart; if App auth ' +
-      'is already configured, the adapter failed to start — check `typeclaw logs`. Do not retry with ' +
+      'so TypeClaw has nothing to give git. Operator remedy: declare `GH_TOKEN` in the agent `.env` and ' +
+      'restart (no further config is needed), or configure GitHub App auth under `channels.github` for ' +
+      'per-repo, short-lived tokens. If App auth is already configured, the adapter failed to start — check ' +
+      '`typeclaw logs`. Do not retry with ' +
       '`gh auth setup-git`, a credential helper, or a tokenized remote URL: those are blocked and the ' +
       'credential files are masked in this sandbox. This is configuration/runtime state, not a stale ' +
       'TypeClaw version — a rebuild or restart alone will not change it. To open a PR without pushing ' +
@@ -371,7 +387,7 @@ export default definePlugin({
     }
 
     const handleGitCommand = async (params: {
-      event: { args: Record<string, unknown> }
+      event: { args: Record<string, unknown>; origin?: SessionOrigin }
       command: string
       agentDir: string
       sessionId: string
@@ -384,14 +400,34 @@ export default definePlugin({
       if (decision.kind === 'pass-through') return
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
 
-      // Only a per-repo GitHub App token is brokered to git — never a PAT (git,
-      // unlike gh, runs repo-local hooks/helpers, and a PAT is not repo-confined).
-      // With no App minter a read can still succeed anonymously, so it passes
-      // through; a write cannot, and passing it through strands git on a
-      // credential prompt whose `could not read Username` says nothing about the
-      // real cause. Block the write instead, so the agent reports the actual
-      // remedy rather than inventing one.
+      const buildGitCredentialOverlay = async (token: string, existing: unknown): Promise<Record<string, string>> => {
+        const askpass = await ensureGitAskPassHelper(resolveSandboxGitAskPassPath())
+        const overlay = existing !== null && typeof existing === 'object' ? (existing as Record<string, string>) : {}
+        return {
+          ...overlay,
+          ...buildGitCredentialEnv(token, askpass),
+        }
+      }
+
       if (!hasAppTokenResolver()) {
+        const inherited = declaredGhTokenForGitBroker()
+        const tokenClass = classifyGhToken(inherited?.value)
+        if (
+          // The analyzer emits write access only for its push subcommand grammar.
+          decision.access === 'write' &&
+          inherited !== undefined &&
+          (tokenClass === 'cross-owner' || tokenClass === 'fine-grained-pat') &&
+          canUsePat(event.origin)
+        ) {
+          event.args[TYPECLAW_INTERNAL_BASH_ENV] = await buildGitCredentialOverlay(
+            inherited.value,
+            event.args[TYPECLAW_INTERNAL_BASH_ENV],
+          )
+          // Withhold wins only when the same ambient names are absent from the overlay.
+          event.args[TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV] = ['GH_TOKEN', 'GITHUB_TOKEN']
+          if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
+          return
+        }
         return decision.access === 'write' ? { block: true, reason: missingAppAuthForPushReason } : undefined
       }
       const result = await resolveTokenForRepo(decision.repoSlug)
@@ -406,26 +442,10 @@ export default definePlugin({
       // belong in a separate agent (see docs/internals/sandbox.mdx).
       // Sandboxed bash: the helper must be on a sandbox-visible path (baked /usr),
       // not the unsandboxed /tmp default the tmpfs would hide.
-      const askpass = await ensureGitAskPassHelper(resolveSandboxGitAskPassPath())
-      const existing = event.args[TYPECLAW_INTERNAL_BASH_ENV]
-      const overlay = existing !== null && typeof existing === 'object' ? (existing as Record<string, string>) : {}
-      event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
-        ...overlay,
-        GIT_ASKPASS: askpass,
-        TYPECLAW_GIT_TOKEN: result.token,
-        GIT_TERMINAL_PROMPT: '0',
-        GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_0: 'core.hooksPath',
-        GIT_CONFIG_VALUE_0: '/dev/null',
-        GIT_CONFIG_KEY_1: 'credential.helper',
-        GIT_CONFIG_VALUE_1: '',
-        // Both ssh remote spellings fold to https so the askpass credential applies:
-        // the scp short form (git@github.com:owner/repo) and the ssh:// URL form.
-        GIT_CONFIG_KEY_2: 'url.https://github.com/.insteadOf',
-        GIT_CONFIG_VALUE_2: 'git@github.com:',
-        GIT_CONFIG_KEY_3: 'url.https://github.com/.insteadOf',
-        GIT_CONFIG_VALUE_3: 'ssh://git@github.com/',
-      }
+      event.args[TYPECLAW_INTERNAL_BASH_ENV] = await buildGitCredentialOverlay(
+        result.token,
+        event.args[TYPECLAW_INTERNAL_BASH_ENV],
+      )
       if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
       return
     }

--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -161,6 +161,21 @@ describe('buildSandboxedCommand env policy', () => {
     }
   })
 
+  test('explicitly unsets a withheld name and omits it from the frozen parent env', () => {
+    const name = 'TYPECLAW_SANDBOX_WITHHELD_SECRET'
+    process.env[name] = 'ambient-secret'
+    try {
+      const { argv, spawnEnv } = buildSandboxedCommand('true', { env: { withhold: [name] } })
+      expect(argv).toContain('--clearenv')
+      expect(argv).toEqual(expect.arrayContaining(['--unsetenv', name]))
+      expect(argv).not.toContain('ambient-secret')
+      expect(spawnEnv[name]).toBeUndefined()
+      expect(Object.keys(spawnEnv)).not.toContain(name)
+    } finally {
+      delete process.env[name]
+    }
+  })
+
   test('keeps an inherited secret out of /proc cmdline while the child receives it', async () => {
     if (process.platform !== 'linux') return
     const name = 'TYPECLAW_SANDBOX_PROC_SECRET'

--- a/src/sandbox/build.ts
+++ b/src/sandbox/build.ts
@@ -91,7 +91,14 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
     argv.push('--die-with-parent')
   }
 
-  const inheritedNames = new Set(policy.env?.inherit ?? [])
+  const withheldNames = new Set(policy.env?.withhold ?? [])
+  const inheritedNames = new Set((policy.env?.inherit ?? []).filter((name) => !withheldNames.has(name)))
+  const unsetNames = new Set<string>()
+  const pushUnset = (name: string): void => {
+    if (unsetNames.has(name)) return
+    unsetNames.add(name)
+    argv.push('--unsetenv', name)
+  }
   if (inheritedNames.size === 0) {
     argv.push('--clearenv')
   } else {
@@ -101,9 +108,10 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
       ...Object.keys(policy.env?.set ?? {}),
     ])
     for (const key of Object.keys(process.env).sort()) {
-      if (!retained.has(key)) argv.push('--unsetenv', key)
+      if (!retained.has(key)) pushUnset(key)
     }
   }
+  for (const name of withheldNames) pushUnset(name)
   for (const [key, value] of Object.entries(resolveEnv(policy.env))) {
     if (inheritedNames.has(key)) continue
     argv.push('--setenv', key, value)
@@ -267,8 +275,13 @@ function appendMount(argv: string[], mount: SandboxMount): void {
 }
 
 function resolveEnv(env: SandboxEnvPolicy | undefined): Record<string, string> {
-  const resolved: Record<string, string> = { ...DEFAULT_SANDBOX_ENV, ...env?.set }
+  const withheldNames = new Set(env?.withhold ?? [])
+  const resolved: Record<string, string> = {}
+  for (const [key, value] of Object.entries({ ...DEFAULT_SANDBOX_ENV, ...env?.set })) {
+    if (!withheldNames.has(key)) resolved[key] = value
+  }
   for (const key of env?.passthrough ?? []) {
+    if (withheldNames.has(key)) continue
     const value = process.env[key]
     if (value !== undefined) resolved[key] = value
   }
@@ -282,10 +295,13 @@ function resolveEnv(env: SandboxEnvPolicy | undefined): Record<string, string> {
 // build-to-spawn TOCTOU on the --unsetenv enumeration.
 function resolveSpawnEnv(env: SandboxEnvPolicy | undefined): Record<string, string> {
   const resolved = resolveEnv(env)
+  const withheldNames = new Set(env?.withhold ?? [])
   for (const name of env?.inherit ?? []) {
+    if (withheldNames.has(name)) continue
     const value = process.env[name]
     if (value !== undefined) resolved[name] = value
   }
+  for (const name of withheldNames) delete resolved[name]
   return resolved
 }
 

--- a/src/sandbox/policy.ts
+++ b/src/sandbox/policy.ts
@@ -37,6 +37,7 @@ export type SandboxProcStrategy = 'tmpfs' | 'none' | 'real-proc' | 'proc-bind'
 export type SandboxEnvPolicy = {
   set?: Record<string, string>
   passthrough?: string[]
+  withhold?: string[]
   // Preserve these names from bwrap's parent environment without rendering
   // their values in argv. The builder switches from --clearenv to explicit
   // --unsetenv for every other inherited name. Reserved for command-scoped


### PR DESCRIPTION
## Background

This builds on #1375 (merged), which stopped the git broker from muting a push it couldn't fund and pointed the agent at GitHub App auth as the remedy. That left a real gap: a deployment with `GH_TOKEN` declared in `.env` (a PAT) authenticates `gh` fine but still cannot `git push` — the broker refuses PATs outright, by design, because git runs repo-local hooks and credential helpers and a PAT is not repo-confined the way a per-repo App installation token is.

A closer look at that design invariant found it drawing the line in the wrong place. The `.env`-declared `GH_TOKEN` is already inherited into model bash on purpose (`src/sandbox/env-exposure.ts:14-19`, `:64-68`) — the model can read it today regardless of what git does with it. Brokering that same value to git discloses nothing new to the model. What actually needs to stay out of git is a PAT that exists only in `process.env` (seeded by PAT-mode channel auth) and was never declared in `.env` — that one is concealed from the model and must not enter a repo-controlled process tree. The real boundary is operator-exposed vs runtime-concealed, not PAT vs App token.

## Summary

Broker an `.env`-declared PAT to `git push`, gated tightly enough that only the already-exposed case qualifies, and land two independent hardening fixes the review surfaced along the way.

- **New trusted per-command env-withholding channel** (`src/agent/plugin-tools.ts`): `TYPECLAW_INTERNAL_BASH_WITHHOLD_ENV` mirrors the existing `TYPECLAW_INTERNAL_BASH_ENV` overlay's trust model — stripped from client-supplied args before `tool.before` runs, settable only by trusted hooks. Withheld names are excluded from bwrap `inherit`/`set`, explicitly `--unsetenv`'d in argv (`src/sandbox/build.ts`), and removed from the frozen bwrap parent-environment snapshot in `resolveSpawnEnv` — argv alone would leave the value reachable through the frozen parent env, so both had to change. A trusted overlay value wins over a withhold for the same name (`buildSandboxEnvPolicy`), since the overlay is a deliberate replacement and the withhold only strips ambient state.
- **The broker uses it** (`src/bundled-plugins/github-cli-auth/index.ts`): on a push decision with no live App token minter, it now checks `declaredGhTokenForGitBroker()` and only proceeds if the token classifies as `cross-owner` or `fine-grained-pat` and `canUsePat(event.origin)` allows it. `declaredGhTokenForGitBroker()` wraps `sandboxInheritedGhToken()` (which validates the env var name against `.env` but returns the live `process.env` value) and additionally requires that live value to exactly equal the `readEnvFile()` parse of the `.env` declaration, failing closed on mismatch — necessary because PAT-mode channel auth reassigns `process.env.GH_TOKEN` at runtime (`src/channels/adapters/github/index.ts:277-280`), so a declared name alone could otherwise carry a value the operator never wrote. When all three hold, it injects the same hardened askpass overlay App-token pushes already use, and sets the withhold to `['GH_TOKEN', 'GITHUB_TOKEN']` so the ambient aliases can't also reach the process. App minting still wins whenever available; reads were already unbrokered and stay that way.
- **Shared credential-env module + `GIT_ALLOW_PROTOCOL=https`**: the credential env is now built once in `src/bundled-plugins/github-cli-auth/git-credential-env.ts` (`buildGitCredentialEnv()` + `GIT_CREDENTIAL_ENV_KEYS`), used by both the App-token and PAT push paths instead of duplicating the literal. `git-command.ts`'s clone-tail `env -u` strip list (`TAIL_STRIP_PREFIX`) is derived from `GIT_CREDENTIAL_ENV_KEYS` rather than restating it, so the injected set and the stripped set can't drift apart — previously these would have been two hand-synced lists with no guard. Both paths also add `GIT_ALLOW_PROTOCOL=https` alongside the existing `core.hooksPath=/dev/null`, empty `credential.helper`, `GIT_TERMINAL_PROMPT=0`, and ssh→https URL folding. Without it: a model-writable nested repo can set `protocol.ext.allow=always` plus `url."ext::<cmd>".insteadOf=https://github.com/` in its LOCAL `.git/config`; the command analyzer approves the literal HTTPS URL without resolving git config; git applies the local rewrite afterwards; `git-remote-ext` (ships with git) then executes `<cmd>` with the credential environment inherited. `GIT_CONFIG_GLOBAL=/dev/null` / `GIT_CONFIG_NOSYSTEM=1` don't help — local repo config is still read, and the attacker's `insteadOf` key is distinct from ours, so both rewrites apply. Covered by a real-git regression test (`git-credential-env.test.ts`) with a control case (same attack, `GIT_ALLOW_PROTOCOL` removed) that proves the variable is load-bearing rather than incidental.
- **Backup push hardening** (`src/bundled-plugins/backup/git-auth.ts`), an independent finding from the same review: the backup runner's direct-spawn push already disabled hooks but never cleared `credential.helper`, so a repo-local helper could still receive the brokered App-token environment. It now clears the helper and pins `GIT_ALLOW_PROTOCOL=https` too. Backup stays App-token-only — no PAT support added there.

**Why this is safe to broker, not just convenient:** the brokered path is strictly more contained than the status quo it replaces. Today, with no broker involvement, a repo-local `credential.helper` runs whenever git wants credentials and can read the ambient `GH_TOKEN` straight out of the environment to exfiltrate it. The new path suppresses that ambient token entirely (via the withhold) and disables hooks and helpers outright, so the token only ever reaches the askpass helper this PR controls.

## What this does NOT do

- Does not broker anything that lives only in `process.env` and was never declared in `.env` — `declaredGhTokenForGitBroker()` requires the live value to match the `.env`-declared value exactly, so a PAT seeded purely by PAT-mode channel auth stays refused.
- Does not touch the `gh` CLI's own credential store (`~/.config/gh/hosts.yml` from `gh auth login`). The review found that reading it from the trusted runtime wouldn't violate the canonical secret mask, but a concealed, potentially account-wide credential needs an operator-controlled destination grant, and deriving that destination from a repo's own configured remote is forgeable — `git remote set-url` isn't denied, and a nested repo's `.git/config` under `/agent/mounts` is model-writable. That needs a durable operator-side pin and is deferred to a follow-up (#1377).
- Does not add PAT support to the backup runner; it remains App-token-only.
- Does not change anonymous read behavior; `clone`/`fetch`/`pull`/`ls-remote` were already unbrokered and still pass through.

## Review notes

The distinction to scrutinize hardest: `.env`-declared (already model-visible, eligible for brokering) vs process-only (concealed, still refused). `declaredGhTokenForGitBroker()` is the sole gate enforcing it — if that ever accepts a live `process.env` value that doesn't match the `.env` declaration, the invariant breaks silently.

Second load-bearing point: the withhold has to reach the frozen bwrap parent-environment snapshot, not just argv. `resolveSpawnEnv` in `src/sandbox/build.ts` deletes withheld names from the resolved map after inherit is applied — dropping just the `--unsetenv` argv entries would still leave the token reachable through the pre-frozen snapshot path documented at the top of that function (build-to-spawn TOCTOU comment).

Also worth checking: `buildGitCredentialEnv` is now shared between the App-token and PAT branches in `index.ts` (via `git-credential-env.ts`), so `GIT_CONFIG_COUNT`/`KEY_N`/`VALUE_N` stay in lockstep between them by construction rather than by two authors remembering to update both — and the clone-tail strip list derives from the same source, so it can't silently miss a new credential variable.

Gates required for the PAT path, all must hold: `push` only (decision's `access` field), `declaredGhTokenForGitBroker()` returns a value, token class is `cross-owner` or `fine-grained-pat`, `canUsePat(origin)` passes. `gitExfil`/`gitRemoteTainted` are enforced independently of this change and unaffected.

Verification:
- `bun run test` — 13032 pass, 31 skip, 0 fail, 605 files
- `bun run typecheck` — clean
- `bun run lint` — 0 errors (71 pre-existing warnings, unrelated files)
- `bun run format:check` — clean
