### PR TITLE
Recover stranded channel turns instead of failing silently

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -417,6 +417,7 @@ function makeRouter(
     listRunningBackgroundSubagentNames?: (sessionId: string) => string[]
     runIdleContinuation?: CreateChannelRouterOptions['runIdleContinuation']
     recordTurnOutcome?: CreateChannelRouterOptions['recordTurnOutcome']
+    onSessionCreated?: (session: FakeSession) => void
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -457,6 +458,7 @@ function makeRouter(
       origins.push(origin)
       options.originRefs?.push(originRef)
       const fake = new FakeSession()
+      options.onSessionCreated?.(fake)
       sessions.push(fake)
       const sessionId = existingSessionId ?? `ses_fake_${sessions.length}`
       return {
@@ -4204,7 +4206,7 @@ describe('ChannelRouter channel-turn protocol', () => {
           state: 'APPROVE',
         })
       }
-      emptyStopAfterToolWork(sessions[0]!)
+      strandOnUnansweredToolUse(sessions[0]!, 'github-review-output')
     }
     await router.__testing!.flushDebounce(githubKey)
 
@@ -4552,7 +4554,7 @@ describe('ChannelRouter channel-turn protocol', () => {
       router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'duplicate' })
       // given: model leaked meta-narration before / instead of NO_REPLY.
       // The skip guard must win — recovery would otherwise post this.
-      sessions[0]!.setAssistantText("Same story as before; I'll stay quiet here.")
+      sessions[0]!.setAssistantMidTurn("Same story as before; I'll stay quiet here.")
     }
     await router.__testing!.flushDebounce(KEY)
 
@@ -5983,14 +5985,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('blocked assistant_text_without_channel_tool'))).toBe(false)
   })
 
-  // Regression for the Kimi-on-Fireworks `kimi-k2p6-turbo` KakaoTalk silence
-  // bug: the model narrated a user-facing reply ("16x now") AND committed to a
-  // tool plan in the same message (stopReason='toolUse'), then the turn ended
-  // before any follow-up message that would have called channel_reply was
-  // persisted. The leaf is the assistant message itself, not a toolResult, so
-  // 'pre-tool' recovery does not apply. Without 'mid-turn' recovery the prose
-  // is silently dropped and the user sees nothing.
-  test('mid-turn recovery: recovers prose when leaf is a toolUse assistant with no follow-up', async () => {
+  test('mid-turn recovery: retries unfinished toolUse prose instead of publishing it as the reply', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -6000,17 +5995,24 @@ describe('ChannelRouter channel-turn protocol', () => {
       return { ok: true }
     })
 
-    await router.route(inbound({ text: 'go 16x speed' }))
+    await router.route(inbound({ text: '설정 적용됐어?' }))
+    let attempt = 0
     sessions[0]!.onPrompt = () => {
-      sessions[0]!.setAssistantMidTurn('Running at 16x speed! Hold on a sec and I will grab a screenshot!')
+      attempt++
+      if (attempt === 1) {
+        sessions[0]!.setAssistantMidTurn('Configuration parsed. Next I will run the remaining step.')
+        return
+      }
+      sessions[0]!.setAssistantText('설정이 적용됐어요.')
     }
     await router.__testing!.flushDebounce(KEY)
 
-    expect(
-      logs.some((m) => m.includes('recovering assistant_text_without_channel_tool') && m.includes('source=mid-turn')),
-    ).toBe(true)
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
     expect(sent).toHaveLength(1)
-    expect(sent[0]!.text).toBe('Running at 16x speed! Hold on a sec and I will grab a screenshot!')
+    expect(sent[0]!.text).toBe('설정이 적용됐어요.')
+    expect(sent.some((message) => message.text.includes('Configuration parsed'))).toBe(false)
+    expect(logs.some((message) => message.includes('source=mid-turn'))).toBe(false)
   })
 
   test('mid-turn recovery: applies the NO_REPLY guard to recovered prose', async () => {
@@ -6034,7 +6036,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
-  test('mid-turn recovery: applies the Kimi tool-call leak guard to recovered prose', async () => {
+  test('mid-turn recovery: never publishes tool-call-like unfinished prose while exhausting retries', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -6052,8 +6054,9 @@ describe('ChannelRouter channel-turn protocol', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('suppressed kimi_tool_call_leak'))).toBe(true)
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(sent.map((message) => message.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(sent.some((message) => message.text.includes('tool_call_argument_begin'))).toBe(false)
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
@@ -6136,7 +6139,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
   })
 
-  test('mid-turn recovery: applies the upstream empty-response sentinel guard to recovered prose', async () => {
+  test('mid-turn recovery: never publishes an unfinished upstream empty-response sentinel', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -6155,17 +6158,16 @@ describe('ChannelRouter channel-turn protocol', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('suppressed upstream_empty_response_sentinel'))).toBe(true)
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(sent.map((message) => message.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(sent.some((message) => message.text.includes('Empty response'))).toBe(false)
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
-  // The leaf-assistant branch recovers ONLY 'stop' and 'toolUse'. length /
-  // error / aborted carry visible text too, but it's a truncation or an
-  // errored partial, not a deliberate reply — recovering it would post broken
-  // output. This is the load-bearing scoping of the mid-turn fix. The truncated
-  // prose is NEVER posted; instead the empty-turn guard retries the turn and,
-  // on exhaustion, posts the fallback (asserted in the empty-turn suite below).
+  // The leaf-assistant branch classifies unfinished `toolUse` separately from
+  // length / error / aborted truncations. None is a deliberate reply, but their
+  // recovery owners differ: toolUse continues from existing results, while the
+  // other stop reasons retain their provider/budget-specific paths.
   for (const stopReason of ['length', 'error', 'aborted'] as const) {
     test(`mid-turn recovery: does NOT recover a leaf assistant with stopReason='${stopReason}'`, async () => {
       const dir = await tempDir()
@@ -6912,14 +6914,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('blocked assistant_text_without_channel_tool'))).toBe(false)
   })
 
-  // Regression for the Kimi-on-Fireworks `kimi-k2p6-turbo` channel-silence
-  // bug observed on 2026-05-26: the model emitted text + a tool call
-  // (stopReason='toolUse'), the tool ran successfully, but the upstream
-  // pi-agent-core loop never produced a follow-up assistant message after
-  // the toolResult. The session JSONL ended with the toolResult as the leaf,
-  // `prompt()` resolved cleanly, and the channel router silently dropped the
-  // pre-tool commentary. User saw nothing in Discord.
-  test('pre-tool recovery: recovers assistant text when leaf is toolResult with no follow-up', async () => {
+  test('pre-tool recovery: retries unfinished prose instead of publishing it when the toolResult has no follow-up', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -6930,7 +6925,13 @@ describe('ChannelRouter channel-turn protocol', () => {
     })
 
     await router.route(inbound({ text: 'why is cron not working' }))
+    let attempt = 0
     sessions[0]!.onPrompt = () => {
+      attempt++
+      if (attempt > 1) {
+        sessions[0]!.setAssistantText('Cron is configured and running.')
+        return
+      }
       // given: an assistant message with text + a tool call. The model never
       // produced a follow-up assistant message after the tool result, so the
       // leaf is the toolResult, NOT the assistant message.
@@ -6981,11 +6982,12 @@ describe('ChannelRouter channel-turn protocol', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    expect(
-      logs.some((m) => m.includes('recovering assistant_text_without_channel_tool') && m.includes('source=pre-tool')),
-    ).toBe(true)
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
     expect(sent).toHaveLength(1)
-    expect(sent[0]!.text).toBe('Sorry about that. I will look into the cron issue right now.')
+    expect(sent[0]!.text).toBe('Cron is configured and running.')
+    expect(sent.some((message) => message.text.includes('look into'))).toBe(false)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool source=pre-tool'))).toBe(false)
   })
 
   test('pre-tool recovery: still applies NO_REPLY / Kimi-leak / empty-sentinel guards', async () => {
@@ -7079,6 +7081,125 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent).toHaveLength(1)
     expect(sent[0]!.text).toBe('real reply')
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('stranded toolUse without a send: retries the same turn and delivers the Korean conclusion', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '설정 된 건가요' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = () => {
+      attempt++
+      if (attempt === 1) {
+        sessions[0]!.setAssistantMidTurn('')
+        return
+      }
+      sessions[0]!.setAssistantText('네, 설정이 적용됐어요.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
+    expect(sent.map((message) => message.text)).toEqual(['네, 설정이 적용됐어요.'])
+    expect(logs.some((message) => message.includes('cause=stranded_toolUse_without_send'))).toBe(true)
+    expect(logs.some((message) => message.includes('no_reply'))).toBe(false)
+  })
+
+  test('stranded toolUse without a send: posts exactly one fallback after exhausting the shared retry budget', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'is it configured?' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantMidTurn('')
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(
+      logs.filter(
+        (message) => message.includes('empty_turn_retry') && message.includes('stranded_toolUse_without_send'),
+      ),
+    ).toHaveLength(MAX_EMPTY_TURN_RETRIES)
+    expect(sent.map((message) => message.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(
+      logs.filter((message) =>
+        message.includes('empty_turn_fallback cause=stranded_toolUse_without_send_retries_exhausted'),
+      ),
+    ).toHaveLength(1)
+  })
+
+  test('stranded toolUse without a send: a queued fresh inbound supersedes recovery and is answered next', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'first question' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      if (attempt === 1) {
+        sessions[0]!.setAssistantMidTurn('')
+        await router.route(inbound({ text: 'new context', externalMessageId: 'm2' }))
+        return
+      }
+      sessions[0]!.setAssistantText('Answer using the new context.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain('new context')
+    expect(sessions[0]!.prompts[1]).not.toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
+    expect(sent.map((message) => message.text)).toEqual(['Answer using the new context.'])
+    expect(logs.some((message) => message.includes('cause=stranded_toolUse_without_send'))).toBe(false)
+    expect(logs.some((message) => message.includes('empty_turn_fallback'))).toBe(false)
+  })
+
+  test('stranded toolUse without a send: text-bearing narration stays private when fresh inbound is queued', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'first question' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      if (attempt === 1) {
+        sessions[0]!.setAssistantMidTurn('도구 결과를 확인한 다음 답변하겠습니다.')
+        await router.route(inbound({ text: 'new context', externalMessageId: 'm2' }))
+        return
+      }
+      sessions[0]!.setAssistantText('새 컨텍스트를 반영한 답변입니다.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain('new context')
+    expect(sessions[0]!.prompts[1]).not.toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
+    expect(sent.map((message) => message.text)).toEqual(['새 컨텍스트를 반영한 답변입니다.'])
+    expect(sent.some((message) => message.text.includes('도구 결과'))).toBe(false)
+    expect(logs.some((message) => message.includes('cause=unfinished_toolUse_continuation_ineligible'))).toBe(true)
   })
 
   // Regression for the "I'll check right now" → silence bug (Discord channel,
@@ -10474,6 +10595,24 @@ describe('ChannelRouter peer-bot loop guard', () => {
     expect(lastPrompt).toContain('[SYSTEM MESSAGE — not from a human]')
     expect(lastPrompt).toContain('Do not acknowledge or reply to this notice')
     expect(lastPrompt).toContain('NO_REPLY')
+  })
+
+  test('a peer-bot loop-guard turn that emits NO_REPLY stays silent', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    for (let i = 0; i < 5; i++) {
+      await router.route(botInbound({ externalMessageId: `peer-${i}`, authorId: `peer-${i}` }))
+      sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    expect(sent).toEqual([])
   })
 
   test('slow peer-bot ring (>60s gaps) still trips via since-human counter', async () => {
@@ -16200,6 +16339,54 @@ describe('resumeRestartHandoff', () => {
     expect(sessions[0]?.prompts.length).toBe(1)
   })
 
+  test('a restart reminder with no author keeps a stranded toolUse silent', async () => {
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      onSessionCreated: (session) => {
+        session.onPrompt = () => session.setAssistantMidTurn('')
+      },
+    })
+    router.registerOutbound('discord-bot', async (message) => {
+      sent.push(message.text ?? '')
+      return { ok: true }
+    })
+
+    await router.resumeRestartHandoff(channelHandoff())
+    await waitFor(() => sessions[0]?.prompts.length === 1)
+
+    expect(sent).toEqual([])
+    expect(logs.some((message) => message.includes('stranded_toolUse_without_send'))).toBe(false)
+    expect(logs.some((message) => message.includes('empty_turn_fallback'))).toBe(false)
+  })
+
+  test('a restart reminder with no author keeps text-bearing unfinished toolUse narration silent', async () => {
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      onSessionCreated: (session) => {
+        session.onPrompt = () => session.setAssistantMidTurn('I will inspect the tool result before answering.')
+      },
+    })
+    router.registerOutbound('discord-bot', async (message) => {
+      sent.push(message.text ?? '')
+      return { ok: true }
+    })
+
+    await router.resumeRestartHandoff(channelHandoff())
+    await waitFor(() => sessions[0]?.prompts.length === 1)
+
+    expect(sent).toEqual([])
+    expect(logs.some((message) => message.includes('cause=unfinished_toolUse_continuation_ineligible'))).toBe(true)
+    expect(logs.some((message) => message.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
   test('skips when the persisted mapping no longer names the handoff session', async () => {
     // given: the channel rolled over to a different session since the restart
     const dir = await tempDir()
@@ -17218,7 +17405,7 @@ describe('ChannelRouter background-child await suppression', () => {
     }
   }
 
-  test('a bare-empty stop while a background child runs stays silent instead of retrying', async () => {
+  test('a stranded toolUse while a background child runs stays silent instead of retrying', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
@@ -17230,7 +17417,7 @@ describe('ChannelRouter background-child await suppression', () => {
 
     // given: the model does tool work (spawning a background child), then ends the turn empty
     await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
-    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    sessions[0]!.onPrompt = () => strandOnUnansweredToolUse(sessions[0]!, 'background-child')
     await router.__testing!.flushDebounce(KEY)
 
     // then: the recovery ladder does not manufacture a status message

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5253,13 +5253,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // acknowledgements. The completion reminder re-wakes this session with the
     // real result, so silence here is delivery deferred, not delivery dropped.
     // Bounded by the same stuck-child backstop as GC/rollover: a wedged child
-    // stops pinning and the normal ladder resumes. A leaf carrying real text is
-    // deliberately NOT covered — recovering an answer the model already wrote is
-    // still correct while a child runs.
+    // stops pinning and the normal ladder resumes. A completed `stop` leaf
+    // carrying real text is deliberately NOT covered — recovering an answer the
+    // model already wrote is still correct while a child runs. Unfinished
+    // toolUse narration is covered because it is no longer publishable as an
+    // answer on any path.
     const awaitLeaf = recoverableAssistantText(live.session)
+    const awaitLeafIsUnfinishedToolUse = awaitLeaf?.source === 'mid-turn' || awaitLeaf?.source === 'pre-tool'
     if (
       live.currentTurnAuthorId !== null &&
-      (awaitLeaf === null || endsWithNoReplySignal(awaitLeaf.text)) &&
+      (awaitLeaf === null || awaitLeafIsUnfinishedToolUse || endsWithNoReplySignal(awaitLeaf.text)) &&
       isAwaitingBackgroundChild(live, 'empty_turn_recovery')
     ) {
       logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=awaiting_background_child`)
@@ -5286,6 +5289,49 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         `[channels] ${live.keyId}: suppressed plain_text_tool_call_leak (retries exhausted, silent) ` +
           `text_len=${leakedText.length}`,
       )
+    }
+
+    const retryStrandedToolUse = async (cause: string, exhaustedCause: string): Promise<void> => {
+      if (live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
+        live.emptyTurnRetries++
+        const routerAbortReason =
+          live.abortReasonThisTurn !== null && live.abortReasonThisTurn.turnSeq === live.turnSeq
+            ? live.abortReasonThisTurn.reason
+            : undefined
+        const agentAbortReason =
+          live.session.agent.signal?.aborted === true ? live.session.getAbortReason?.() : undefined
+        const abortReason = routerAbortReason ?? agentAbortReason ?? 'unknown'
+        logger.warn(
+          `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
+            `cause=${cause} abort_reason=${abortReason}`,
+        )
+        live.pendingSystemReminders.push(retryReminder(STRANDED_TOOLUSE_CONTINUATION_NUDGE))
+        return
+      }
+      await postEmptyTurnFallback(live, exhaustedCause)
+    }
+
+    // A real asker who received nothing cannot distinguish unfinished tool-use
+    // narration from a completed answer. Posting that scratchpad can falsely
+    // claim completion in the wrong language or before the tool result is
+    // interpreted; treating it as deliberate silence strands the asker instead.
+    // Keep both textless and text-bearing unfinished shapes on the established
+    // bounded continuation ladder, while explicit NO_REPLY, queued fresh input,
+    // observation-only turns, and every earlier delivery-deferred guard retain
+    // their narrower silence contracts.
+    const unfinishedToolUse = awaitLeaf
+    const unfinishedToolUseWithoutReply =
+      unfinishedToolUse !== null &&
+      (unfinishedToolUse.source === 'mid-turn' || unfinishedToolUse.source === 'pre-tool') &&
+      (unfinishedToolUse.text.trim() === '' || !endsWithNoReplySignal(unfinishedToolUse.text))
+    if (
+      unfinishedToolUseWithoutReply &&
+      live.successfulChannelSends === successfulSendsBeforePrompt &&
+      live.currentTurnAuthorId !== null &&
+      live.promptQueue.length === 0
+    ) {
+      await retryStrandedToolUse('stranded_toolUse_without_send', 'stranded_toolUse_without_send_retries_exhausted')
+      return
     }
 
     // A send landed this turn, but the model may have posted a `more_work_this_turn: true`
@@ -5395,27 +5441,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // that accompanied the already-landed reply); only the no-prose strand
         // gets a retry-or-fallback.
         if (leafIsStrandedToolUse(live.session) && live.currentTurnAuthorId !== null) {
-          if (live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
-            live.emptyTurnRetries++
-            const routerAbortReason =
-              live.abortReasonThisTurn !== null && live.abortReasonThisTurn.turnSeq === live.turnSeq
-                ? live.abortReasonThisTurn.reason
-                : undefined
-            const agentAbortReason =
-              live.session.agent.signal?.aborted === true ? live.session.getAbortReason?.() : undefined
-            const abortReason = routerAbortReason ?? agentAbortReason ?? 'unknown'
-            logger.warn(
-              `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
-                `cause=stranded_toolUse_after_send abort_reason=${abortReason}`,
-            )
-            live.pendingSystemReminders.push(retryReminder(STRANDED_TOOLUSE_CONTINUATION_NUDGE))
-          } else {
-            await postEmptyTurnFallback(live, 'stranded_toolUse_retries_exhausted')
-          }
+          await retryStrandedToolUse('stranded_toolUse_after_send', 'stranded_toolUse_retries_exhausted')
         }
         return
       }
       if (live.session.sessionManager.getLeafEntry()?.id === live.lastSendLeafId) return
+    }
+
+    if (unfinishedToolUseWithoutReply) {
+      logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=unfinished_toolUse_continuation_ineligible`)
+      return
     }
 
     let candidate = recoverableAssistantText(live.session)
@@ -5697,21 +5732,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       assistantText = extracted
     }
 
-    // `source` distinguishes the three recovery shapes for log triage:
+    // `source` distinguishes the completed recovery shapes for log triage:
     //   - 'leaf': the assistant message IS the leaf with stopReason 'stop'
     //     (existing behavior; model ended its turn with text but forgot to
     //     call channel_reply).
-    //   - 'mid-turn': the assistant message IS the leaf with stopReason
-    //     'toolUse'; the model narrated a reply, committed to a tool plan, and
-    //     the turn ended before a follow-up that would have called a channel
-    //     tool was persisted. The narration is the only user-facing text.
-    //   - 'pre-tool': the leaf is a toolResult (or other non-assistant entry)
-    //     and the assistant message lives upstream in the branch. This is the
-    //     Kimi-on-Fireworks `kimi-k2p6-turbo` failure mode where the post-tool
-    //     follow-up LLM call never produced a persisted assistant message, so
-    //     the model's pre-tool commentary is the only user-facing text we have.
-    //     Recovering it means the user gets *something* — strictly better than
-    //     the historical silent drop.
+    //   - 'length-leaf': the assistant message hit the output cap, leaked
+    //     reasoning was stripped, and a complete-looking answer survived.
+    // Unfinished 'mid-turn' / 'pre-tool' prose never reaches this egress: the
+    // terminal gate above either continues an eligible turn or preserves the
+    // silence contract that made continuation ineligible.
     // Egress-level GitHub review guards. The false-receipt and re-review
     // stranding guards live inside the channel_reply / channel_send tool
     // handlers, but recovery surfaces trailing assistant prose through a
@@ -7676,27 +7705,19 @@ async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): 
 //     Observed against claude on a channel turn that fell silent (2026-06-12).
 //
 //   - source: 'mid-turn'
-//     The leaf IS an assistant message with `stopReason === 'toolUse'` that
-//     carries visible text. The model narrated a user-facing reply ("on it,
-//     bumping to 16x now") AND committed to a tool plan in the same message,
-//     but the turn ended before any follow-up assistant message that would
-//     have called `channel_reply` was persisted — the upstream pi-agent-core
-//     loop's post-tool follow-up never landed, or the run was aborted
-//     mid-loop. The model treated its visible prose as ambient narration; in
-//     a channel session that prose is dead text. Recovers it so the user gets
-//     the reply the model thought it had already given. Observed against
-//     Fireworks' `kimi-k2p6-turbo` on KakaoTalk: the agent posted speed-change
-//     status as narration, kept taking screenshots, and the user saw nothing.
-//     This is the leaf-is-assistant twin of the 'pre-tool' shape below.
+//     The leaf IS an assistant message with `stopReason === 'toolUse'`. Its
+//     visible text, if any, is unfinished narration rather than a trustworthy
+//     answer because the planned tool work never reached a follow-up assistant
+//     message. The caller uses this source to enter bounded continuation rather
+//     than publishing the narration.
 //
 //   - source: 'pre-tool'
 //     The leaf is a `toolResult` and the immediately-prior assistant message
 //     has `stopReason === 'toolUse'` (it called the tool that produced this
 //     toolResult). The upstream pi-agent-core loop SHOULD have made a
 //     follow-up LLM call after the tool returned, but that call either never
-//     happened or produced no persisted message. Recovers the assistant's
-//     pre-tool commentary so the user gets *something* — observed against
-//     Fireworks' `accounts/fireworks/routers/kimi-k2p6-turbo` on 2026-05-26.
+//     happened or produced no persisted message. The caller treats the
+//     assistant's commentary as unfinished and enters bounded continuation.
 //
 // Returns null when no recovery is appropriate:
 //   - No leaf, no messages in branch, branch is malformed
@@ -7719,9 +7740,8 @@ function recoverableAssistantText(
     if (leaf.message.stopReason === 'stop') {
       return { text: visibleAssistantText(leaf.message), source: 'leaf' }
     }
-    // The model committed to a tool plan but its visible prose never reached
-    // the channel and no follow-up message that would have called a channel
-    // tool was persisted. Recover the stranded prose.
+    // Preserve the unfinished shape for the caller's continuation ladder; its
+    // prose is not a final answer and must not be published directly.
     if (leaf.message.stopReason === 'toolUse') {
       return { text: visibleAssistantText(leaf.message), source: 'mid-turn' }
     }
@@ -7752,7 +7772,9 @@ function recoverableAssistantText(
     if (!parent) return null
     if (parent.type === 'message') {
       if (parent.message.role === 'assistant') {
-        return { text: visibleAssistantText(parent.message), source: 'pre-tool' }
+        return parent.message.stopReason === 'toolUse'
+          ? { text: visibleAssistantText(parent.message), source: 'pre-tool' }
+          : null
       }
       if (parent.message.role === 'user') return null
     }


### PR DESCRIPTION
## Background

A production agent went silent on five consecutive messages from its own operator in a Slack thread. The operator asked a question, then `??`, then `??` again, then "is it set up?" — and received nothing each time. In one of the five the agent did speak, but what it posted was its own scratchpad note ("JSON valid. Now reload cron and commit.") in English, into a conversation held entirely in Korean. From the operator's side the work looked abandoned; in fact the agent had completed it and died before saying so.

Root-cause mechanism, traced through the transcripts:

A turn whose last assistant message has `stopReason: 'toolUse'` and no visible text is classified as *deliberate silence* and dropped.

- `recoverableAssistantText()` returns `{ text: '', source: 'mid-turn' }` for that leaf. `'leaf'` means `stopReason === 'stop'`; `'mid-turn'` means `'toolUse'`.
- A stranded-toolUse retry ladder already existed, but it was nested under the branch that requires a successful channel send to have already happened this turn. When the model sent nothing at all, the whole branch was skipped.
- The two no-send bare-empty guards both require `source === 'leaf'`, so a `'mid-turn'` source skipped them too.
- Execution therefore fell to the historical `no_reply` return. `isNoReplySignal('')` returns `true`, so an empty string was read as an explicit decision to stay quiet.

The result is the one failure mode this repo's own guidance forbids: the agent fails silently to the operator, with no way to tell "I decided not to answer" from "I broke".

## Summary

Two changes, both in `src/channels/router.ts`.

**A turn that stranded on unfinished tool use now enters the existing bounded ladder.** The retry/fallback body is extracted into `retryStrandedToolUse()` and made reachable from both the post-send path (unchanged) and a new no-send path. Exhaustion posts exactly one fallback under a distinct cause so the two shapes stay separable in logs. Reusing the existing `MAX_EMPTY_TURN_RETRIES` + `postEmptyTurnFallback` machinery rather than adding a parallel mechanism keeps the retry budget shared and the operator-visible behavior consistent.

**Unfinished `mid-turn` / `pre-tool` prose is no longer published as a reply.** Whether that text is an answer or a note-to-self is not knowable — the production case posted a scratchpad line as if it were the reply, in the wrong language. Both empty and text-bearing unfinished shapes now go to the continuation ladder, which asks the model to interpret its own tool result and produce a real answer. `'leaf'` and `'length-leaf'` recovery are untouched.

Why not simply eliminate silence for every empty turn: manufacturing replies on observation-only turns, peer-bot loop-guard turns, or turns awaiting a background child would be a worse regression than the bug. The new path is gated on a real asker, no send this turn, an empty prompt queue, and a non-`NO_REPLY` leaf.

## What this does NOT do

- Does not change `isNoReplySignal` / `endsWithNoReplySignal` semantics for non-empty input. An explicit `NO_REPLY` still yields silence.
- Does not touch the compaction trigger, the security guards, or the permissions layer. Those are separate problems found in the same investigation and are filed separately.
- Does not fix the underlying reason these turns strand. In all five production cases the last tool call was `reload`, and the loop ended without a follow-up model call. That cause is still unidentified; `chore/abort-observability` adds the instrumentation to name it. This PR makes the symptom non-silent regardless of cause, which is the part the operator actually experiences.

## Review notes

The load-bearing invariant is that every *deliberate* silence path still stays silent. Each has a named test:

| Preserved path | Test |
|---|---|
| explicit `NO_REPLY` | `mid-turn recovery: applies the NO_REPLY guard to recovered prose` |
| `skip_response` | `skip_response: suppresses recovery even when the assistant turn produced visible prose` |
| GitHub review already delivered | `github review output: an APPROVE landed this turn suppresses the empty-turn fallback (no dead-air apology)` |
| background child pending | `a stranded toolUse while a background child runs stays silent instead of retrying` |
| reminder-only / no author | `a restart reminder with no author keeps a stranded toolUse silent` |
| queued fresh inbound | `stranded toolUse without a send: a queued fresh inbound supersedes recovery and is answered next` |
| peer-bot loop guard | `a peer-bot loop-guard turn that emits NO_REPLY stays silent` |
| send + narration | `continue-reply guard: does NOT re-prompt when the trailing toolUse carries narration and a send landed` |

Two things worth a second opinion:

1. **Branch ordering.** The new no-send branch sits ahead of the skip-locked send-thrash guard. A turn that called `skip_response` *and* ended on an unfinished `toolUse` leaf with no send would now retry rather than respect the skip. I believe that combination is unreachable in practice and the existing `skip_response` tests pass, but I did not construct that exact shape — worth confirming.
2. **Comment provenance loss.** The old comments on `'mid-turn'` / `'pre-tool'` recorded the specific production failures that motivated them (model, platform, date). Since the handling changed, I rewrote them, but that provenance has value independent of the behavior. Happy to restore it as history if preferred.

Per-turn regression coverage lives beside the existing analogous post-send tests in `src/channels/router.test.ts`. One new test asserts the recovered conclusion in Korean, per the repo's multi-language rule.
