### PR TITLE
Stop the private-surface guard from blocking oversized non-path arguments

### DIFF
--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -45,6 +45,13 @@ function localOnlyLstat(agentDir: string): (candidate: string) => Stats {
   }
 }
 
+function linuxNameMaxRealpath(candidate: string): string {
+  if (Buffer.byteLength(path.basename(candidate), 'utf8') > 255) {
+    throw Object.assign(new Error('name too long'), { code: 'ENAMETOOLONG' })
+  }
+  return realpathSync.native(candidate)
+}
+
 describe('private-surface-read guard — builtin file tools', () => {
   test('blocks reading a file inside a hidden dir (relative and absolute)', () => {
     expect(check('read', { path: 'workspace/notes.md' })?.block).toBe(true)
@@ -116,7 +123,7 @@ describe('private-surface-read guard — fail-closed across ALL tools (not a whi
     expect(result?.reason).not.toMatch(/internal guard error/i)
   })
 
-  for (const code of ['ELOOP', 'ENOTDIR', 'EPERM', 'ENAMETOOLONG', 'EIO']) {
+  for (const code of ['ELOOP', 'ENOTDIR', 'EPERM', 'EIO']) {
     test(`blocks with a generic reason when realpathSync.native reports ${code}`, () => {
       // Must resolve like the guard does: a POSIX literal would not match on Windows.
       const inaccessible = path.resolve(AGENT, 'public/protected.md')
@@ -159,6 +166,32 @@ describe('private-surface-read guard — fail-closed across ALL tools (not a whi
 
     expect(result?.block).toBe(true)
     expect(result?.reason).toMatch(/internal guard error/i)
+  })
+
+  test('allows long Korean and English plugin prose without an internal guard error', () => {
+    const agentDir = realpathSync(mkdtempSync(path.join(tmpdir(), 'typeclaw-long-plugin-prose-')))
+    const koreanBody = '장기 기억에 남길 일반적인 사용자 지침입니다. '.repeat(10)
+    const englishBody = 'This is ordinary user guidance that should be written to long-term memory. '.repeat(5)
+    const internalErrors: unknown[] = []
+
+    expect(Buffer.byteLength(koreanBody, 'utf8')).toBeGreaterThan(255)
+    expect(Buffer.byteLength(englishBody, 'utf8')).toBeGreaterThan(255)
+    for (const body of [koreanBody, englishBody]) {
+      expect(
+        checkPrivateSurfaceReadGuard(
+          {
+            tool: 'memory_append',
+            args: { body },
+            agentDir,
+            hidden: privilegedHidden,
+            fileOperands: { nonFile: ['body'] },
+            toolProvenance: 'plugin',
+          },
+          { realpathNative: linuxNameMaxRealpath, onInternalError: (error) => internalErrors.push(error) },
+        ),
+      ).toBeUndefined()
+    }
+    expect(internalErrors).toEqual([])
   })
 
   test('blocks find_entry reading a hidden transcript via top-level path', () => {
@@ -490,6 +523,26 @@ describe('private-surface-read guard — traversal + scope', () => {
     expect(check('read', { path: './workspace/./x' })?.block).toBe(true)
   })
 
+  test('blocks traversal-normalized canonical secrets before resolving an oversized component', () => {
+    const oversized = 'x'.repeat(300)
+    const internalErrors: unknown[] = []
+    const result = checkPrivateSurfaceReadGuard(
+      {
+        tool: 'plugin_reader',
+        args: { value: `${oversized}/../secrets.json` },
+        agentDir: AGENT,
+        hidden: privilegedHidden,
+        toolProvenance: 'plugin',
+      },
+      { realpathNative: linuxNameMaxRealpath, onInternalError: (error) => internalErrors.push(error) },
+    )
+
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('secrets.json')
+    expect(result?.reason).not.toMatch(/internal guard error/i)
+    expect(internalErrors).toEqual([])
+  })
+
   test('covers the secret files across ALL tools (one deny-list, not delegated to secretExfilRead)', () => {
     expect(check('read', { path: '/agent/.env' })?.block).toBe(true)
     expect(check('read', { path: '.env' })?.block).toBe(true)
@@ -665,6 +718,29 @@ describe('private-surface-read guard — symlink bypass defense', () => {
       hidden,
     })
     expect(result?.block).toBe(true)
+  })
+
+  test('blocks an oversized tail below a symlink prefix into a hidden directory', () => {
+    const { agentDir, hidden } = makeAgentWithSymlinks()
+    const oversized = '기억'.repeat(50)
+    const internalErrors: unknown[] = []
+
+    expect(Buffer.byteLength(oversized, 'utf8')).toBeGreaterThan(255)
+    const result = checkPrivateSurfaceReadGuard(
+      {
+        tool: 'plugin_reader',
+        args: { value: path.join('public', 'mem-link', oversized) },
+        agentDir,
+        hidden,
+        toolProvenance: 'plugin',
+      },
+      { realpathNative: linuxNameMaxRealpath, onInternalError: (error) => internalErrors.push(error) },
+    )
+
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain(path.join(agentDir, 'memory'))
+    expect(result?.reason).not.toMatch(/internal guard error/i)
+    expect(internalErrors).toEqual([])
   })
 
   test('blocks the symlink via a NESTED arg shape (look_at images[].path)', () => {
@@ -1138,6 +1214,21 @@ describe('private-surface-read guard — honors a tool author fileOperands.nonFi
         fileOperands: { nonFile: ['query'] },
       })?.block,
     ).toBe(true)
+  })
+
+  test('blocks canonical secret files and directories despite declared nonFile operands', () => {
+    for (const value of ['secrets.json', '.env', '.typeclaw/home/credentials.json']) {
+      expect(
+        checkPrivateSurfaceReadGuard({
+          tool: 'unknown_plugin_reader',
+          args: { value },
+          agentDir: AGENT,
+          hidden: privilegedHidden,
+          fileOperands: { nonFile: ['value'] },
+          toolProvenance: 'plugin',
+        })?.block,
+      ).toBe(true)
+    }
   })
 
   test('blocks a colliding channel_send plugin local text operand from reading a canonical credential', () => {

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -16,7 +16,10 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { TOOLS_WITHOUT_LOCAL_FILE_OPERANDS } from '@/agent/tools-without-local-file-operands'
-import { RECOVER_MISSING_OR_UNSEARCHABLE, realIntendedPathSync } from '@/path-safety/real-intended-path'
+import {
+  RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG,
+  realIntendedPathSync,
+} from '@/path-safety/real-intended-path'
 import type { ToolFileOperands, ToolProvenance } from '@/plugin'
 import {
   CANONICAL_AGENT_SECRET_FILES,
@@ -1073,13 +1076,12 @@ function hasSameFileIdentity(candidate: string, deniedFile: string): boolean {
 }
 
 // Sync keeps the guard synchronous; the cost is one syscall per existing
-// component, negligible at the tool-call boundary. EACCES is recoverable here
-// (but NOT in the guard plugin's write policies): this is denylist matching, so
-// a path under an unsearchable ancestor must still be matched rather than
-// aborting the whole guard. See @/path-safety/real-intended-path.
+// component, negligible at the tool-call boundary. The broader errno recovery
+// is confined to this denylist matcher; guard plugin write policies retain the
+// allowlist-oriented default. See @/path-safety/real-intended-path.
 function realpathRealIntendedPath(absolutePath: string, realpath: (candidate: string) => string): string {
   return realIntendedPathSync(absolutePath, realpath, {
-    recoverable: RECOVER_MISSING_OR_UNSEARCHABLE,
+    recoverable: RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG,
     onExhausted: 'return-input',
   })
 }

--- a/src/path-safety/real-intended-path.test.ts
+++ b/src/path-safety/real-intended-path.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import {
+  RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG,
   RECOVER_MISSING,
   RECOVER_MISSING_OR_UNSEARCHABLE,
   realIntendedPath,
@@ -86,13 +87,49 @@ describe('realIntendedPathSync — unsearchable ancestor (the /root regression)'
   })
 })
 
+describe('realIntendedPathSync — oversized component', () => {
+  test('ENAMETOOLONG walks to a resolvable prefix when denylist recovery is opted in', () => {
+    const parent = path.resolve(path.sep, 'agent', 'public', 'gate')
+    const oversized = '긴'.repeat(100)
+    const leaf = path.join(parent, oversized)
+    const deniedReal = path.resolve(path.sep, 'agent', 'memory')
+
+    expect(Buffer.byteLength(oversized, 'utf8')).toBeGreaterThan(255)
+    expect(
+      realIntendedPathSync(
+        leaf,
+        (candidate) => {
+          if (candidate === leaf) throw errno('ENAMETOOLONG')
+          if (candidate === parent) return deniedReal
+          throw errno('ENOENT')
+        },
+        { recoverable: RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG },
+      ),
+    ).toBe(path.join(deniedReal, oversized))
+  })
+
+  test('ENAMETOOLONG remains fatal under the default and allowlist-oriented sets', () => {
+    const target = path.resolve(path.sep, 'agent', 'public', 'x')
+
+    expect(() => realIntendedPathSync(target, unsearchableUntilRoot('ENAMETOOLONG'))).toThrow(/synthetic ENAMETOOLONG/)
+    expect(() =>
+      realIntendedPathSync(target, unsearchableUntilRoot('ENAMETOOLONG'), { recoverable: RECOVER_MISSING }),
+    ).toThrow(/synthetic ENAMETOOLONG/)
+    expect(() =>
+      realIntendedPathSync(target, unsearchableUntilRoot('ENAMETOOLONG'), {
+        recoverable: RECOVER_MISSING_OR_UNSEARCHABLE,
+      }),
+    ).toThrow(/synthetic ENAMETOOLONG/)
+  })
+})
+
 describe('realIntendedPathSync — non-recoverable errors stay fatal', () => {
-  for (const code of ['ELOOP', 'ENOTDIR', 'EPERM', 'ENAMETOOLONG', 'EIO']) {
+  for (const code of ['ELOOP', 'ENOTDIR', 'EPERM', 'EIO']) {
     test(`${code} rethrows even with the broadest recoverable set`, () => {
       const target = path.resolve(path.sep, 'agent', 'public', 'x')
       expect(() =>
         realIntendedPathSync(target, unsearchableUntilRoot(code), {
-          recoverable: RECOVER_MISSING_OR_UNSEARCHABLE,
+          recoverable: RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG,
         }),
       ).toThrow(new RegExp(`synthetic ${code}`))
     })
@@ -106,7 +143,7 @@ describe('realIntendedPathSync — non-recoverable errors stay fatal', () => {
         () => {
           throw new Error('bare failure')
         },
-        { recoverable: RECOVER_MISSING_OR_UNSEARCHABLE },
+        { recoverable: RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG },
       ),
     ).toThrow(/bare failure/)
   })

--- a/src/path-safety/real-intended-path.ts
+++ b/src/path-safety/real-intended-path.ts
@@ -9,7 +9,7 @@ import path from 'node:path'
 // not exist.
 //
 // Which errnos may be walked past is the security-sensitive part, so it is the
-// CALLER's decision, not a default. See the two exported sets below.
+// CALLER's decision, not a default. See the three exported sets below.
 
 // The historical, strictest set: only a missing component is walked past.
 // Correct for allowlist/authorization policies, where an unresolvable component must
@@ -24,6 +24,19 @@ export const RECOVER_MISSING: ReadonlySet<string> = new Set(['ENOENT'])
 // the denied surface after rejoining: a masked directory still matches lexically and
 // still blocks. It is NOT sound for an allowlist — see RECOVER_MISSING.
 export const RECOVER_MISSING_OR_UNSEARCHABLE: ReadonlySet<string> = new Set(['ENOENT', 'EACCES'])
+
+// Adds ENAMETOOLONG for denylist matching of values that may be prose rather
+// than filesystem paths. Walking past an oversized component is sound for a
+// DENYLIST because lexical matching has already caught direct and
+// traversal-normalized denied paths, while the ancestor walk still resolves a
+// symlinked prefix before rejoining and matching the oversized tail. The
+// oversized component cannot itself name a real file on the affected
+// filesystem. It is NOT sound for an allowlist — see RECOVER_MISSING.
+export const RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG: ReadonlySet<string> = new Set([
+  'ENOENT',
+  'EACCES',
+  'ENAMETOOLONG',
+])
 
 export type RealIntendedPathOptions = {
   // Defaults to RECOVER_MISSING: callers must opt in to the broader set.


### PR DESCRIPTION
## Background

A production agent's long-term memory silently stopped recording. Its operator gave it a standing instruction; the instruction was never persisted, so later turns had no memory of it. The container log showed:

```
[plugin:security] internal security guard error guard=privateSurfaceRead
  code=ENAMETOOLONG: Error: ENAMETOOLONG: name too long, realpath '/agent/<the memory fragment body>'
  at realIntendedPathSync (src/path-safety/real-intended-path.ts)
  at matchHidden (src/bundled-plugins/security/policies/private-surface-read.ts)
  at checkPrivateSurfaceReadGuard (src/bundled-plugins/security/policies/private-surface-read.ts)
```

followed by `fragments_written=0`.

Mechanism:

- `collectPathCandidates` scans every string argument of every non-bash tool as a possible path, recursively, and the canonical-secret pass runs with exemptions disabled so unknown plugin tools stay fail-closed. That is deliberate and correct.
- A memory fragment *body* therefore became `path.resolve('/agent', <body>)` and was handed to `realpath`.
- `realIntendedPathSync` treats only `ENOENT` and `EACCES` as recoverable. `ENAMETOOLONG` was rethrown, caught by the guard's outer handler, and converted into a fail-closed block of the tool call.

So an errno that means "this string is not a filename" was being treated as "this path is indeterminate, deny". The guard was not defending anything here — no secret was reachable — it was just misclassifying a syscall error, and the cost was the agent's memory.

**Multi-language amplifier, and why this never showed up in development.** Linux `NAME_MAX` is 255 **bytes**; macOS APFS counts characters. Korean and other CJK text is 3 bytes per character in UTF-8, so a Korean argument trips this at roughly 85 characters while English needs 256. The agent runs on Linux in a container; developers run macOS. A Korean-speaking deployment hits this constantly and a macOS dev box essentially never does.

This is the pattern `AGENTS.md` documents in "Security serves the product, not the other way around": an over-broad guard failing closed on ordinary input, breaking a legitimate workflow while blocking no actual threat.

## Summary

Adds a third, explicitly-named recoverable-errno set — `RECOVER_MISSING_OR_UNSEARCHABLE_OR_NAME_TOO_LONG` (`ENOENT`, `EACCES`, `ENAMETOOLONG`) — used **only** by the denylist matching in `private-surface-read.ts`. The default and allowlist-oriented sets are unchanged, so `ENAMETOOLONG` remains fatal everywhere it should be.

Recovery is sound for a denylist specifically, and the new set's comment documents why:

- `matchLexicallyDenied()` runs before any `realpath`, so a direct or traversal-normalized denied path (`long-component/../secrets.json`) is caught regardless of length.
- The ancestor walk still canonicalizes the longest resolvable *prefix* and lexically rejoins the oversized tail, so `public/symlink-to-memory/<oversized>` still resolves the symlink into the denied directory and still matches under it.
- An oversized component cannot name a real file on the affected filesystem, so nothing becomes reachable.

Why not the alternatives:

- **Skip candidates that are "obviously not paths".** A raw length skip misses traversal and symlink prefixes. Making it sound requires lexical normalization plus ancestor canonicalization — i.e. reimplementing the recovery this PR adds.
- **Let the memory plugin declare its arguments as free text.** It already does: the append tool declares its arguments `fileOperands.nonFile` and `wrapPluginTool()` forwards that. The canonical-secret pass ignores plugin exemptions **by design**, so that a plugin cannot label `secrets.json` non-file and dereference it anyway. That invariant is preserved here, not weakened.

## What this does NOT do

- Does not make the guard fail open on unknown internal errors. `EIO`, `EPERM`, `ELOOP`, `ENOTDIR` and non-errno throws still produce the generic fail-closed block plus the diagnostic log.
- Does not enable exemptions for the canonical pass, and adds nothing to `FREE_TEXT_KEYS_BY_TOOL`, `CANONICAL_FREE_TEXT_KEYS_BY_TOOL`, or `CANONICAL_FREE_TEXT_OPERANDS_BY_TOOL`.
- Does not touch the channel router, compaction, or permissions.

## Review notes

Tested in both directions, as required for a guard change.

Threat still blocked:
- `blocks canonical secret files and directories despite declared nonFile operands` — covers `secrets.json`, `.env`, and a canonical hidden directory
- `blocks traversal-normalized canonical secrets before resolving an oversized component`
- `blocks an oversized tail below a symlink prefix into a hidden directory`
- existing generic-error coverage for `ELOOP`, `ENOTDIR`, `EPERM`, `EIO`, and non-errno throws, including the diagnostic log

Authorized workflow restored:
- `allows long Korean and English plugin prose without an internal guard error`
- `ENAMETOOLONG walks to a resolvable prefix when denylist recovery is opted in`
- `ENAMETOOLONG remains fatal under the default and allowlist-oriented sets`

Platform stability: tests inject a `linuxNameMaxRealpath()` hook that raises `ENAMETOOLONG` past 255 UTF-8 bytes, so the Korean and English cases exercise Linux semantics identically on macOS and Linux. Without that, this suite would pass vacuously on a developer machine — which is precisely how the bug survived.
