### PR TITLE
Reduce readability styles to the properties pruning reads

### DIFF
--- a/src/agent/tools/webfetch/inline-style-visibility.ts
+++ b/src/agent/tools/webfetch/inline-style-visibility.ts
@@ -2,7 +2,7 @@ export type InlineStyleVisibility = 'hidden' | 'visible' | 'uncertain'
 
 const MAX_RAW_INLINE_STYLE_CHARS = 64 * 1024
 const MAX_CSS_NESTING_DEPTH = 32
-const RELEVANT_PROPERTIES = new Set(['content-visibility', 'display', 'visibility', 'opacity'])
+export const VISIBILITY_PROPERTIES = new Set(['content-visibility', 'display', 'visibility', 'opacity'])
 const CSS_NUMBER = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/iu
 const CSS_PERCENTAGE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?%$/iu
 const VISIBLE_DISPLAY_VALUES = new Set([
@@ -54,7 +54,7 @@ export function classifyRawInlineStyleVisibility(style: string): InlineStyleVisi
       continue
     }
     const property = asciiFold(decodedProperty.value.trim())
-    if (!RELEVANT_PROPERTIES.has(property)) continue
+    if (!VISIBILITY_PROPERTIES.has(property)) continue
 
     const declaration = classifyDeclaration(property, rawValue)
     const prior = declarations.get(property)

--- a/src/agent/tools/webfetch/strategies/readability.test.ts
+++ b/src/agent/tools/webfetch/strategies/readability.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
-import { applyReadability, applyReadabilityDetailed } from './readability'
+import { VISIBILITY_PROPERTIES } from '../inline-style-visibility'
+import {
+  applyReadability,
+  applyReadabilityDetailed,
+  buildComputedStyleResolver,
+  pruneHiddenContent,
+  reduceToVisibilityDeclarations,
+} from './readability'
 
 const ARTICLE = `
 <!doctype html>
@@ -263,5 +270,140 @@ describe('applyReadability', () => {
 
       expect(result).toContain(`Visible positive ${opacity} opacity article`)
     }
+  })
+
+  test('prunes stylesheet-hidden content on pages whose CSS also conflicts border shorthand with longhand', async () => {
+    const concealed = 'Concealed article behind conflicting border declarations. '.repeat(40)
+    const visible = 'Visible article behind conflicting border declarations. '.repeat(40)
+    const result = await applyReadability(
+      `<html><head><style>span,article{margin:0;padding:0;border:0px;font-size:100%}.chrome{border-bottom:1px solid;display:none}</style></head><body><article class="chrome"><h1>Hidden</h1><p>${concealed}</p></article><article><h1>Visible</h1><p>${visible}</p></article></body></html>`,
+      'https://example.com/border-shorthand-conflict',
+    )
+
+    expect(result).toContain('Visible article behind conflicting border declarations')
+    expect(result).not.toContain('Concealed article behind conflicting border declarations')
+  })
+})
+
+describe('buildComputedStyleResolver', () => {
+  const resolverFor = async (css: string, inlineStyle = '') => {
+    const { JSDOM } = await import('jsdom')
+    const dom = new JSDOM(
+      `<html><head><style>${css}</style></head><body><p class="a" style="${inlineStyle}">x</p></body></html>`,
+    )
+    const { document } = dom.window
+    const resolve = buildComputedStyleResolver(document, (element) => dom.window.getComputedStyle(element))
+    return { resolve, element: document.querySelector('p')! }
+  }
+
+  test('resolves the visibility properties pruning depends on', async () => {
+    const { resolve, element } = await resolverFor('.a{border-bottom:3px solid red;display:none}')
+
+    expect(resolve?.(element).display).toBe('none')
+  })
+
+  test('cannot resolve declarations pruning never reads, so jsdom never computes them', async () => {
+    const { resolve, element } = await resolverFor('.a{border-bottom:3px solid red;display:none}')
+
+    expect(resolve?.(element).borderBottomWidth).not.toBe('3px')
+  })
+
+  test('cannot resolve an inline shorthand/longhand conflict, the other route into the cascade', async () => {
+    const { resolve, element } = await resolverFor(
+      '.unused{color:red}',
+      'border:0;border-bottom:1px solid;display:none',
+    )
+
+    expect(resolve?.(element).borderBottomStyle).not.toBe('solid')
+  })
+
+  test('keeps an inline custom property while removing the inline declarations it never reads', async () => {
+    const { resolve, element } = await resolverFor(
+      '.unused{color:red}',
+      '--hidden:0;border:0;border-bottom:1px solid;display:none',
+    )
+
+    resolve?.(element)
+
+    expect(Array.from((element as HTMLElement).style).toSorted()).toEqual(['--hidden', 'display'])
+    expect((element as HTMLElement).style.getPropertyValue('--hidden')).toBe('0')
+  })
+
+  test('still resolves inline visibility declarations so inline pruning keeps working', async () => {
+    const { resolve, element } = await resolverFor(
+      '.unused{color:red}',
+      'border:0;border-bottom:1px solid;display:none',
+    )
+
+    expect(resolve?.(element).display).toBe('none')
+  })
+})
+
+describe('pruneHiddenContent', () => {
+  test('reduces every inline style before resolving any element, including ancestors it prunes first', async () => {
+    const { JSDOM } = await import('jsdom')
+    const dom = new JSDOM(
+      `<html><body><div hidden style="color:rgb(1,2,3);border:0;border-bottom:1px solid"><p>x</p></div><section style="position:absolute;left:-10000px;border:0;border-bottom:1px solid"><span>y</span></section></body></html>`,
+    )
+    const { document } = dom.window
+    const unreduced: string[] = []
+
+    pruneHiddenContent(document, (element) => {
+      for (let node = element.parentElement; node !== null; node = node.parentElement) {
+        const declarations = Array.from(node.style).filter((property) => !VISIBILITY_PROPERTIES.has(property))
+        if (declarations.length > 0) unreduced.push(`${node.tagName}:${declarations.join(',')}`)
+      }
+      return dom.window.getComputedStyle(element)
+    })
+
+    expect(unreduced).toEqual([])
+  })
+})
+
+describe('reduceToVisibilityDeclarations', () => {
+  const styleElementsFor = async (css: string) => {
+    const { JSDOM } = await import('jsdom')
+    const dom = new JSDOM(`<html><head><style>${css}</style></head><body><p>x</p></body></html>`)
+    return Array.from(dom.window.document.querySelectorAll('style'))
+  }
+
+  test('drops declarations that cannot affect visibility and keeps the ones that can', async () => {
+    const styles = await styleElementsFor(
+      '.a{border:0px;border-bottom:1px solid;transition:all 250ms;display:none;opacity:0;visibility:hidden;content-visibility:hidden}',
+    )
+
+    reduceToVisibilityDeclarations(styles)
+
+    const rule = styles[0]!.sheet!.cssRules[0] as CSSStyleRule
+    expect(Array.from(rule.style).toSorted()).toEqual(['content-visibility', 'display', 'opacity', 'visibility'])
+  })
+
+  test('keeps custom properties a retained visibility declaration could reference', async () => {
+    const styles = await styleElementsFor('.a{--hidden:0;border:0px;transition:all 250ms;opacity:var(--hidden)}')
+
+    reduceToVisibilityDeclarations(styles)
+
+    const rule = styles[0]!.sheet!.cssRules[0] as CSSStyleRule
+    expect(Array.from(rule.style).toSorted()).toEqual(['--hidden', 'opacity'])
+    expect(rule.style.getPropertyValue('--hidden')).toBe('0')
+  })
+
+  test('reduces declarations nested inside grouping rules', async () => {
+    const styles = await styleElementsFor('@media screen{@supports (display:grid){.a{border:0px;display:none}}}')
+
+    reduceToVisibilityDeclarations(styles)
+
+    const media = styles[0]!.sheet!.cssRules[0] as CSSGroupingRule
+    const supports = media.cssRules[0] as CSSGroupingRule
+    expect(Array.from((supports.cssRules[0] as CSSStyleRule).style)).toEqual(['display'])
+  })
+
+  test('leaves style textContent untouched so the complexity budgets still measure the original stylesheet', async () => {
+    const css = '.a{border:0px;display:none}'
+    const styles = await styleElementsFor(css)
+
+    reduceToVisibilityDeclarations(styles)
+
+    expect(styles[0]!.textContent).toBe(css)
   })
 })

--- a/src/agent/tools/webfetch/strategies/readability.ts
+++ b/src/agent/tools/webfetch/strategies/readability.ts
@@ -2,7 +2,7 @@ import type { Readability as ReadabilityClass } from '@mozilla/readability'
 import type TurndownService from 'turndown'
 
 import { walkHtmlLexically } from '../html-lexical'
-import { classifyRawInlineStyleVisibility } from '../inline-style-visibility'
+import { classifyRawInlineStyleVisibility, VISIBILITY_PROPERTIES } from '../inline-style-visibility'
 
 // Perf: jsdom (+readability+turndown) costs ~40-60MB RSS at import time. Keep it
 // lazy so idle agents that never call web_fetch don't pay for it. Do NOT hoist to
@@ -180,7 +180,7 @@ function countRawCssRules(source: string): { rules: number; selectorComponents: 
   return { rules, selectorComponents }
 }
 
-function buildComputedStyleResolver(
+export function buildComputedStyleResolver(
   document: Document,
   resolve: (element: Element) => CSSStyleDeclaration,
 ): ((element: Element) => CSSStyleDeclaration) | undefined {
@@ -206,7 +206,52 @@ function buildComputedStyleResolver(
   if (selectorComponentCount * elementCount > MAX_COMPUTED_STYLE_WORK) {
     throw new Error('Embedded stylesheet complexity limit exceeded')
   }
-  return resolve
+  reduceToVisibilityDeclarations(styles)
+  return (element) => {
+    reduceInlineStyleToVisibilityDeclarations(element)
+    return resolve(element)
+  }
+}
+
+// getComputedStyle resolves the WHOLE declaration, but pruneHiddenContent reads
+// only VISIBILITY_PROPERTIES. Everything else is computed at our expense and at
+// our risk, so it is deleted from the CSSOM before the first resolve.
+//
+// Load-bearing, not a micro-optimization: this is the fix for an OOM that killed
+// a live agent. jsdom 29.0.2 allocates ~27GB and burns ~11s inside a SINGLE
+// getComputedStyle() call while reconciling a `border` shorthand against a
+// `border-bottom` longhand (living/css/helpers/shorthand-properties.js), then
+// throws a TypeError. The triggering CSS is ubiquitous rather than hostile: a
+// reset (`span { border: 0 }`) plus a component rule that omits the border
+// colour (`.x { border-bottom: 1px solid }`), as every Emotion/MUI page emits.
+// A 236KB page with 545 elements was enough to exhaust a 16GB host.
+//
+// Nothing upstream can catch it. The allocation is SYNCHRONOUS, so the request
+// AbortSignal and the 30s timeout never get a turn, and the try/catch in
+// isHiddenElement catches the TypeError only after the memory is committed. The
+// complexity budgets above bound the QUANTITY of CSS work, so a single
+// pathological declaration on a small page passes all of them.
+//
+// Deleting declarations rather than hand-rolling a cascade keeps jsdom
+// authoritative for specificity, inheritance, and !important on the properties
+// actually read, so pruning behaviour is unchanged. It also generalises: a
+// future jsdom blowup in any property never read here is now unreachable.
+// Only the CSSOM is edited — <style> textContent is untouched, so the budgets
+// above still measure the original stylesheet.
+export function reduceToVisibilityDeclarations(styles: HTMLStyleElement[]): void {
+  let budget = MAX_EMBEDDED_STYLE_RULES
+  const visit = (rules: CSSRuleList): void => {
+    for (const rule of Array.from(rules)) {
+      if (budget-- <= 0) return
+      if ('cssRules' in rule) visit((rule as CSSGroupingRule).cssRules)
+      const { style } = rule as CSSStyleRule
+      if (!style) continue
+      removeUnreadDeclarations(style)
+    }
+  }
+  for (const style of styles) {
+    if (style.sheet !== null) visit(style.sheet.cssRules)
+  }
 }
 
 function countCssRules(rules: CSSRuleList): { rules: number; selectorComponents: number } {
@@ -273,14 +318,61 @@ function countVisibleTextCharacters(body: HTMLElement | null): number {
   return Array.from(normalizeVisibleText(body.textContent ?? '')).length
 }
 
-function pruneHiddenContent(
+export function pruneHiddenContent(
   document: Document,
   computedStyle: ((element: Element) => CSSStyleDeclaration) | undefined,
 ): void {
   for (const details of document.querySelectorAll('details:not([open])')) pruneClosedDetails(details)
 
-  for (const element of document.querySelectorAll('*')) {
-    if (isHiddenElement(element, computedStyle)) element.remove()
+  const elements = Array.from(document.querySelectorAll('*'))
+  // Three passes, because reducing an element's inline style has to happen
+  // after the checks that read the declarations it removes, but before ANY
+  // element resolves a computed style.
+  //
+  // A single interleaved pass cannot satisfy both. querySelectorAll returns a
+  // STATIC list, so a descendant is still visited after its ancestor is
+  // removed, and jsdom resolves inherited properties by walking parentElement
+  // into that removed ancestor. An ancestor pruned by `hidden`, aria-hidden or
+  // the offscreen test returns before the resolver ever touches it, so it would
+  // still be carrying its full inline declaration when the descendant reaches
+  // it — the OOM route again, one level up.
+  const staticallyHidden = new Set<Element>()
+  for (const element of elements) {
+    if (isStaticallyHiddenElement(element)) staticallyHidden.add(element)
+  }
+  for (const element of elements) reduceInlineStyleToVisibilityDeclarations(element)
+  for (const element of elements) {
+    if (staticallyHidden.has(element) || isComputedHiddenElement(element, computedStyle)) element.remove()
+  }
+}
+
+// The inline style attribute is the second way a declaration reaches the
+// cascade, so reducing stylesheets alone leaves the same OOM reachable via
+// style="border:0;border-bottom:1px solid". See reduceToVisibilityDeclarations
+// for the mechanism.
+//
+// This runs inside the resolver rather than at a call site so the invariant
+// holds for every caller: an element cannot reach getComputedStyle carrying a
+// declaration outside VISIBILITY_PROPERTIES. It is safe to reduce this late
+// because the callers that need the removed declarations read them WITHOUT the
+// resolver — classifyRawInlineStyleVisibility parses the raw attribute text and
+// the offscreen test reads position/left/top off element.style, both before
+// isHiddenElement resolves anything.
+function reduceInlineStyleToVisibilityDeclarations(element: Element): void {
+  if (!('style' in element)) return
+  removeUnreadDeclarations((element as HTMLElement).style)
+}
+
+// Custom properties are retained even though they are not read directly: a
+// retained declaration can be written `opacity: var(--hidden)`, and dropping
+// the `--hidden` definition would silently un-hide content this guard exists to
+// prune. They are safe to keep because a custom property is stored as an
+// unparsed token sequence — it never enters the shorthand expansion that makes
+// ordinary properties dangerous.
+function removeUnreadDeclarations(style: CSSStyleDeclaration): void {
+  for (const property of Array.from(style)) {
+    if (property.startsWith('--')) continue
+    if (!VISIBILITY_PROPERTIES.has(property.toLocaleLowerCase())) style.removeProperty(property)
   }
 }
 
@@ -291,10 +383,10 @@ function pruneClosedDetails(details: Element): void {
   }
 }
 
-function isHiddenElement(
-  element: Element,
-  computedStyle: ((element: Element) => CSSStyleDeclaration) | undefined,
-): boolean {
+// Everything decidable from attributes and the element's own inline style, so
+// it stays readable before reduceInlineStyleToVisibilityDeclarations strips the
+// declarations these checks consume.
+function isStaticallyHiddenElement(element: Element): boolean {
   if (element.hasAttribute('hidden')) return true
   if (element.getAttribute('aria-hidden')?.toLocaleLowerCase() === 'true') return true
   if (element.tagName === 'INPUT' && element.getAttribute('type')?.toLocaleLowerCase() === 'hidden') return true
@@ -308,6 +400,13 @@ function isHiddenElement(
     if ((position === 'absolute' || position === 'fixed') && (isFarOffscreen(left) || isFarOffscreen(top))) return true
   }
 
+  return false
+}
+
+function isComputedHiddenElement(
+  element: Element,
+  computedStyle: ((element: Element) => CSSStyleDeclaration) | undefined,
+): boolean {
   if (computedStyle === undefined || NON_CONTENT_ELEMENTS.has(element.tagName)) return false
   let resolved: CSSStyleDeclaration
   try {


### PR DESCRIPTION
## Background

A live agent container was killed by the kernel OOM killer after seven days of healthy operation:

```
Out of memory: Killed process (bun) total-vm:100153060kB, anon-rss:9545868kB
oom-kill:constraint=CONSTRAINT_NONE, global_oom, task=bun
```

It went from 971MB to 9.1GB in roughly 36 seconds. The last thing it did was issue four concurrent `web_fetch(strategy:"readability")` calls.

The mechanism, reproduced deterministically against the real pages:

| scenario | before |
| --- | --- |
| four concurrent fetches | 16964ms / **27936MB** |
| the single culprit page (236KB, 545 elements) | 13229ms / **26034MB** |
| pinned to one element | +27537MB in 11208ms, then `TypeError` |

It narrows to a **single** `getComputedStyle()` call on one ordinary `<span>`. jsdom 29.0.2 allocates ~27GB while reconciling a `border` shorthand against a `border-bottom` longhand (`living/css/helpers/shorthand-properties.js`: `prepareBorderProperties` → `prepareBorderArrayValue` → `replaceBorderShorthandValue`), then throws.

The triggering CSS is ubiquitous rather than hostile — a reset (`span { border: 0 }`) plus a component rule that omits the border colour (`.x { border-bottom: 1px solid }`). That is what every Emotion/MUI page emits, so this is reachable from a large fraction of the web.

Nothing upstream could have caught it:

- The allocation is **synchronous**. A 50ms sampler never fired during the 13s run, so the request `AbortSignal` and the 30s timeout never get a turn.
- The existing `try/catch` in `isHiddenElement` *does* catch the `TypeError` — but only after the memory is already committed.
- Every complexity budget passes. They bound the **quantity** of CSS work (`MAX_ADAPTIVE_HTML_TAG_COUNT`, `MAX_EMBEDDED_STYLE_RULES`, `MAX_COMPUTED_STYLE_WORK`), and this is one pathological declaration on a small page. They are structurally blind to it.

## Summary

`pruneHiddenContent` reads exactly four resolved properties — `display`, `visibility`, `content-visibility`, `opacity` — but `getComputedStyle` resolves the *entire* declaration. We were paying for, and being endangered by, properties we never read. So they are now deleted from the CSSOM before the first resolve, on both routes into the cascade.

**Both routes into the cascade.** Reducing embedded stylesheets alone left the same OOM reachable through `style="border:0;border-bottom:1px solid"`, so the inline style attribute is reduced too. That reduction runs *inside the resolver* rather than at a call site, so the invariant holds for every caller. It is safe to reduce that late because the checks needing the removed declarations never go through the resolver: `classifyRawInlineStyleVisibility` parses the raw attribute text, and the offscreen test reads `position`/`left`/`top` off `element.style`.

**Why deletion and not a hand-rolled cascade.** Matching rules ourselves means reimplementing specificity, inheritance and `!important`, which is exactly the kind of subtle logic that regresses an anti-injection guard. Deleting declarations keeps jsdom authoritative for the cascade on the properties we do read, so pruning behaviour is unchanged by construction.

**Why not a timeout or a worker.** The allocation is synchronous, so no JS-level timeout can interrupt it. A `Worker` shares process RSS, so only a child process with an OS-enforced bound would contain it — that costs IPC of up to 5MiB of HTML per fetch plus latency on every call, to paper over a bug we can simply make unreachable.

**Why this generalises.** The fix is not `border`-specific. Any future jsdom blowup in a property this path never reads is now unreachable from it.

Only the CSSOM is edited; `<style>` `textContent` is untouched, so the complexity budgets still measure the original stylesheet.

## Preview

Same two pages, after the change — **output byte-identical** in both cases:

| scenario | before | after |
| --- | --- | --- |
| single culprit page | 13229ms / 26034MB | **396ms / 334MB** |
| four concurrent | 16964ms / 27936MB | **1567ms / 411MB** |

That is ~68x less memory and ~11x faster, with no change in extracted content.

## What this does NOT do

- **Does not add a container memory limit.** `docker run` still sets no `--memory`, which is why one agent's runaway allocation produced a VM-wide `global_oom` that could have killed an *innocent* co-tenant agent rather than the guilty one. Worth fixing separately.
- **Does not add restart or liveness recovery.** `RestartPolicy` is `no`, and hostd's `probeContainerAlive()` uses `docker ps -a`, which still lists an **exited** container — so hostd believes a dead agent is alive indefinitely and never restarts or alerts. This is why the incident went unnoticed for hours. Also worth fixing separately.
- Does not patch or pin jsdom, and does not change extraction behaviour.

## Review notes

The load-bearing line is `reduceToVisibilityDeclarations(styles)` in `buildComputedStyleResolver`, guarded by a comment explaining why it must not be deleted as a micro-optimization.

**The invariant to verify:** no declaration outside `VISIBILITY_PROPERTIES` reaches `getComputedStyle`, via either an embedded stylesheet rule or an inline `style` attribute.

Tests were verified red-green — removing that one line fails `cannot resolve declarations pruning never reads`. Note the three `reduceToVisibilityDeclarations` unit tests alone do *not* catch its removal (they call it directly); the `buildComputedStyleResolver` tests are what guard the wiring.

`RELEVANT_PROPERTIES` was exported as `VISIBILITY_PROPERTIES` so the property set has one source of truth shared with the inline-style path.

A minimal offline fixture was attempted and is not achievable — the target span plus all four stylesheets does not reproduce; it needs the full 545-element cascade. Committing the 236KB page as a fixture was rejected as opaque and a CI OOM risk, so the guard is the invariant test rather than a memory assertion.
