### PR TITLE
Make Discord thread rules inherit parent scope

### DIFF
--- a/docs/content/docs/internals/permissions.mdx
+++ b/docs/content/docs/internals/permissions.mdx
@@ -64,7 +64,7 @@ discord:9999 author:U_MOD
 kakao:group/*
 ```
 
-Within one rule, tokens AND. Across rules on the same role, OR. Strict equality everywhere — no regex, no glob beyond listed `*` shapes. The parser owns precise typo errors, rejection of redundant forms (`slack:*/*` etc.), and rejection of legacy prefixes (`team:`, `guild:`, `tg:`) with a hint to use the canonical form (`slack:`, `discord:`, `telegram:`).
+Within one rule, tokens AND. Across rules on the same role, OR. Coordinates use strict equality — no regex, no glob beyond listed `*` shapes — with one Discord-specific inheritance rule: a resolved thread may also match its `parentChat`. Its own `chat` remains the thread ID, so a rule naming that ID is still exact; missing parent metadata fails closed. The parser owns precise typo errors, rejection of redundant forms (`slack:*/*` etc.), and rejection of legacy prefixes (`team:`, `guild:`, `tg:`) with a hint to use the canonical form (`slack:`, `discord:`, `telegram:`).
 
 ## Cron and subagent provenance
 

--- a/docs/content/docs/reference/discord-bot.mdx
+++ b/docs/content/docs/reference/discord-bot.mdx
@@ -55,6 +55,10 @@ If slash command registration returns 403, re-invite with `applications.commands
 
 `/help`, `/stop`, `/reload`, `/restart`. Auto-registered on connect.
 
+## Permission scopes
+
+Discord role match rules use `discord:<guildId>` for a server and `discord:<guildId>/<channelId>` for a concrete channel. A parent-channel scope also covers its resolved child threads, while a scope naming a thread ID remains exact. DMs use `discord:dm/*`. See the [match-rule DSL](/docs/reference/match-rule-dsl).
+
 ## Config
 
 ```json

--- a/docs/content/docs/reference/discord.mdx
+++ b/docs/content/docs/reference/discord.mdx
@@ -84,7 +84,7 @@ Discord chats fall into two internal workspace shapes:
 | `@dm`              | 1:1 direct messages                |
 | `<guildId>`        | Server channels (numeric guild id) |
 
-In role match rules, DMs are addressed by the canonical `dm` **bucket** scope, not the internal `@dm` workspace value: `discord:*` for everything, `discord:dm/*` for any DM, `discord:<guildId>` for one server, or `discord:<guildId>/<channelId>` for a concrete server channel. See the [match-rule DSL](/docs/reference/match-rule-dsl).
+In role match rules, DMs are addressed by the canonical `dm` **bucket** scope, not the internal `@dm` workspace value: `discord:*` for everything, `discord:dm/*` for any DM, `discord:<guildId>` for one server, or `discord:<guildId>/<channelId>` for a concrete server channel. A concrete parent-channel scope also covers its resolved child threads; a scope naming a thread ID remains exact. See the [match-rule DSL](/docs/reference/match-rule-dsl).
 
 ## Quirks
 

--- a/docs/content/docs/reference/match-rule-dsl.mdx
+++ b/docs/content/docs/reference/match-rule-dsl.mdx
@@ -31,6 +31,8 @@ Compact strings parsed at config load. AND within a rule (whitespace-separated t
 | `kakao:group/*`             | any KakaoTalk group chat          |
 | `kakao:group/<chat-id>`     | one specific group chat           |
 
+Discord threads inherit their parent channel's scope. A rule for `discord:<guild-id>/<parent-channel-id>` therefore matches both the parent channel and its resolved child threads. A rule that names a thread ID still matches only that thread, and a thread whose parent cannot be resolved does not inherit a parent rule.
+
 ## Author qualifier
 
 Appended to a channel rule, AND-combined:

--- a/src/channels/adapters/discord-bot-slash-commands.test.ts
+++ b/src/channels/adapters/discord-bot-slash-commands.test.ts
@@ -41,6 +41,56 @@ describe('parseInteractionAsCommand', () => {
     })
   })
 
+  test('carries a canonical thread parent from the interaction channel object', () => {
+    const event = makeInteraction({
+      channel_id: '100000000000000001',
+      guild_id: '100000000000000002',
+    }) as DiscordGatewayInteractionEvent & {
+      channel: { id: string; type: number; parent_id: string }
+    }
+    event.channel = {
+      id: '100000000000000001',
+      type: 11,
+      parent_id: '100000000000000003',
+    }
+
+    const result = parseInteractionAsCommand(event, known)
+
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.parentChat).toBe('100000000000000003')
+  })
+
+  test('does not trust malformed or non-thread interaction parent metadata', () => {
+    const event = makeInteraction() as DiscordGatewayInteractionEvent & {
+      channel: { type: number; parent_id: string }
+    }
+    event.channel = { type: 0, parent_id: '100000000000000003' }
+    expect(parseInteractionAsCommand(event, known)).not.toHaveProperty('command.parentChat')
+
+    event.channel = { type: 11, parent_id: 'not-a-snowflake' }
+    expect(parseInteractionAsCommand(event, known)).not.toHaveProperty('command.parentChat')
+  })
+
+  test('does not trust thread metadata for another channel or without a guild', () => {
+    const event = makeInteraction({
+      channel_id: '100000000000000001',
+      guild_id: '100000000000000002',
+    }) as DiscordGatewayInteractionEvent & {
+      channel: { id: string; type: number; parent_id: string }
+    }
+    event.channel = {
+      id: '100000000000000009',
+      type: 11,
+      parent_id: '100000000000000003',
+    }
+    expect(parseInteractionAsCommand(event, known)).not.toHaveProperty('command.parentChat')
+
+    event.guild_id = undefined
+    event.channel.id = '100000000000000001'
+    expect(parseInteractionAsCommand(event, known)).not.toHaveProperty('command.parentChat')
+  })
+
   test('DM interaction (no guild_id) maps workspace to @dm and reads user.id', () => {
     const result = parseInteractionAsCommand(
       makeInteraction({ guild_id: undefined, member: undefined, user: { id: 'u-bob', username: 'bob' } }),

--- a/src/channels/adapters/discord-bot-slash-commands.ts
+++ b/src/channels/adapters/discord-bot-slash-commands.ts
@@ -3,6 +3,8 @@ import type { DiscordGatewayInteractionEvent } from 'agent-messenger/discordbot'
 import type { ChannelKey } from '@/channels/types'
 
 import { describeError } from '../describe-error'
+import { discordThreadRoom } from './discord-bot-thread-room'
+import { isDiscordSnowflake } from './discord-id'
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10'
 
@@ -72,6 +74,7 @@ export async function registerCommands(args: RegisterCommandsArgs): Promise<Regi
 export type ParsedSlashCommand = {
   name: string
   key: ChannelKey
+  parentChat?: string
   invokerId: string
   interactionId: string
   interactionToken: string
@@ -108,16 +111,35 @@ export function parseInteractionAsCommand(
   // as channels; interaction.channel_id is the thread id when the user
   // invoked from a thread).
   const workspace = typeof event.guild_id === 'string' && event.guild_id !== '' ? event.guild_id : '@dm'
+  const parentChat = interactionParentChat(event)
   return {
     kind: 'parsed',
     command: {
       name,
       key: { adapter: 'discord-bot', workspace, chat: event.channel_id, thread: null },
+      ...(parentChat !== undefined ? { parentChat } : {}),
       invokerId,
       interactionId: event.id,
       interactionToken: event.token,
     },
   }
+}
+
+type RawDiscordInteractionEvent = DiscordGatewayInteractionEvent & {
+  channel?: { id?: string; type?: number; parent_id?: string | null }
+}
+
+function interactionParentChat(event: DiscordGatewayInteractionEvent): string | undefined {
+  const channel = (event as RawDiscordInteractionEvent).channel
+  if (
+    channel === undefined ||
+    !isDiscordSnowflake(event.guild_id ?? '') ||
+    !isDiscordSnowflake(event.channel_id ?? '') ||
+    channel.id !== event.channel_id
+  )
+    return undefined
+  const parentChat = discordThreadRoom(channel)?.parentChat
+  return parentChat !== undefined && isDiscordSnowflake(parentChat) ? parentChat : undefined
 }
 
 // Content is required even when there's nothing to stop, because Discord

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -1922,7 +1922,7 @@ describe('discord-bot slash command declarations', () => {
 
 describe('createInteractionHandler', () => {
   type CapturedCall = { url: string; init: RequestInit }
-  type RouterCall = { key: ChannelKey; name: string; invokerId: string }
+  type RouterCall = { key: ChannelKey; name: string; invokerId: string; parentChat?: string }
   type RouterResult =
     | { kind: 'handled'; name: string; reply?: string }
     | { kind: 'no-live-session' }
@@ -1948,7 +1948,12 @@ describe('createInteractionHandler', () => {
     const handler = createInteractionHandler({
       router: {
         executeCommand: async (key, name, options) => {
-          routerCalls.push({ key, name, invokerId: options.invokerId })
+          routerCalls.push({
+            key,
+            name,
+            invokerId: options.invokerId,
+            ...(options.parentChat !== undefined ? { parentChat: options.parentChat } : {}),
+          })
           return routerImpl(key, name, options.invokerId)
         },
       },
@@ -1995,6 +2000,25 @@ describe('createInteractionHandler', () => {
     const body = JSON.parse(fetchCalls[0]!.init.body as string)
     expect(body.data.content).toContain('Stopped')
     expect(body.data.flags).toBe(64)
+  })
+
+  test('/stop interaction forwards its Discord thread parent to executeCommand', async () => {
+    const { handler, routerCalls } = setup(async () => ({ kind: 'handled', name: 'stop' }))
+    const event = interaction({
+      channel_id: '100000000000000001',
+      guild_id: '100000000000000002',
+    }) as Parameters<ReturnType<typeof createInteractionHandler>>[0] & {
+      channel: { id: string; type: number; parent_id: string }
+    }
+    event.channel = {
+      id: '100000000000000001',
+      type: 11,
+      parent_id: '100000000000000003',
+    }
+
+    await handler(event)
+
+    expect(routerCalls[0]?.parentChat).toBe('100000000000000003')
   })
 
   test('/help interaction acks with the handler-provided command list', async () => {

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -992,6 +992,7 @@ export function createInteractionHandler(
 
       const result = await deps.router.executeCommand(command.key, command.name, {
         invokerId: command.invokerId,
+        ...(command.parentChat !== undefined ? { parentChat: command.parentChat } : {}),
       })
       const replyContent =
         result.kind === 'handled'

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8257,6 +8257,28 @@ describe('ChannelRouter commands', () => {
 })
 
 describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
+  test('permission origin includes a Discord slash command thread parent', async () => {
+    const permissions: PermissionService = {
+      has: (origin) => origin?.kind === 'channel' && origin.parentChat === 'parent-c1',
+      resolveRole: () => 'member',
+      compareRoleSeverity: () => undefined,
+      permissionsForRole: () => undefined,
+      describe: () => ({ role: 'member', permissions: ['session.control'] }),
+      replaceRoles: () => {},
+    }
+    const dir = await tempDir()
+    const { router } = makeRouter(dir, { permissions })
+    const key: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'thread-c1', thread: null }
+
+    expect(await router.executeCommand(key, 'stop', { invokerId: 'alice' })).toEqual({ kind: 'permission-denied' })
+    expect(
+      await router.executeCommand(key, 'stop', {
+        invokerId: 'alice',
+        parentChat: 'parent-c1',
+      }),
+    ).toEqual({ kind: 'no-live-session' })
+  })
+
   test('stop on a live session aborts the in-flight turn', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
@@ -12290,6 +12312,31 @@ describe('ChannelRouter channel.respond gate', () => {
 
     expect(sessions).toHaveLength(1)
     expect(sessions[0]!.prompts).toHaveLength(1)
+  })
+
+  test('permission origin includes the resolved Discord parent channel', async () => {
+    const dir = await tempDir()
+    const checkedOrigins: SessionOrigin[] = []
+    const permissions: PermissionService = {
+      ...buildPermissions({}),
+      has: (origin, permission) => {
+        if (origin !== undefined) checkedOrigins.push(origin)
+        return permission === 'channel.respond' && origin?.kind === 'channel' && origin.parentChat === 'parent-c1'
+      },
+    }
+    const { router, sessions } = makeRouter(dir, { permissions })
+
+    await router.route(
+      inbound({
+        adapter: 'discord-bot',
+        chat: 'thread-c1',
+        room: { kind: 'thread', parentChat: 'parent-c1' },
+      }),
+    )
+    await router.__testing!.flushDebounce({ ...KEY, adapter: 'discord-bot', chat: 'thread-c1' })
+
+    expect(checkedOrigins.some((origin) => origin.kind === 'channel' && origin.parentChat === 'parent-c1')).toBe(true)
+    expect(sessions).toHaveLength(1)
   })
 
   test('author lacks channel.respond → inbound dropped, no session created', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1323,6 +1323,7 @@ export type ExecuteCommandResult =
 // happened to be live, bypassing role gating entirely.
 export type ExecuteCommandOptions = {
   invokerId: string
+  parentChat?: string
 }
 
 export type SendSource = 'tool' | 'system'
@@ -4009,6 +4010,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     workspace: event.workspace,
     chat: event.chat,
     thread: event.thread,
+    ...(event.room?.parentChat !== undefined ? { parentChat: event.room.parentChat } : {}),
     lastInboundAuthorId: event.authorId,
   })
 
@@ -6032,6 +6034,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         workspace: key.workspace,
         chat: key.chat,
         thread: key.thread,
+        ...(options.parentChat !== undefined ? { parentChat: options.parentChat } : {}),
         lastInboundAuthorId: options.invokerId,
       }
       if (!permissions.has(partial, requiredPermission)) {

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -335,6 +335,24 @@ describe('PermissionService — role resolution cache', () => {
     expect(svc.resolveRole({ ...slackOwnerChat, chat: 'C_OTHER' })).toBe('guest')
   })
 
+  test('discord thread parent is matched and isolated in the role cache', () => {
+    const roles = parseRoles({ trusted: { match: ['discord:GUILD/PARENT author:U_ME'] } })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    const thread: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: 'GUILD',
+      chat: 'THREAD',
+      thread: null,
+      parentChat: 'PARENT',
+      lastInboundAuthorId: 'U_ME',
+    }
+
+    expect(svc.resolveRole(thread)).toBe('trusted')
+    expect(svc.resolveRole({ ...thread, parentChat: 'OTHER_PARENT' })).toBe('guest')
+    expect(svc.resolveRole({ ...thread, parentChat: undefined })).toBe('guest')
+  })
+
   test('adapter is part of the key (identical coordinates under discord-bot do not inherit slack verdict)', () => {
     // Same workspace/chat/author, different adapter. Only slack is trusted;
     // if `adapter` were omitted from the key, the discord origin would inherit

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -393,7 +393,7 @@ function resolveOne(
 // kinds worth caching:
 //   - tui: verdict depends only on kind (matchesOrigin's tui rule ignores
 //     sessionId), so every tui origin shares one entry.
-//   - channel: verdict depends on adapter + workspace + chat + lastInboundAuthorId
+//   - channel: verdict depends on adapter + workspace + chat + parentChat + lastInboundAuthorId
 //     (the exact inputs matchesChannel/matchesBucket/matchesAuthor read).
 // The `c` prefix + NUL separators keep channel keys unambiguous even if a field
 // contained the delimiter of another.
@@ -402,7 +402,14 @@ function roleCacheKey(origin: SessionOrigin): string | null {
     case 'tui':
       return 'tui'
     case 'channel':
-      return ['c', origin.adapter, origin.workspace, origin.chat, origin.lastInboundAuthorId ?? ''].join('\u0000')
+      return [
+        'c',
+        origin.adapter,
+        origin.workspace,
+        origin.chat,
+        origin.parentChat ?? '',
+        origin.lastInboundAuthorId ?? '',
+      ].join('\u0000')
     default:
       return null
   }
@@ -418,6 +425,7 @@ function toMatchable(origin: SessionOrigin): Parameters<typeof matchesOrigin>[1]
         adapter: origin.adapter,
         workspace: origin.workspace,
         chat: origin.chat,
+        ...(origin.parentChat !== undefined ? { parentChat: origin.parentChat } : {}),
         ...(origin.lastInboundAuthorId !== undefined ? { lastInboundAuthorId: origin.lastInboundAuthorId } : {}),
       }
     default:

--- a/src/permissions/resolve.test.ts
+++ b/src/permissions/resolve.test.ts
@@ -26,6 +26,11 @@ const discordChat: MatchableOrigin = {
   workspace: '9999',
   chat: '123456',
 }
+const discordThread: MatchableOrigin = {
+  ...discordChat,
+  chat: 'thread-123',
+  parentChat: '123456',
+}
 const lineSquare: MatchableOrigin = {
   kind: 'channel',
   adapter: 'line',
@@ -64,6 +69,18 @@ const SLACK_CHAT: MatchRule = { kind: 'channel', platform: 'slack', workspace: '
 const SLACK_WS_AUTHOR: MatchRule = { kind: 'channel', platform: 'slack', workspace: 'T0123', author: 'U_ME' }
 const SLACK_DM_BUCKET: MatchRule = { kind: 'channel', platform: 'slack', bucket: 'dm' }
 const DISCORD_GUILD: MatchRule = { kind: 'channel', platform: 'discord', workspace: '9999' }
+const DISCORD_PARENT: MatchRule = {
+  kind: 'channel',
+  platform: 'discord',
+  workspace: '9999',
+  chat: '123456',
+}
+const DISCORD_THREAD: MatchRule = {
+  kind: 'channel',
+  platform: 'discord',
+  workspace: '9999',
+  chat: 'thread-123',
+}
 const LINE_SQUARE_BUCKET: MatchRule = { kind: 'channel', platform: 'line', bucket: 'square' }
 const KAKAO_GROUP_BUCKET: MatchRule = { kind: 'channel', platform: 'kakao', bucket: 'group' }
 const WEBEX_DM_BUCKET: MatchRule = { kind: 'channel', platform: 'webex', bucket: 'dm' }
@@ -130,7 +147,31 @@ describe('matchesOrigin — channel coordinates', () => {
 
   test('discord workspace match', () => {
     expect(matchesOrigin(DISCORD_GUILD, discordChat)).toBe(true)
+    expect(matchesOrigin(DISCORD_GUILD, discordThread)).toBe(true)
     expect(matchesOrigin(DISCORD_GUILD, { ...discordChat, workspace: '8888' })).toBe(false)
+  })
+
+  test('discord parent channel matches its resolved child thread', () => {
+    expect(matchesOrigin(DISCORD_PARENT, discordThread)).toBe(true)
+    expect(matchesOrigin(DISCORD_PARENT, { ...discordThread, parentChat: 'other-parent' })).toBe(false)
+    expect(matchesOrigin(DISCORD_PARENT, { ...discordThread, parentChat: undefined })).toBe(false)
+  })
+
+  test('discord explicit thread remains strict and does not match its parent or siblings', () => {
+    expect(matchesOrigin(DISCORD_THREAD, discordThread)).toBe(true)
+    expect(matchesOrigin(DISCORD_THREAD, discordChat)).toBe(false)
+    expect(matchesOrigin(DISCORD_THREAD, { ...discordThread, chat: 'sibling-thread' })).toBe(false)
+  })
+
+  test('discord parent channel does not match a DM carrying the same chat id', () => {
+    expect(
+      matchesOrigin(DISCORD_PARENT, {
+        ...discordThread,
+        workspace: '@dm',
+        chat: '123456',
+        parentChat: undefined,
+      }),
+    ).toBe(false)
   })
 
   test('line square bucket matches the @line-square workspace prefix', () => {

--- a/src/permissions/resolve.ts
+++ b/src/permissions/resolve.ts
@@ -27,6 +27,7 @@ export type MatchableOrigin =
       adapter: AdapterId
       workspace: string
       chat: string
+      parentChat?: string
       lastInboundAuthorId?: string
     }
 
@@ -53,14 +54,19 @@ function matchesChannel(rule: Extract<MatchRule, { kind: 'channel' }>, origin: M
 
   if (rule.bucket !== undefined) {
     if (!matchesBucket(rule.bucket, origin)) return false
-    if (rule.chat !== undefined && rule.chat !== origin.chat) return false
+    if (rule.chat !== undefined && !matchesChat(rule.chat, origin)) return false
   } else {
     if (rule.workspace !== undefined && rule.workspace !== origin.workspace) return false
-    if (rule.chat !== undefined && rule.chat !== origin.chat) return false
+    if (rule.chat !== undefined && !matchesChat(rule.chat, origin)) return false
   }
 
   if (rule.author !== undefined && !matchesAuthor(rule.platform, rule.author, origin.lastInboundAuthorId)) return false
   return true
+}
+
+function matchesChat(ruleChat: string, origin: Extract<MatchableOrigin, { kind: 'channel' }>): boolean {
+  if (ruleChat === origin.chat) return true
+  return ADAPTER_TO_PLATFORM[origin.adapter] === 'discord' && ruleChat === origin.parentChat
 }
 
 // Webex person ids are base64(`ciscospark://<cluster>/PEOPLE/<uuid-or-email>`),


### PR DESCRIPTION
Closes #1350

## Background

Discord threads carry their own snowflake channel IDs, so a permission rule scoped to a parent channel (`discord:<guild>/<parent-channel> author:<id>`) never matched messages posted inside a thread spawned from that channel — `matchesChannel` compared `chat` by strict equality only. The only existing workaround was `discord:* author:<id>`, which is platform-wide: every guild the bot can see, plus DMs. Operators had no way to say "this channel and its threads" without either per-thread rules that don't survive new threads, or a scope far broader than intended (#1350).

## Summary

Implements the thread-inheritance option from the issue: a parent-channel scope now also covers its resolved child threads, while a scope naming a thread ID stays exact.

- `matchesChat` (`src/permissions/resolve.ts`) accepts a rule chat equal to either `origin.chat` or — for Discord only — `origin.parentChat`. Non-Discord adapters are untouched; they keep equality-only matching. An unresolved parent (`parentChat` undefined) fails closed, and a DM sharing the same numeric id as some channel cannot accidentally match, since `parentChat` is only ever populated on real thread origins.
- The role-resolution cache key (`src/permissions/permissions.ts`) now includes `parentChat`. The verdict depends on it, so two threads with different parents can no longer share a stale cache entry.
- Two propagation paths feed `parentChat` into the permission origin that `matchesChannel` reads:
  - **Regular messages / channel commands** (`src/channels/router.ts`) — the router already resolves a thread's parent via `discord-channel-resolver` for membership scoping; this wires that same `room.parentChat` into the permission origin built for inbound routing and for `executeCommand`.
  - **Native Discord slash commands** (`src/channels/adapters/discord-bot-slash-commands.ts`, `discord-bot.ts`) — interaction events don't go through the message-path resolver, and there's no budget to spend on a pre-ACK REST call inside Discord's 3-second interaction window. Instead, `interactionParentChat` reads the parent straight off the `channel` object Discord already includes on `INTERACTION_CREATE`, after validating that `guild_id`, `channel_id`, and `parent_id` are all well-formed snowflakes, that `channel.id` matches `event.channel_id` (so metadata for a different channel can't be substituted in), and that the channel is actually a thread type (via `discordThreadRoom`). The value then flows through `parseInteractionAsCommand`, `ParsedSlashCommand.parentChat`, `createInteractionHandler`, and `router.executeCommand`'s new `parentChat` option, into the permission origin.
- Docs updated across the four surfaces that describe this scope: `match-rule-dsl.mdx`, `discord.mdx`, `discord-bot.mdx`, and the internals `permissions.mdx`.

## What this does NOT do

- Does not add the wildcard DSL form from the issue's Option B (`discord:<guild>/<parent>/**`). Thread inheritance is the smaller change and matches Discord's own mental model of threads inheriting visibility from their parent.
- Does not change explicit thread-id rule behavior — a rule naming a thread ID still matches only that thread, not its parent or siblings.
- Does not add new parent-resolution logic for the message path; it consumes the `parentChat` the channel resolver already produces.
- Does not perform any REST lookup before acking a native interaction — `interactionParentChat` only trusts metadata Discord already attached to the event.

## Review notes

- Load-bearing check: `matchesChat` gates the parent-inheritance branch on the origin's adapter resolving to the Discord platform, so no other adapter's chat matching changes.
- `interactionParentChat`'s validation is the trust boundary for the native path — it rejects a non-thread channel type, a malformed snowflake, and a channel object whose id doesn't match the event's own channel id, all without any network I/O.
- The role-cache key change is a correctness fix, not just a cache-miss cost: without `parentChat` in the key, a cached verdict for one thread could leak into a sibling thread under a different parent.

## Verification

- `bun run check`
- Focused suite across the five files touched by this change (discord-bot-slash-commands.test.ts, discord-bot.test.ts, router.test.ts, permissions.test.ts, resolve.test.ts) — 900 pass
- `bun run test` — 13,017 pass, 31 skip, 0 fail
- Independent goal, code-quality, security, and context review — PASS