### PR TITLE
Require security guards to justify their UX cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,38 @@ bun run format
 
 No exceptions. No `--no-verify`. No partial fixes.
 
+## Security serves the product, not the other way around
+
+TypeClaw is a **productivity product**. It is not a security-guard product. Nobody adopts an agent because its sandbox is elegant — they adopt it because it does their work, and they drop it the first time it refuses to. So a security control that breaks a legitimate workflow is a **defect, in the same sense a crash is a defect**. "But it's hardening" is not a defense. A `feat(sandbox):` prefix is not a justification.
+
+**Design outward from the workflow that has to keep working.** Establish what an authorized agent must still be able to do, then constrain the actual threat with the narrowest control that stops it. Security does not get to go first and hand the UX whatever is left over. That ordering is about sequence of design, not about importance — you still ship the guard, you just don't get to bill its collateral damage to the user.
+
+**This is a demand for precision, not for permissiveness.** It is not license to expose a secret, skip an authorization check, or drop a sandbox boundary because a guard is inconvenient. Those two failure modes are not symmetric and this section does not pretend they are. When the only options genuinely are "leak protected data" or "block the work", block the work — but block it _loudly_, name the cause, and escalate the design instead of quietly picking either failure.
+
+**This section does not repeal load-bearing invariants.** A documented `MUST`, a `fail closed`, a secret boundary, a permission boundary, or anything this file marks "do not harden this back" cannot be removed by citing productivity alone. Replacing one requires naming the threat it covered, showing why its _scope_ was wrong, preserving the guarantee through a narrower control, and adding regression tests for both directions — threat still blocked, authorized workflow restored.
+
+### The scars
+
+Every one of these was an over-broad guard, not a guard that was too strict at its real threat. They are the reason this section exists.
+
+- **`69401ed4` → `79bd56bf`/`7a6f5266`/`e581896f` (2026-07-14 → 07-16).** The canonical-secret Git guard "failed closed on any unreachable or dangling object, disabling all model-driven Git/bash." Unreachable objects are normal debris from every amend/rebase/reset — and from the agent's own self-backup and dreaming rewrites — so "real agent repos accumulate dozens of them and got fully blocked without any actual secret exposure."
+- **`035da123` → `7b12232e` (2026-07-14 → 07-21).** A root `.env` reachable in Git history hard-blocked the entire bash surface, even though every declared `.env` var is already inherited into model bash — so "blocking the entire bash surface over it is pure disruption with no confidentiality gain." Worse, it was unrecoverable by design: "the guard's prescribed remediation (`git reflog expire`/`gc`) itself runs through the blocked bash, so the agent could not self-recover." A real agent reviewing an unrelated repo was bricked by its own committed `SENTRY_DSN`.
+- **`d770026d` → `9c95b981` (2026-07-14 → 07-21).** Blocking all authenticated network Git in model bash left bind-mounted reference clones to go stale "with no in-band way to refresh." The superseded attempt "tried to harden the in-bash path against hostile repo config and became an unwinnable key/flag arms race." Git is a config-driven process launcher; enumerating its dangerous keys is not a winnable game, and pretending otherwise cost a core workflow for a week.
+- **`d477c8b6` → `a8407cc5` (2026-07-28 → 08-03).** A refusal built on an untrue assumption about credential resolution "generalized a single uncredentialed agent into a universal law and refused every one of them, breaking the workflows built on the eighteen `agent-*` skills this package ships." It also pointed the model at a replacement that does not exist. Verify the real dev/host/container/bwrap credential flow before you enforce against it.
+
+Two live examples of the _diagnosability_ half of the same failure: issue **#1377**, where "`gh auth status` succeeds while `git push` fails, and nothing in git's error names the cause"; and the `guest`-role inbound drop (`src/skills/typeclaw-permissions/SKILL.md`), still "the most common cause of 'the agent stopped responding'" because the denial is invisible in-session.
+
+### Rules for adding or widening a guard
+
+- **Name both sides before you write it.** The exact threat, and the authorized workflow that must keep working. If you can't state the workflow, you don't understand the blast radius yet.
+- **Scope the denial to the offending operand** — the specific command, path, credential, principal, repo, or request. Never block a broader tool surface because narrower enforcement is more work.
+- **Ship the authorized path in the same change.** Don't remove a working capability and leave "we'll broker it later" for a follow-up. `#1377` is what that IOU looks like from the user's side. _Emergency containment is the one exception:_ when a boundary is actively being crossed and no safe authorized path exists yet, a fail-closed stopgap may land on its own — but only if it is scoped to the violating operation, visible to the operator, marked temporary at the code site, and filed with a tracked restoration issue. Miss any of those four and it isn't containment, it's the IOU again with better branding.
+- **A guard that can disable a whole tool, adapter, or the bash surface must prove every operation on that surface necessarily crosses the boundary.** Otherwise move the guard down to the operand. Whole-surface denial is the single most repeated mistake in the list above.
+- **Never fail silently to the operator.** Say what was blocked, which policy blocked it, and how to recover. This means the operator and the diagnostic surface — not that an unauthorized channel user gets told why, which would just build an authorization oracle.
+- **Leave a recovery path that isn't behind the gate.** A guard whose own prescribed remediation runs through the surface it blocks is unrecoverable — that is `7b12232e`. Recovery may be agent-accessible **only where existing runtime authorization already permits that remediation on its own**; otherwise it is an operator path outside the denied surface. It is a recovery path, never a bypass: prompt intent, a stated reason, and model-authored acknowledgements cannot open a boundary, and a guard must not grow an agent-controlled switch that turns it off (`src/bundled-plugins/security/` — "model-authored acknowledgements cannot bypass this guard").
+- **Test both directions.** The threat must fail, and representative legitimate operations must still pass. A guard test that only asserts the block is half a test.
+- **Verify the actual credential/runtime flow first.** Across dev, host, container, and bwrap. Don't generalize from one adapter, one auth mode, or one deployment state — `d477c8b6` did exactly that.
+
 ## Debugging the system prompt
 
 `bun run debug:prompt` dumps the rendered system prompt for each session-origin kind (`tui`, `cron`, `channel`, `subagent`) with placeholder values, plus a per-section token/char/byte breakdown.


### PR DESCRIPTION
## Background

Four times in five weeks, a hardening change shipped, broke a workflow that had worked for months, and had to be walked back:

| Hardening | Unbreak | What died |
| --- | --- | --- |
| `69401ed4` (07-14) | `79bd56bf` `7a6f5266` `e581896f` (07-16) | All model-driven Git/bash |
| `035da123` (07-14) | `7b12232e` (07-21) | The entire bash surface |
| `d770026d` (07-14) | `9c95b981` (07-21) | Authenticated network Git |
| `d477c8b6` (07-28) | `a8407cc5` (08-03) | All eighteen `agent-*` CLIs |

Not one of these was a guard that was too strict *at its actual threat*. Every one was a guard applied at the wrong **scope** — a narrow risk answered by denying an entire tool surface. The commit bodies say it plainly:

- `79bd56bf` — the guard "failed closed on any unreachable or dangling object, disabling all model-driven Git/bash." Unreachable objects are normal debris from every amend/rebase/reset *and from the agent's own self-backup and dreaming rewrites*, so "real agent repos accumulate dozens of them and got fully blocked without any actual secret exposure."
- `7b12232e` — a root `.env` in history blocked everything, though every declared `.env` var is already inherited into model bash: "blocking the entire bash surface over it is pure disruption with no confidentiality gain." It was also unrecoverable by construction — "the guard's prescribed remediation (`git reflog expire`/`gc`) itself runs through the blocked bash, so the agent could not self-recover." A live agent reviewing an unrelated repo got bricked by its own committed `SENTRY_DSN`.
- `9c95b981` — the superseded attempt "tried to harden the in-bash path against hostile repo config and became an unwinnable key/flag arms race," and meanwhile reference clones went stale "with no in-band way to refresh."
- `a8407cc5` — a refusal resting on an untrue claim about credential resolution "generalized a single uncredentialed agent into a universal law and refused every one of them." It also pointed the model at a replacement that does not exist.

Two more live examples of the same failure's *diagnosability* half: #1377, where "`gh auth status` succeeds while `git push` fails, and nothing in git's error names the cause"; and the `guest`-role inbound drop, still documented as "the most common cause of 'the agent stopped responding'."

Nothing in the contributor guidance said any of this was wrong, so each one passed review as an improvement. That's the actual gap this fills — not a missing guard, a missing standard.

## Summary

A new top-level `## Security serves the product, not the other way around` in `AGENTS.md`, placed after `## Pre-commit checks` so it sits above every subsystem section that carries a security invariant.

It states the product position — TypeClaw is a productivity product, not a security-guard product; a guard that breaks legitimate work is a **defect**, in the same sense a crash is a defect, and `feat(sandbox):` is not a justification — then records the four regressions as worked examples, then lands eight reviewable rules for adding or widening a guard.

**Why not the blunt version.** The originating instruction was "security is always later than UX." Directionally right, but written literally into a file that AI contributors read, in a repo holding live channel credentials, that sentence is a loaded gun: it licenses exposing a secret or dropping a sandbox boundary any time a guard is inconvenient. The section instead argues **precision, not permissiveness**, and fences itself explicitly — it does not authorize leaking a secret, skipping an authorization check, or removing a boundary, and it cannot be cited to delete a documented `MUST`, a `fail closed`, or anything this file already marks "do not harden this back." Replacing an over-broad guard requires naming the threat it covered, showing the *scope* was wrong, and testing both directions.

**Why "never fail silently" is scoped to the operator.** Written unqualified, that rule would demand telling an unauthorized channel user *why* they were denied, which builds an authorization oracle. The rule names the operator and the diagnostic surface specifically.

## What this does NOT do

- No behavior change. Markdown only, one file, +32 lines.
- Does not weaken, remove, or re-scope any existing guard. `#1377` in particular stays open and unaddressed here.
- Does not touch the runtime agent prompt. `AGENTS.md` is dev-stage contributor guidance by its own preamble — this is not model permission to negotiate runtime controls.
- No companion docs page. If this should also be public-facing threat-model prose, `docs/content/docs/internals/` is the right home and belongs in its own PR.

## Review notes

- The load-bearing part is the **fence** (paragraphs 3–4), not the stance. Read those adversarially: assume a future agent wants to delete a `fail closed` path and is looking for a sentence in this section to cite. If one works, the wording needs tightening.
- Every SHA, date, and quoted phrase is verbatim from the commit bodies in this repo's history — worth spot-checking `git show 7b12232e` and `git show a8407cc5`, which are the two strongest.
- Two additional hardening→fix pairs surfaced during research were **dropped**: `646ad8c7`→`028b3a27` and `d7f9a8c1`→`cfcbda33`. Their dates run backwards, so the causal claim isn't supported. Flagging in case someone recognizes them and wants to reconstruct the real pairing.
- Placement is deliberate. It could live next to `## Testing Philosophy` near the bottom as a sibling philosophy section, but everything it governs — the channel-adapter checklist, the `## Stages` rules of thumb, all of `src/` — appears below it. Happy to move it if you'd rather keep the top of the file purely operational.
