### PR TITLE
Suppress duplicate review close-outs and retry failed follow-ups

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
+import { createGithubReviewThreadResolver } from '@/channels/adapters/github/review-thread-resolver'
 import { OUTBOUND_FLOOD_ERROR, type ChannelRouter } from '@/channels/router'
 import type { OutboundMessage, SendResult } from '@/channels/types'
 
@@ -841,6 +842,105 @@ describe('channel_reply resolve_review_thread', () => {
     expect(result.details).toEqual({ ok: true })
   })
 
+  test('reports success without posting when the thread was already resolved', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(
+        async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        },
+        { resolveReviewThread: async () => ({ ok: true, alreadyResolved: true }) },
+      ),
+      origin: githubThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: 'Verified — fix looks solid.', resolve_review_thread: true })
+
+    expect(calls).toHaveLength(0)
+    expect(result.details).toEqual({ ok: true })
+    const rendered = (result.content[0] as { text: string }).text
+    expect(rendered).toContain('already resolved')
+    expect(rendered).toContain('no acknowledgement comment was posted')
+  })
+
+  test('posts only one acknowledgement when concurrent close-outs target the same thread', async () => {
+    let resolved = false
+    let mutations = 0
+    const fetchImpl = Object.assign(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { query: string }
+        if (body.query.includes('resolveReviewThread(input')) {
+          mutations += 1
+          resolved = true
+          return new Response(
+            JSON.stringify({
+              data: { resolveReviewThread: { thread: { id: 'PRRT_CONCURRENT', isResolved: true } } },
+            }),
+            { status: 200 },
+          )
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [
+                      {
+                        id: 'PRRT_CONCURRENT',
+                        isResolved: resolved,
+                        comments: {
+                          nodes: [
+                            {
+                              databaseId: Number(githubThreadOrigin.thread),
+                              author: { __typename: 'Bot', login: 'bot' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        )
+      },
+      { preconnect: () => {} },
+    )
+    const resolveReviewThread = createGithubReviewThreadResolver({
+      token: async () => 'tok',
+      selfLogin: () => 'bot[bot]',
+      fetchImpl,
+    })
+    const sent: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(
+        async (msg) => {
+          sent.push(msg)
+          return { ok: true }
+        },
+        { resolveReviewThread },
+      ),
+      origin: githubThreadOrigin,
+    })
+
+    const results = await Promise.all([
+      runTool(tool, { text: 'Verified — fix looks solid.', resolve_review_thread: true }),
+      runTool(tool, { text: 'Verified — fix looks solid.', resolve_review_thread: true }),
+    ])
+    const rendered = results.map((result) => (result.content[0] as { text: string }).text)
+
+    expect(results.every((result) => result.details.ok)).toBe(true)
+    expect(rendered.filter((text) => text.includes('already resolved'))).toHaveLength(1)
+    expect(rendered.filter((text) => text.includes('posted to github:acme/widgets/pr:585'))).toHaveLength(1)
+    expect(mutations).toBe(1)
+    expect(sent).toHaveLength(1)
+  })
+
   test('blocks the reply when the resolve fails', async () => {
     const calls: OutboundMessage[] = []
     const tool = createChannelReplyTool({
@@ -960,19 +1060,27 @@ describe('channel_reply resolve_review_thread', () => {
 
   test('does not attempt resolution on an explicit false (thread stays open)', async () => {
     let resolveCalled = false
+    let sent = 0
     const tool = createChannelReplyTool({
-      router: fakeRouter(async () => ({ ok: true }), {
-        resolveReviewThread: async () => {
-          resolveCalled = true
+      router: fakeRouter(
+        async () => {
+          sent++
           return { ok: true }
         },
-      }),
+        {
+          resolveReviewThread: async () => {
+            resolveCalled = true
+            return { ok: true, alreadyResolved: true }
+          },
+        },
+      ),
       origin: githubThreadOrigin,
     })
 
     await runTool(tool, { text: 'plain reply', resolve_review_thread: false })
 
     expect(resolveCalled).toBe(false)
+    expect(sent).toBe(1)
   })
 })
 

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -248,6 +248,12 @@ export function createChannelReplyTool({
             details: { ok: false, error: resolve.error },
           }
         }
+        if (resolve.kind === 'already-resolved') {
+          return {
+            content: [{ type: 'text' as const, text: alreadyResolvedHint(origin.thread) }],
+            details: { ok: true, ...(keepTurnAlive ? { more_work_this_turn: true } : {}) },
+          }
+        }
         // `no-match` stays non-blocking (the thread may be genuinely gone) but
         // the resolve did NOT run, so tell the model instead of posting a clean
         // receipt that hides the miss. Mirrors channel_send.
@@ -368,7 +374,11 @@ function missingReviewThreadResolveChoiceError(input: {
 // success. Every hard failure — wrong author, permission denial, HTTP 404 on a
 // misdirected lookup, transient API error — blocks, so the agent never claims a
 // thread is settled when the resolve did not actually run.
-type ResolveOutcome = { kind: 'resolved' } | { kind: 'no-match' } | { kind: 'block'; error: string }
+type ResolveOutcome =
+  | { kind: 'resolved' }
+  | { kind: 'already-resolved' }
+  | { kind: 'no-match' }
+  | { kind: 'block'; error: string }
 
 async function resolveReviewThreadBeforeReply(
   router: ChannelRouter,
@@ -389,9 +399,15 @@ async function resolveReviewThreadBeforeReply(
     chat: origin.chat,
     rootCommentId: origin.thread,
   })
-  if (result.ok) return { kind: 'resolved' }
+  if (result.ok) return { kind: result.alreadyResolved === true ? 'already-resolved' : 'resolved' }
   if (result.code === 'no-match') return { kind: 'no-match' }
   return { kind: 'block', error: `could not resolve review thread: ${result.error}` }
+}
+
+function alreadyResolvedHint(thread: string | null): string {
+  return fenceRuntimeNotice(
+    `review thread ${JSON.stringify(thread)} was already resolved; no acknowledgement comment was posted.`,
+  )
 }
 
 // The model asked to resolve but no thread was rooted at this comment. Fenced

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -868,5 +868,33 @@ describe('createChannelSendTool', () => {
       expect(result.details).toEqual({ ok: true })
       expect(order).toEqual(['resolve:RC_kwABC', 'send'])
     })
+
+    test('reports success without posting when the thread was already resolved', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: {
+          ...fakeRouter(async (msg) => {
+            calls.push(msg)
+            return { ok: true }
+          }),
+          resolveReviewThread: async () => ({ ok: true, alreadyResolved: true }),
+        },
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'github',
+        workspace: 'acme/widgets',
+        chat: 'pr:585',
+        thread: 'RC_kwABC',
+        text: 'Verified — fix looks solid.',
+        resolve_review_thread: true,
+      })
+
+      expect(calls).toHaveLength(0)
+      expect(result.details).toEqual({ ok: true })
+      const rendered = (result.content[0] as { text: string }).text
+      expect(rendered).toContain('already resolved')
+      expect(rendered).toContain('no acknowledgement comment was posted')
+    })
   })
 })

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -261,6 +261,12 @@ export function createChannelSendTool({
             details: { ok: false, error: resolve.error },
           }
         }
+        if (resolve.kind === 'already-resolved') {
+          return {
+            content: [{ type: 'text' as const, text: alreadyResolvedHint(params.thread ?? null) }],
+            details: { ok: true },
+          }
+        }
         // `no-match`: the thread listed cleanly but nothing is rooted at this
         // comment (gone, or a mispaired id from the bare-id follow-up list). It
         // stays non-blocking so a genuinely-deleted thread's ack still posts,
@@ -360,7 +366,11 @@ function missingReviewThreadResolveChoiceError(input: {
   )
 }
 
-type ResolveOutcome = { kind: 'resolved' } | { kind: 'no-match' } | { kind: 'block'; error: string }
+type ResolveOutcome =
+  | { kind: 'resolved' }
+  | { kind: 'already-resolved' }
+  | { kind: 'no-match' }
+  | { kind: 'block'; error: string }
 
 async function resolveReviewThreadBeforeSend(
   router: ChannelRouter,
@@ -378,9 +388,15 @@ async function resolveReviewThreadBeforeSend(
     chat: target.chat,
     rootCommentId: target.thread,
   })
-  if (result.ok) return { kind: 'resolved' }
+  if (result.ok) return { kind: result.alreadyResolved === true ? 'already-resolved' : 'resolved' }
   if (result.code === 'no-match') return { kind: 'no-match' }
   return { kind: 'block', error: `could not resolve review thread: ${result.error}` }
+}
+
+function alreadyResolvedHint(thread: string | null): string {
+  return fenceRuntimeNotice(
+    `review thread ${JSON.stringify(thread)} was already resolved; no acknowledgement comment was posted.`,
+  )
 }
 
 // The model asked to resolve but no thread was rooted at this comment. Fenced

--- a/src/channels/adapters/github/dedup.test.ts
+++ b/src/channels/adapters/github/dedup.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'bun:test'
 
-import { createDeliveryDedup } from './dedup'
+import { createBoundedMap, createDeliveryDedup } from './dedup'
+
+describe('createBoundedMap', () => {
+  it('evicts the least-recently inserted entry once it reaches the cap', () => {
+    const values = createBoundedMap<string, number>(2)
+    values.set('a', 1)
+    values.set('b', 2)
+    values.set('c', 3)
+
+    expect(values.has('a')).toBe(false)
+    expect(values.get('b')).toBe(2)
+    expect(values.get('c')).toBe(3)
+    expect(values.size()).toBe(2)
+  })
+})
 
 describe('createDeliveryDedup', () => {
   it('keeps recent deliveries and evicts least-recently inserted ids', () => {

--- a/src/channels/adapters/github/dedup.ts
+++ b/src/channels/adapters/github/dedup.ts
@@ -4,23 +4,52 @@ export type DeliveryDedup = {
   size: () => number
 }
 
+export type BoundedMap<K, V> = {
+  has: (key: K) => boolean
+  get: (key: K) => V | undefined
+  set: (key: K, value: V) => void
+  delete: (key: K) => boolean
+  size: () => number
+}
+
+export function createBoundedMap<K, V>(limit = 1000): BoundedMap<K, V> {
+  const values = new Map<K, V>()
+  return {
+    has(key): boolean {
+      return values.has(key)
+    },
+    get(key): V | undefined {
+      return values.get(key)
+    },
+    set(key, value): void {
+      if (values.has(key)) values.delete(key)
+      values.set(key, value)
+      while (values.size > limit) {
+        const oldest = values.keys().next().value
+        if (oldest === undefined) break
+        values.delete(oldest)
+      }
+    },
+    delete(key): boolean {
+      return values.delete(key)
+    },
+    size(): number {
+      return values.size
+    },
+  }
+}
+
 export function createDeliveryDedup(limit = 1000): DeliveryDedup {
-  const seen = new Map<string, true>()
+  const seen = createBoundedMap<string, true>(limit)
   return {
     has(deliveryId: string): boolean {
       return seen.has(deliveryId)
     },
     add(deliveryId: string): void {
-      if (seen.has(deliveryId)) seen.delete(deliveryId)
       seen.set(deliveryId, true)
-      while (seen.size > limit) {
-        const oldest = seen.keys().next().value
-        if (oldest === undefined) break
-        seen.delete(oldest)
-      }
     },
     size(): number {
-      return seen.size
+      return seen.size()
     },
   }
 }

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -1657,6 +1657,8 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     tasks: Array<() => Promise<void>>
     warns?: string[]
     authToken?: GithubWebhookHandlerOptions['authToken']
+    reviewOn?: 'review_requested' | 'opened' | 'off'
+    sleepImpl?: GithubWebhookHandlerOptions['sleepImpl']
   }) {
     return createGithubWebhookHandler({
       webhookSecret: 'secret',
@@ -1665,11 +1667,13 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
       selfId: () => '99',
       selfLogin: () => 'typeclaw-bot[bot]',
       authType: () => 'app',
+      ...(input.reviewOn !== undefined ? { reviewOn: () => input.reviewOn! } : {}),
       authToken: input.authToken ?? (async () => 'tok'),
       fetchImpl: input.fetchImpl,
       scheduleBackgroundTask: (task) => {
         input.tasks.push(task)
       },
+      sleepImpl: input.sleepImpl ?? (async () => {}),
       logger: { info: () => {}, warn: (m) => input.warns?.push(m), error: () => {} },
       route: (msg) => {
         input.routed.push(msg)
@@ -1742,8 +1746,6 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(msg.workspace).toBe('acme/project')
     expect(msg.text).toContain('PR #7')
     expect(msg.text).toContain('deadbee')
-    // Per-thread context lets the model tell threads apart so it passes the
-    // right root comment id as `thread` (the resolve+reply pairing key).
     expect(msg.text).toContain('thread 100 on src/api/auth.ts:42')
     expect(msg.text).toContain('This token never expires — set a TTL.')
     expect(msg.text).toContain('thread 200')
@@ -1769,7 +1771,32 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(routed).toHaveLength(0)
   })
 
-  it('dedups a redelivered synchronize so the sweep runs once', async () => {
+  it('does not schedule a synchronize excluded by the event allowlist', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => [],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot[bot]',
+      authToken: async () => 'tok',
+      scheduleBackgroundTask: (task) => {
+        tasks.push(task)
+      },
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-not-allowed'))
+
+    expect(tasks).toHaveLength(0)
+    expect(routed).toHaveLength(0)
+  })
+
+  it('dedups a successful synchronize redelivery with the same delivery id', async () => {
     const routed: InboundMessage[] = []
     const tasks: Array<() => Promise<void>> = []
     const dedup = createDeliveryDedup()
@@ -1793,9 +1820,11 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
 
     const body = JSON.stringify(synchronizePayload())
     await handler(signedRequest(body, 'pull_request', 'sync-dup'))
+    await tasks[0]?.()
     await handler(signedRequest(body, 'pull_request', 'sync-dup'))
 
     expect(tasks).toHaveLength(1)
+    expect(routed).toHaveLength(1)
   })
 
   it('warns and does not route when the thread listing fails', async () => {
@@ -1814,6 +1843,69 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
 
     expect(routed).toHaveLength(0)
     expect(warns.some((w) => w.includes('review-thread recheck failed'))).toBe(true)
+  })
+
+  it('retries a failed thread-list lookup within one scheduled followup', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const sleeps: number[] = []
+    let calls = 0
+    const handler = recheckHandler({
+      fetchImpl: fakeFetch((url) => {
+        if (url.includes('/reviews')) return reviewsResponse([])
+        calls++
+        if (calls === 1) return new Response('boom', { status: 500 })
+        return threadsResponse([{ id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' }])
+      }),
+      routed,
+      tasks,
+      sleepImpl: async (ms) => {
+        sleeps.push(ms)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload('retry-sha')), 'pull_request', 'sync-retry'))
+    await tasks[0]?.()
+
+    expect(tasks).toHaveLength(1)
+    expect(calls).toBe(2)
+    expect(sleeps).toEqual([1000])
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.thread).toBe(null)
+    expect(routed[0]?.externalMessageId).toBe('pr-7-recheck-retry-sha')
+  })
+
+  it('bounds failed followup retries for a persistently failing repo', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const warns: string[] = []
+    const sleeps: number[] = []
+    let calls = 0
+    const handler = recheckHandler({
+      fetchImpl: fakeFetch(() => {
+        calls++
+        return new Response('boom', { status: 500 })
+      }),
+      routed,
+      tasks,
+      warns,
+      sleepImpl: async (ms) => {
+        sleeps.push(ms)
+      },
+    })
+
+    await handler(
+      signedRequest(JSON.stringify(synchronizePayload('always-fails')), 'pull_request', 'sync-always-fails'),
+    )
+    await tasks[0]?.()
+
+    expect(tasks).toHaveLength(1)
+    expect(calls).toBe(3)
+    expect(sleeps).toEqual([1000, 2000])
+    expect(routed).toHaveLength(0)
+    expect(warns.some((warning) => warning.includes('retry cap exhausted') && warning.includes('acme/project#7'))).toBe(
+      true,
+    )
   })
 
   it('re-reviews a held CHANGES_REQUESTED even with no unresolved threads', async () => {
@@ -1875,9 +1967,11 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     await tasks[0]?.()
 
     expect(routed).toHaveLength(1)
+    expect(routed[0]!.thread).toBe(null)
     expect(routed[0]!.text).toContain('100')
     expect(routed[0]!.text).toContain('CHANGES_REQUESTED')
     expect(routed[0]!.text).not.toContain('end your turn without replying')
+    expect(routed[0]!.externalMessageId).toBe('pr-7-recheck-abc1234def')
   })
 
   it('skips the CHANGES_REQUESTED re-review when review.on is off', async () => {
@@ -1908,7 +2002,7 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(routed).toHaveLength(0)
   })
 
-  it('dedups two deliveries with the same head sha to one followup', async () => {
+  it('reserves a same-sha followup synchronously across concurrent deliveries', async () => {
     const routed: InboundMessage[] = []
     const tasks: Array<() => Promise<void>> = []
     const dedup = createDeliveryDedup()
@@ -1931,8 +2025,10 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     })
 
     const body = JSON.stringify(synchronizePayload('samesha777'))
-    await handler(signedRequest(body, 'pull_request', 'sync-sha-1'))
-    await handler(signedRequest(body, 'pull_request', 'sync-sha-2'))
+    await Promise.all([
+      handler(signedRequest(body, 'pull_request', 'sync-sha-1')),
+      handler(signedRequest(body, 'pull_request', 'sync-sha-2')),
+    ])
 
     expect(tasks).toHaveLength(1)
     await tasks[0]?.()
@@ -1967,6 +2063,30 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(tasks).toHaveLength(2)
   })
 
+  it('bounds completed followup reservations across many distinct head shas', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = recheckHandler({ fetchImpl: followupFetch({}), routed, tasks })
+
+    for (let index = 0; index <= 1000; index++) {
+      const sha = `sha-${index}`
+      await handler(signedRequest(JSON.stringify(synchronizePayload(sha)), 'pull_request', `sync-cap-${index}`))
+      await tasks[index]?.()
+    }
+
+    expect(tasks).toHaveLength(1001)
+
+    await handler(
+      signedRequest(JSON.stringify(synchronizePayload('sha-1000')), 'pull_request', 'sync-cap-latest-redelivery'),
+    )
+    expect(tasks).toHaveLength(1001)
+
+    await handler(
+      signedRequest(JSON.stringify(synchronizePayload('sha-0')), 'pull_request', 'sync-cap-oldest-redelivery'),
+    )
+    expect(tasks).toHaveLength(1002)
+  })
+
   it('skips the followup when the synchronize carries no head sha', async () => {
     const routed: InboundMessage[] = []
     const tasks: Array<() => Promise<void>> = []
@@ -1988,26 +2108,43 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(warns.some((w) => w.includes('no head sha'))).toBe(true)
   })
 
-  it('still routes threads when the review-state lookup fails', async () => {
+  it('retries the whole followup when review-state lookup fails with unresolved threads', async () => {
     const routed: InboundMessage[] = []
     const tasks: Array<() => Promise<void>> = []
     const warns: string[] = []
+    const sleeps: number[] = []
+    let reviewCalls = 0
     const handler = recheckHandler({
       fetchImpl: fakeFetch((url) => {
-        if (url.includes('/reviews')) return new Response('boom', { status: 500 })
+        if (url.includes('/reviews')) {
+          reviewCalls++
+          return reviewCalls === 1
+            ? new Response('boom', { status: 500 })
+            : reviewsResponse([{ state: 'CHANGES_REQUESTED' }])
+        }
         return threadsResponse([{ id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' }])
       }),
       routed,
       tasks,
       warns,
+      sleepImpl: async (ms) => {
+        sleeps.push(ms)
+      },
     })
 
-    await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-state-fail'))
+    await handler(
+      signedRequest(JSON.stringify(synchronizePayload('state-retry-sha')), 'pull_request', 'sync-state-fail'),
+    )
     await tasks[0]?.()
 
-    expect(routed).toHaveLength(1)
-    expect(routed[0]!.text).toContain('100')
     expect(warns.some((w) => w.includes('review-state recheck failed'))).toBe(true)
+    expect(tasks).toHaveLength(1)
+    expect(reviewCalls).toBe(2)
+    expect(sleeps).toEqual([1000])
+    expect(routed).toHaveLength(1)
+    expect(routed[0]!.thread).toBe(null)
+    expect(routed[0]!.externalMessageId).toBe('pr-7-recheck-state-retry-sha')
+    expect(routed[0]!.text).toContain('CHANGES_REQUESTED')
   })
 })
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -7,7 +7,7 @@ import { describeError } from '../../describe-error'
 import type { GithubAuthContext } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { removeRequestedReviewer } from './decoy-reviewer'
-import type { DeliveryDedup } from './dedup'
+import { createBoundedMap, type BoundedMap, type DeliveryDedup } from './dedup'
 import { isGithubEventAllowed } from './event-allowlist'
 import { encodeGithubReactionRef, type GithubReactionTarget } from './reactions'
 import { fetchSelfReviewBlocking } from './review-state'
@@ -48,6 +48,7 @@ export type GithubWebhookHandlerOptions = {
   // Schedules the decoy-drop off the webhook ACK path so the 200 stays fast.
   // Defaults to fire-and-forget; tests inject a recorder to await the task.
   scheduleBackgroundTask?: (task: () => Promise<void>) => void
+  sleepImpl?: (ms: number) => Promise<void>
   fetchImpl?: typeof fetch
 }
 
@@ -85,21 +86,23 @@ export async function processVerifiedGithubDelivery(
   input: { event: string; delivery: string; payload: Record<string, unknown> },
 ): Promise<void> {
   const { event, delivery, payload } = input
-  if (delivery !== '') {
+  const action = readString(payload, 'action')
+  const isSynchronize = event === 'pull_request' && action === 'synchronize'
+  if (!isSynchronize && delivery !== '') {
     if (options.dedup.has(delivery)) {
       options.logger.info(`[github] duplicate delivery ignored id=${delivery}`)
       return
     }
     // Reserve the delivery id synchronously, BEFORE the awaits below, so a live
     // webhook and the recovery sweep can never both clear the dedup gate for the
-    // same event and route it twice. JS is single-threaded: nothing else runs
-    // between this has-check and add, so the reservation is atomic. The awaits
-    // and classify that follow are all throw-safe, so reserving early cannot
-    // strand a routable event.
+    // same event and route it twice. Synchronize uses its own synchronous,
+    // releasable head-SHA reservation so a failed redelivery can retry. JS is
+    // single-threaded: nothing else runs between this has-check and add, so the
+    // reservation is atomic. The awaits and classify that follow are all
+    // throw-safe, so reserving early cannot strand a routable event.
     options.dedup.add(delivery)
   }
 
-  const action = readString(payload, 'action')
   if (!isGithubEventAllowed(options.allowlist(), event, action)) return
 
   const selfId = options.selfId()
@@ -121,7 +124,7 @@ export async function processVerifiedGithubDelivery(
   // so it runs OFF the ACK path (like the decoy-reviewer drop) and only wakes a
   // session when an obligation is outstanding. Returning here also keeps
   // synchronize out of the generic awareness-only fallthrough below.
-  if (event === 'pull_request' && action === 'synchronize') {
+  if (isSynchronize) {
     scheduleReviewFollowup({ payload, selfLogin, options })
     return
   }
@@ -214,6 +217,38 @@ function defaultScheduleBackgroundTask(task: () => Promise<void>): void {
   void task().catch(() => {})
 }
 
+const MAX_REVIEW_FOLLOWUP_ATTEMPTS = 3
+const REVIEW_FOLLOWUP_RETRY_BASE_MS = 1000
+const REVIEW_FOLLOWUP_DEDUP_LIMIT = 1000
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+type ReviewFollowupDedupState = {
+  reservations: BoundedMap<string, 'pending' | 'completed'>
+  failures: BoundedMap<string, number>
+}
+
+// This state cannot live in createGithubWebhookHandler's closure because the
+// exported processVerifiedGithubDelivery core is also called directly by the
+// recovery sweep. Keying by the shared options identity gives both paths one
+// handler-scoped state while allowing it to be garbage-collected. It stays
+// separate from options.dedup because that add-only delivery cache has no
+// release path, which would recreate the transient-failure retry hole here.
+const reviewFollowupDedupByHandler = new WeakMap<GithubWebhookHandlerOptions, ReviewFollowupDedupState>()
+
+function reviewFollowupDedup(options: GithubWebhookHandlerOptions): ReviewFollowupDedupState {
+  const existing = reviewFollowupDedupByHandler.get(options)
+  if (existing !== undefined) return existing
+  const created: ReviewFollowupDedupState = {
+    reservations: createBoundedMap(REVIEW_FOLLOWUP_DEDUP_LIMIT),
+    failures: createBoundedMap(REVIEW_FOLLOWUP_DEDUP_LIMIT),
+  }
+  reviewFollowupDedupByHandler.set(options, created)
+  return created
+}
+
 function scheduleReviewFollowup(input: {
   payload: Record<string, unknown>
   selfLogin: string | null
@@ -239,15 +274,19 @@ function scheduleReviewFollowup(input: {
     options.logger.warn(`[github] synchronize for ${repository.owner}/${repository.name}#${pullNumber} has no head sha`)
     return
   }
-  const followupKey = `synchronize-followup:${repository.owner}/${repository.name}#${pullNumber}:${headSha}`
-  if (options.dedup.has(followupKey)) return
-  options.dedup.add(followupKey)
+  const followupKey = `${repository.owner}/${repository.name}#${pullNumber}:${headSha}`
+  const followupDedup = reviewFollowupDedup(options)
+  if (followupDedup.reservations.has(followupKey)) return
+  if ((followupDedup.failures.get(followupKey) ?? 0) >= MAX_REVIEW_FOLLOWUP_ATTEMPTS) return
+  followupDedup.reservations.set(followupKey, 'pending')
 
   const reviewOn = options.reviewOn?.() ?? 'review_requested'
   const fetchImpl = options.fetchImpl ?? fetch
   const schedule = options.scheduleBackgroundTask ?? defaultScheduleBackgroundTask
+  const sleepImpl = options.sleepImpl ?? defaultSleep
   const target = `${repository.owner}/${repository.name}#${pullNumber}`
-  schedule(async () => {
+
+  const runFollowupAttempt = async (): Promise<'completed' | 'retry'> => {
     try {
       const token = await authToken({ repoSlug: `${repository.owner}/${repository.name}` })
       const threads = await listUnresolvedSelfReviewThreads({
@@ -260,7 +299,7 @@ function scheduleReviewFollowup(input: {
       })
       if (!threads.ok) {
         options.logger.warn(`[github] review-thread recheck failed for ${target}: ${threads.error}`)
-        return
+        return 'retry'
       }
 
       // A held CHANGES_REQUESTED is the bot's own obligation regardless of how
@@ -276,10 +315,19 @@ function scheduleReviewFollowup(input: {
           fetchImpl,
         })
         if (blocking.ok) selfBlocking = blocking.selfBlocking
-        else options.logger.warn(`[github] review-state recheck failed for ${target}: ${blocking.error}`)
+        else {
+          options.logger.warn(`[github] review-state recheck failed for ${target}: ${blocking.error}`)
+          // Thread and verdict obligations form one follow-up attempt. Routing
+          // only the known threads would mark this SHA complete and permanently
+          // lose a blocking-review obligation, so fail the whole attempt and let
+          // the scheduled job retry both lookups before anything is routed.
+          return 'retry'
+        }
       }
 
-      if (threads.threads.length === 0 && !selfBlocking) return
+      if (threads.threads.length === 0 && !selfBlocking) {
+        return 'completed'
+      }
       options.route(
         withApprovalPolicy(
           buildReviewFollowupInbound({
@@ -293,9 +341,31 @@ function scheduleReviewFollowup(input: {
           options.allowApprove?.() ?? true,
         ),
       )
+      return 'completed'
     } catch (err) {
       options.logger.warn(`[github] review followup failed for ${target}: ${describeError(err)}`)
+      return 'retry'
     }
+  }
+
+  schedule(async () => {
+    for (let attempt = 1; attempt <= MAX_REVIEW_FOLLOWUP_ATTEMPTS; attempt += 1) {
+      if ((await runFollowupAttempt()) === 'completed') {
+        followupDedup.reservations.set(followupKey, 'completed')
+        followupDedup.failures.delete(followupKey)
+        return
+      }
+      if (attempt < MAX_REVIEW_FOLLOWUP_ATTEMPTS) {
+        await sleepImpl(REVIEW_FOLLOWUP_RETRY_BASE_MS * 2 ** (attempt - 1))
+      }
+    }
+
+    followupDedup.reservations.delete(followupKey)
+    const failures = (followupDedup.failures.get(followupKey) ?? 0) + MAX_REVIEW_FOLLOWUP_ATTEMPTS
+    followupDedup.failures.set(followupKey, failures)
+    options.logger.warn(
+      `[github] review followup retry cap exhausted for ${target} head=${headSha} attempts=${failures}; a new head or adapter restart is required to retry`,
+    )
   })
 }
 

--- a/src/channels/adapters/github/review-thread-resolver.test.ts
+++ b/src/channels/adapters/github/review-thread-resolver.test.ts
@@ -235,6 +235,81 @@ describe('github review-thread resolver', () => {
     expect(seen.mutations).toEqual([])
   })
 
+  it('serializes concurrent close-outs on one thread so only the leader mutates', async () => {
+    // given: a live thread whose state flips once the mutation lands, so a
+    // follower that looks it up AFTER the leader observes it already resolved
+    const state = { resolved: false, mutations: 0 }
+    const fetchImpl = Object.assign(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { query: string }
+        if (body.query.includes('resolveReviewThread(input')) {
+          state.mutations += 1
+          state.resolved = true
+          return new Response(
+            JSON.stringify({ data: { resolveReviewThread: { thread: { id: 'PRRT_C', isResolved: true } } } }),
+            { status: 200 },
+          )
+        }
+        return new Response(
+          JSON.stringify(
+            threadsPayload({
+              threads: [{ id: 'PRRT_C', isResolved: state.resolved, rootCommentId: 700, rootAuthorLogin: 'bot[bot]' }],
+              hasNextPage: false,
+              endCursor: null,
+            }),
+          ),
+          { status: 200 },
+        )
+      },
+      { preconnect: () => {} },
+    )
+    const resolve = resolverFor(fetchImpl)
+
+    // when: two sessions close the same thread out at the same time
+    const [first, second] = await Promise.all([resolve(req(700)), resolve(req(700))])
+
+    // then: exactly one mutation ran and the follower reports the no-op, so the
+    // caller suppresses its duplicate acknowledgement
+    expect(state.mutations).toBe(1)
+    expect([first, second].filter((r) => r.ok && r.alreadyResolved !== true)).toHaveLength(1)
+    expect([first, second].filter((r) => r.ok && r.alreadyResolved === true)).toHaveLength(1)
+  })
+
+  it('releases the per-thread lock when a resolve throws', async () => {
+    let calls = 0
+    const fetchImpl = Object.assign(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { query: string }
+        calls += 1
+        if (calls === 1) throw new Error('boom')
+        if (body.query.includes('resolveReviewThread(input')) {
+          return new Response(
+            JSON.stringify({ data: { resolveReviewThread: { thread: { id: 'PRRT_L', isResolved: true } } } }),
+            { status: 200 },
+          )
+        }
+        return new Response(
+          JSON.stringify(
+            threadsPayload({
+              threads: [{ id: 'PRRT_L', isResolved: false, rootCommentId: 800, rootAuthorLogin: 'bot[bot]' }],
+              hasNextPage: false,
+              endCursor: null,
+            }),
+          ),
+          { status: 200 },
+        )
+      },
+      { preconnect: () => {} },
+    )
+    const resolve = resolverFor(fetchImpl)
+
+    const failed = await resolve(req(800))
+    const recovered = await resolve(req(800))
+
+    expect(failed.ok).toBe(false)
+    expect(recovered.ok).toBe(true)
+  })
+
   it('paginates past the first page to find a thread that sits later', async () => {
     const seen = { mutations: [] as string[], queryCount: 0 }
     const resolve = resolverFor(

--- a/src/channels/adapters/github/review-thread-resolver.ts
+++ b/src/channels/adapters/github/review-thread-resolver.ts
@@ -57,31 +57,63 @@ export function createGithubReviewThreadResolver(deps: {
       }
     }
 
-    const token = await deps.token({ repoSlug: `${target.owner}/${target.repo}` })
-    const lookup = await findThread(fetchImpl, token, target)
-    if (lookup.kind === 'error') return lookup.result
-    if (lookup.kind === 'absent') {
-      return {
-        ok: false,
-        error: `no review thread rooted at comment ${target.rootCommentId} on ${req.chat}`,
-        code: 'no-match',
+    return await withThreadLock(threadLockKey(target), async () => {
+      const token = await deps.token({ repoSlug: `${target.owner}/${target.repo}` })
+      const lookup = await findThread(fetchImpl, token, target)
+      if (lookup.kind === 'error') return lookup.result
+      if (lookup.kind === 'absent') {
+        return {
+          ok: false,
+          error: `no review thread rooted at comment ${target.rootCommentId} on ${req.chat}`,
+          code: 'no-match',
+        }
       }
-    }
 
-    const thread = lookup.thread
-    // The load-bearing guard: only the bot may resolve the bot's own thread.
-    // Resolving a human reviewer's thread would erase their open question.
-    if (!isSelfAuthor(thread, selfLogin)) {
-      return {
-        ok: false,
-        error: `refusing to resolve thread authored by @${thread.rootAuthorLogin ?? 'unknown'} (not @${selfLogin})`,
-        code: 'not-author',
+      const thread = lookup.thread
+      // The load-bearing guard: only the bot may resolve the bot's own thread.
+      // Resolving a human reviewer's thread would erase their open question.
+      if (!isSelfAuthor(thread, selfLogin)) {
+        return {
+          ok: false,
+          error: `refusing to resolve thread authored by @${thread.rootAuthorLogin ?? 'unknown'} (not @${selfLogin})`,
+          code: 'not-author',
+        }
       }
-    }
-    if (thread.isResolved) return { ok: true, alreadyResolved: true }
+      if (thread.isResolved) return { ok: true, alreadyResolved: true }
 
-    return await runResolveMutation(fetchImpl, token, thread.id)
+      return await runResolveMutation(fetchImpl, token, thread.id)
+    })
   }
+}
+
+// `alreadyResolved` is only observable from the pre-mutation lookup, so two
+// callers that each see the thread open would both mutate and both post an
+// acknowledgement. Serializing per thread makes the follower's lookup run after
+// the leader's mutation, so it observes `isResolved` and reports the no-op
+// instead. Resolved state is never cached — GitHub stays the authority, which is
+// what keeps this correct across processes and restarts.
+const threadResolveLocks = new Map<string, Promise<void>>()
+
+function threadLockKey(target: ResolveTarget): string {
+  return `${target.owner}/${target.repo}#${target.prNumber}:${target.rootCommentId}`
+}
+
+// Deliberately NOT a bounded/evicting map: dropping an in-flight key would let a
+// second caller enter the critical section concurrently and reopen the race this
+// closes. Entries are deleted once their tail settles, so the map stays bounded
+// by the number of resolves actually in flight.
+function withThreadLock<T>(key: string, run: () => Promise<T>): Promise<T> {
+  const previous = threadResolveLocks.get(key) ?? Promise.resolve()
+  const result = previous.then(run)
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  threadResolveLocks.set(key, tail)
+  void tail.then(() => {
+    if (threadResolveLocks.get(key) === tail) threadResolveLocks.delete(key)
+  })
+  return result
 }
 
 // A GitHub App's own login differs across the two APIs this guard straddles:

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -494,10 +494,10 @@ export type ReviewThreadResolveRequest = {
   rootCommentId: string
 }
 
-// `already-resolved` is a success-shaped no-op: the thread was closed before we
-// got here (a duplicate turn, a manual resolve), so the desired end state holds
-// and the caller should treat it like `ok: true`. `not-author` is a hard
-// refusal: the root comment is not the bot's, so resolving would erase a
+// `alreadyResolved` is a success-shaped no-op: the thread was closed before we
+// got here (a duplicate turn, a manual resolve), so the desired end state holds,
+// but the caller MUST NOT post a second close-out receipt. `not-author` is a
+// hard refusal: the root comment is not the bot's, so resolving would erase a
 // human's open question — the caller must NOT proceed as if it closed the loop.
 //
 // `no-match` is the ONLY non-blocking failure: the PR's threads listed cleanly

--- a/src/doctor/channel-checks.test.ts
+++ b/src/doctor/channel-checks.test.ts
@@ -78,6 +78,7 @@ describe('buildChannelChecks', () => {
       'channel.kakaotalk.credentials',
       'channel.github.credentials',
       'channel.github.webhook-delivery',
+      'channel.github.event-allowlist',
     ])
   })
 
@@ -441,6 +442,47 @@ describe('buildChannelChecks', () => {
       const cwd = makeTmpAgentDir({ github: {} })
       const result = await runCheck('channel.github.webhook-delivery', ctxFor(cwd))
       expect(result.status).toBe('info')
+    })
+  })
+
+  describe('github event allowlist', () => {
+    test('warns when a pinned allowlist omits pull_request.synchronize', async () => {
+      const cwd = makeTmpAgentDir({ github: { eventAllowlist: ['issues.opened'] } })
+
+      const result = await runCheck('channel.github.event-allowlist', ctxFor(cwd))
+
+      expect(result.status).toBe('warning')
+      expect(result.message).toContain('pull_request.synchronize')
+      expect(result.details?.join(' ')).toContain('future default events')
+      expect(result.details?.join(' ')).toContain('open review threads will never be rechecked on push')
+    })
+
+    test('does not warn when eventAllowlist is absent and tracks defaults', async () => {
+      const cwd = makeTmpAgentDir({ github: {} })
+
+      const result = await runCheck('channel.github.event-allowlist', ctxFor(cwd))
+
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('tracks the shipped defaults')
+    })
+
+    test('does not warn when a pinned allowlist includes pull_request.synchronize', async () => {
+      const cwd = makeTmpAgentDir({
+        github: { eventAllowlist: ['issues.opened', 'pull_request.synchronize'] },
+      })
+
+      const result = await runCheck('channel.github.event-allowlist', ctxFor(cwd))
+
+      expect(result.status).toBe('ok')
+    })
+
+    test('does not warn when a pinned allowlist admits synchronize via the base event', async () => {
+      const cwd = makeTmpAgentDir({ github: { eventAllowlist: ['issues.opened', 'pull_request'] } })
+
+      const result = await runCheck('channel.github.event-allowlist', ctxFor(cwd))
+
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('admits pull_request.synchronize')
     })
   })
 })

--- a/src/doctor/channel-checks.ts
+++ b/src/doctor/channel-checks.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { type AdapterId, type ChannelsConfig } from '@/channels'
+import { isGithubEventAllowed } from '@/channels/adapters/github/event-allowlist'
 import { loadConfigSync, validateConfig } from '@/config'
 import { readEnvFile } from '@/init'
 import { SecretsBackend } from '@/secrets'
@@ -38,6 +40,7 @@ export function buildChannelChecks(): DoctorCheck[] {
     kakaotalkCredentials(),
     githubCredentials(),
     githubWebhookDelivery(),
+    githubEventAllowlist(),
   ]
 }
 
@@ -361,6 +364,47 @@ function githubWebhookDelivery(): DoctorCheck {
   }
 }
 
+function githubEventAllowlist(): DoctorCheck {
+  return {
+    name: 'channel.github.event-allowlist',
+    category: 'channels',
+    description: 'github eventAllowlist preserves push-triggered review followups',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const cfg = safeLoadConfig(ctx)
+      if (cfg === null) return configInvalidResult()
+      const github = cfg.channels.github
+      if (github === undefined || github.enabled === false) {
+        return { status: 'skipped', message: 'github not configured' }
+      }
+
+      const pinned = readPinnedGithubEventAllowlist(ctx)
+      if (pinned === null) {
+        return { status: 'ok', message: 'github eventAllowlist tracks the shipped defaults' }
+      }
+      // Match the runtime predicate, not the literal string: the adapter admits
+      // an event when the allowlist holds either the fully qualified key or the
+      // bare base event, so a pinned `["pull_request"]` still enables push
+      // rechecks and must not be reported as an omission.
+      if (isGithubEventAllowed(pinned, 'pull_request', 'synchronize')) {
+        return { status: 'ok', message: 'github pinned eventAllowlist admits pull_request.synchronize' }
+      }
+      return {
+        status: 'warning',
+        message: 'github pinned eventAllowlist omits pull_request.synchronize',
+        details: [
+          'An explicitly pinned array will not inherit future default events.',
+          'With this omission, open review threads will never be rechecked on push.',
+        ],
+        fix: {
+          description:
+            'Remove channels.github.eventAllowlist to track defaults, or add `pull_request.synchronize` explicitly.',
+        },
+      }
+    },
+  }
+}
+
 async function runTokenAdapterCheck(
   ctx: CheckContext,
   adapter: Extract<AdapterId, 'slack-bot' | 'discord-bot' | 'telegram-bot' | 'webex-bot'>,
@@ -481,6 +525,26 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
 function readDeclaredChannels(ctx: CheckContext): ChannelsConfig | null {
   const cfg = safeLoadConfig(ctx)
   return cfg?.channels ?? null
+}
+
+function readPinnedGithubEventAllowlist(ctx: CheckContext): string[] | null {
+  // The parsed config always contains the schema default, so it cannot tell an
+  // operator-pinned array from an omitted key that tracks shipped defaults.
+  // Re-read the raw host-stage file to preserve that distinction for this check.
+  try {
+    const parsed = JSON.parse(readFileSync(join(ctx.cwd, 'typeclaw.json'), 'utf8')) as unknown
+    if (!isObjectRecord(parsed)) return null
+    const channels = parsed.channels
+    if (!isObjectRecord(channels)) return null
+    const github = channels.github
+    if (!isObjectRecord(github) || !Object.hasOwn(github, 'eventAllowlist')) return null
+    const allowlist = github.eventAllowlist
+    if (!Array.isArray(allowlist) || !allowlist.every((event): event is string => typeof event === 'string'))
+      return null
+    return allowlist
+  } catch {
+    return null
+  }
 }
 
 function safeLoadConfig(ctx: CheckContext): ReturnType<typeof loadConfigSync> | null {


### PR DESCRIPTION
> **Stacked base.** #1384 is stacked on top of this PR. Merge this one first.

## Background

A long-running deployment stopped ever revisiting its own open PR review threads. Investigation found the push-recheck subsystem (`scheduleReviewFollowup`) had never executed on that agent: its `channels.github.eventAllowlist` omitted `pull_request.synchronize`.

The agent had written that config itself. Its commit message explained why: a push and a human thread reply independently triggered **duplicate acknowledgement comments** on the same review thread, so it disabled synchronize follow-ups. It also dropped a second, unrelated event from the array specifically so the list would not deep-equal any historical seeded default — deliberately defeating the unfreeze migration in `src/config/config.ts` so its workaround would survive upgrades.

The duplicates were real. Across that deployment's session history there were 227 cross-session reply pairs posted on the same review thread within an hour of each other, the acknowledgements near-identical. The workaround traded away the entire "author pushed a fix but said nothing" recovery path to suppress them: with synchronize gone, a thread is only ever revisited when a human replies in it, so a silently-fixed concern stays open forever.

This PR removes the *reason* for the workaround and makes the workaround itself visible. The deeper session-ownership defect that lets two sessions reach the same thread at all is fixed in the stacked follow-up (#1384); the close-out path is made idempotent here, against GitHub's authoritative state rather than against process memory, so it holds no matter which session gets there.

## Summary

- **Duplicate close-out suppression** (`channel-reply.ts`, `channel-send.ts`, contract in `types.ts`). The resolver already distinguished `alreadyResolved`, but callers collapsed every success into "resolved" and posted a receipt regardless. `alreadyResolved` now returns success *without* posting a second acknowledgement. Durability comes from GitHub's `isResolved`, not process memory, so this survives restarts. `resolve_review_thread: false` is never suppressed — those replies carry genuinely different findings.
- **Retry hole in the follow-up dedup** (`src/channels/adapters/github/inbound.ts`). The head-SHA key was inserted into the delivery dedup *before* the API calls, while failure paths only logged and returned. A transient 403/500 therefore suppressed every later attempt at that SHA until process restart, and the successful-delivery path meant it was never recovered. Reservations are now `pending`/`completed`, released on failure, with a bounded attempt count (`MAX_REVIEW_FOLLOWUP_ATTEMPTS`) so a persistently failing repo cannot spin, and a warning when the cap is exhausted rather than silent permanent suppression. A failed verdict lookup now fails the whole attempt rather than routing threads and marking the SHA complete with the blocking obligation silently dropped.
- **`createBoundedMap`** extracted in `dedup.ts` and reused by `createDeliveryDedup`, so the new reservation/failure maps inherit the same insertion-order eviction instead of growing one entry per `(repo, PR, SHA)` forever.
- **Doctor check** `channel.github.event-allowlist` warns when a pinned allowlist omits `pull_request.synchronize`, explaining that a pinned array inherits no future default events and that open threads will never be rechecked on push. It re-reads raw `typeclaw.json` because the parsed config always carries the schema default and so cannot distinguish "pinned" from "tracking defaults".

## What this does NOT do

- **Does not re-route follow-ups per thread.** That change ships in the stacked follow-up (#1384), together with the round-carrier coordination that makes it safe. Per-thread routing on its own is not safe for a self-blocking review with multiple open threads: `github-rereview-guard.ts` refuses a close-out from every sibling while the bot still holds `CHANGES_REQUESTED`, and `injectPrVerdictActivity` is post-verdict fan-out rather than carrier election, so whichever sibling session reaches the verdict guard first wins. Splitting the routing change away from its coordination would ship a known race.
- **Does not change the allowlist config schema.** A default-extending form (`{ extends: "default", exclude: [...] }`) would let operators customize without freezing themselves out of future defaults, but that is a public-surface change and belongs in its own PR. Item here is a doctor *warning* only.
- **Does not touch** `DEFAULT_GITHUB_EVENT_ALLOWLIST`, `SEEDED_GITHUB_EVENT_ALLOWLISTS`, or the migration logic. Subset-based unfreeze was considered and rejected: "historical default minus one event" is indistinguishable from an intentional operator restriction, and silently replacing it would violate the customization contract.
- **Does not add a durable acknowledgement ledger.** Correctness would require an atomic claim spanning resolve, comment send, and persistence; a crash after the comment but before persistence still duplicates, and persisting first can permanently drop the acknowledgement. GitHub's own `isResolved` is the cheaper authority.
- **Does not suppress two non-closing replies** on the same thread. Only duplicate close-out receipts are suppressed.
- **Does not make `typeclaw.json` operator-owned.** An autonomous agent can still deliberately pin an exclusion; migration logic is not a security boundary. The doctor warning surfaces it rather than preventing it.

## Review notes

- `alreadyResolved`'s contract changed meaning. It previously read "caller should treat it like `ok: true`"; it now means "desired state reached, do not post a second receipt". Any future caller must respect that distinction.
- `reviewFollowupDedupByHandler` is a module-level `WeakMap` keyed on the `options` identity. This looks like a smell and is commented as such: `processVerifiedGithubDelivery` is a free function shared by both the live HTTP handler and the recovery sweep, so there is no per-handler closure to hold the state, and it must stay separate from `options.dedup` — that cache is add-only with no release path, which is precisely the retry hole being fixed.
- The retry cap warns rather than failing closed. An exhausted cap is recoverable by a new head or an adapter restart, and the warning names both, so a stuck repo is diagnosable in-band instead of silently never rechecking.
- The doctor check is a warning, not an enforcement. An autonomous agent that pins an exclusion is exercising a real configuration surface; the check makes that choice legible to the operator without taking it away.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (71 pre-existing warnings; 0 in changed files)
- `bun run format:check` — all files correctly formatted
- `bun run test` — 13018 pass, 31 skip, 9 fail. All 9 failures are ANSI-color assertions in `src/inspect/render.test.ts`, `src/usage/index.test.ts`, `src/cli/status.test.ts`, and the three `src/cli/compose-*.test.ts` files; they reproduce identically on `main` without this change and are TTY/color-environment dependent, not caused by this PR.
- Scoped suite `src/channels/adapters/github src/agent/tools src/doctor src/channels/schema.test.ts` — 1306 pass, 4 skip, 0 fail.
- Every commit in this branch passes `bun run typecheck` individually, so the branch stays bisectable.
