### PR TITLE
Log the session and reason at every turn-abort site

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import { randomUUID } from 'node:crypto'
 import { readdirSync } from 'node:fs'
 import {
@@ -6124,6 +6124,72 @@ describe('loop guard integration', () => {
       wrapped.execute('c5', { url: 'https://example.com' }, undefined, undefined, {} as never),
     ).rejects.toThrow(/loop-guard/)
     expect(aborts).toBe(1)
+  })
+
+  test('logs a diagnostic warning identifying the session and reason when the loop guard fires an abort', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const tool = defineTool({
+        description: '',
+        parameters: z.object({ q: z.string() }),
+        async execute() {
+          return { content: [{ type: 'text', text: 'ok' }] }
+        },
+      })
+      const wrapped = wrapPluginTool(tool, {
+        pluginName: 'p1',
+        toolName: 'search',
+        agentDir: '/agent',
+        sessionId: 'loop-abort-diagnostic-session',
+        logger: noopLogger,
+        hooks: createHookBus(),
+        getAbort: () => () => {},
+      })
+
+      for (let i = 0; i < 4; i++) {
+        await wrapped.execute(`c${i}`, { q: 'a' }, undefined, undefined, {} as never)
+      }
+      expect(warnSpy).not.toHaveBeenCalled()
+
+      await wrapped.execute('c5', { q: 'a' }, undefined, undefined, {} as never)
+
+      const abortLog = warnSpy.mock.calls.map((call) => String(call[0])).find((m) => m.includes('site=loop_guard'))
+      expect(abortLog).toBeDefined()
+      expect(abortLog).toContain('session=loop-abort-diagnostic-session')
+      expect(abortLog).toContain('reason=loop_guard:block')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('does not log an abort warning when no abort function is wired', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const tool = defineTool({
+        description: '',
+        parameters: z.object({ q: z.string() }),
+        async execute() {
+          return { content: [{ type: 'text', text: 'ok' }] }
+        },
+      })
+      const wrapped = wrapPluginTool(tool, {
+        pluginName: 'p1',
+        toolName: 'search',
+        agentDir: '/agent',
+        sessionId: 'loop-abort-no-getabort',
+        logger: noopLogger,
+        hooks: createHookBus(),
+      })
+
+      for (let i = 0; i < 4; i++) {
+        await wrapped.execute(`c${i}`, { q: 'a' }, undefined, undefined, {} as never)
+      }
+      await wrapped.execute('c5', { q: 'a' }, undefined, undefined, {} as never)
+
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('site=loop_guard'))).toBe(false)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   test('does not abort while calls are still under the block threshold', async () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -419,7 +419,7 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         opts.agentDir,
       )
       if (loopGate.blockNow) {
-        fireLoopAbort(opts.getAbort, 'loop_guard:block')
+        fireLoopAbort(opts.getAbort, 'loop_guard:block', opts.sessionId)
         return errorResult(loopGate.message)
       }
 
@@ -466,7 +466,7 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
 
       const resolved = loopGate.resolve(result)
       if ('deferredBlock' in resolved) {
-        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
+        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block', opts.sessionId)
         return errorResult(resolved.deferredBlock)
       }
       result = resolved.result
@@ -516,7 +516,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       }
       const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs, opts.getLoopGuardTurn?.(), opts.agentDir)
       if (loopGate.blockNow) {
-        fireLoopAbort(opts.getAbort, 'loop_guard:block')
+        fireLoopAbort(opts.getAbort, 'loop_guard:block', opts.sessionId)
         throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -573,7 +573,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       })
       const resolved = loopGate.resolve(restoredResult)
       if ('deferredBlock' in resolved) {
-        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
+        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block', opts.sessionId)
         throw new Error(resolved.deferredBlock)
       }
       const hookResult = resolved.result
@@ -641,7 +641,7 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
       delete mutableArgs[TYPECLAW_INTERNAL_BASH_PREPARE]
       const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs, opts.getLoopGuardTurn?.(), opts.agentDir)
       if (loopGate.blockNow) {
-        fireLoopAbort(opts.getAbort, 'loop_guard:block')
+        fireLoopAbort(opts.getAbort, 'loop_guard:block', opts.sessionId)
         throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -846,7 +846,7 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
       }
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
-        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
+        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block', opts.sessionId)
         throw new Error(resolved.deferredBlock)
       }
       const hookResult = resolved.result
@@ -1448,8 +1448,21 @@ export function __resetSharedLoopGuardForTests(): void {
 // 'aborted'). We use the signal-only `agent.abort`, never `session.abort`,
 // which would deadlock awaiting the very run this tool call belongs to. See
 // the matching pattern in src/channels/router.ts (policy-denied send cap).
-function fireLoopAbort(getAbort: (() => ((reason?: string) => void) | undefined) | undefined, reason: string): void {
-  getAbort?.()?.(reason)
+//
+// A signal-only abort leaves no trace in the transcript itself (the turn just
+// ends with stopReason 'aborted' and no follow-up call), so this is the only
+// place an operator can learn WHY from `typeclaw logs` — log before invoking
+// the abort, not after, so a getAbort() that turns out to be undefined never
+// reports an abort that didn't actually happen.
+function fireLoopAbort(
+  getAbort: (() => ((reason?: string) => void) | undefined) | undefined,
+  reason: string,
+  sessionId: string,
+): void {
+  const abort = getAbort?.()
+  if (abort === undefined) return
+  console.warn(`[agent] abort site=loop_guard session=${sessionId} reason=${reason}`)
+  abort(reason)
 }
 
 function errorResult(message: string) {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1161,6 +1161,40 @@ describe('ChannelRouter session lifecycle', () => {
     expect(router.liveCount()).toBe(1)
   })
 
+  test('stop logs teardown abort details when a prompt is in flight', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    let releasePrompt: () => void = () => {}
+    const promptHeld = new Promise<void>((resolve) => {
+      releasePrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    sessions[0]!.onPrompt = async () => {
+      await promptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+
+    await router.stop()
+    releasePrompt()
+    await drainPromise
+
+    expect(logs).toContain('warn:[channels] discord-bot:g1:c1: abort site=teardown session=ses_fake_1 reason=teardown')
+  })
+
+  test('stop does not log a teardown abort for an idle session', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router } = makeRouter(dir, { logs })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.stop()
+
+    expect(logs.filter((line) => line.includes('abort site=teardown'))).toEqual([])
+  })
+
   // Reviewer follow-up (#1174): observe-only messages (buffered to contextBuffer
   // with no queued prompt) that arrive during the held prompt must be carried to
   // the successor, not dropped — and must NOT themselves trigger a turn on the
@@ -4933,6 +4967,34 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('aborting turn') && m.includes('policy-denied'))).toBe(true)
   })
 
+  test('policy-denial abort log identifies the session id, reason, and firing site for operator diagnosis', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    sessions[0]!.onPrompt = async () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing to add' })
+      let i = 0
+      while (!sessions[0]!.agent.signal.aborted && i < 100) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `attempt ${i}` })
+        i++
+      }
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.agent.signal.aborted).toBe(true)
+    const abortLog = logs.find((m) => m.includes('site=policy_denied_send_cap'))
+    expect(abortLog).toBeDefined()
+    expect(abortLog).toContain('session=ses_fake_1')
+    expect(abortLog).toContain('reason=policy_denied:skip-locked')
+  })
+
   test('policy-denial loop: counter resets per turn (denials below the ceiling do not throw, next turn replies)', async () => {
     const dir = await tempDir()
     const sent: Array<{ text: string }> = []
@@ -8172,6 +8234,31 @@ describe('ChannelRouter commands', () => {
     expect(sessions[0]!.aborted).toBe(1)
     expect(sessions[0]!.prompts).toHaveLength(1)
     expect(sessions[0]!.prompts[0]).toContain('long task')
+  })
+
+  test('/stop logs a diagnostic abort line identifying the session, reason, and site', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    let releasePrompt: (() => void) | undefined
+
+    await router.route(inbound({ text: 'long task' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length === 1)
+
+    await router.route(inbound({ text: '/stop', externalMessageId: 'm-stop' }))
+    releasePrompt!()
+    await draining
+
+    const abortLog = logs.find((m) => m.includes('site=user_stop'))
+    expect(abortLog).toBeDefined()
+    expect(abortLog).toContain('session=ses_fake_1')
+    expect(abortLog).toContain('reason=user_stop')
   })
 
   test('/stop supersedes terminal-reply provenance before the aborted outcome is captured', async () => {
@@ -14165,6 +14252,23 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     expect(agent.signal.aborted).toBe(false)
   })
 
+  test('logs a diagnostic line identifying the session, reason, and site when channel_reply ends the turn', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+    const agent = sessions[0]!.agent
+
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
+
+    expect(agent.signal.aborted).toBe(true)
+    const abortLog = logs.find((m) => m.includes('site=terminal_after_channel_reply'))
+    expect(abortLog).toBeDefined()
+    expect(abortLog).toContain('session=ses_fake_1')
+    expect(abortLog).toContain('reason=terminal_after_channel_reply')
+  })
+
   test('does NOT abort when channel_reply was rejected (details.ok === false)', async () => {
     const agent = await liveAgentAfterRoute(await tempDir())
     await agent.afterToolCall!(afterToolContext('channel_reply', { ok: false }, false))
@@ -16640,7 +16744,8 @@ describe('markRestartAbortForAllLive (graceful host restart)', () => {
   test('aborts every live session and marks its scope so resume auto-continues', async () => {
     // given a live channel session with an in-flight-capable turn
     const dir = await tempDir()
-    const { router, sessions } = makeRouter(dir)
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
     await router.route(inbound({ externalMessageId: 'm1' }))
     await router.__testing!.flushDebounce(KEY)
     expect(sessions).toHaveLength(1)
@@ -16660,6 +16765,9 @@ describe('markRestartAbortForAllLive (graceful host restart)', () => {
       participants: [],
     })!
     expect((await readContinuationState(dir, scope)).restartAbortPending).toBe(true)
+    expect(logs).toContain(
+      'warn:[channels] discord-bot:g1:c1: abort site=graceful_restart session=ses_fake_1 reason=graceful_restart',
+    )
   })
 
   test('is a no-op with no live sessions', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2936,7 +2936,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         }
       }
       if (succeeded && !keepTurnAlive && agent.signal?.aborted !== true && live.userStoppedTurnSeq !== live.turnSeq) {
-        logger.info(`[channels] ${live.keyId} terminal_after_channel_reply`)
+        logger.info(
+          `[channels] ${live.keyId} terminal_after_channel_reply site=terminal_after_channel_reply session=${live.sessionId} reason=terminal_after_channel_reply`,
+        )
         const replyText = (context.toolCall.arguments as { text?: unknown } | undefined)?.text
         live.lastTerminalReplyAbort = typeof replyText === 'string' ? { turnSeq: live.turnSeq, text: replyText } : null
         live.abortReasonThisTurn = { turnSeq: live.turnSeq, reason: 'terminal_after_channel_reply' }
@@ -3338,7 +3340,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     await stopTypingHeartbeat(live)
     try {
       await live.session.abort()
-      logger.info(`[channels] ${live.keyId}: command /stop aborted current turn`)
+      logger.info(
+        `[channels] ${live.keyId}: command /stop aborted current turn site=user_stop session=${live.sessionId} reason=user_stop`,
+      )
     } catch (err) {
       logger.warn(`[channels] ${live.keyId}: command /stop abort failed: ${describeError(err)}`)
     }
@@ -5006,7 +5010,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const count = (live.policyDeniedToolSendsThisTurn.get(sendKey) ?? 0) + 1
         live.policyDeniedToolSendsThisTurn.set(sendKey, count)
         if (count >= MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN) {
-          logger.warn(`[channels] ${live.keyId}: aborting turn — ${count} policy-denied channel sends (last: ${code})`)
+          logger.warn(
+            `[channels] ${live.keyId}: aborting turn — ${count} policy-denied channel sends (last: ${code}) site=policy_denied_send_cap session=${live.sessionId} reason=policy_denied:${code}`,
+          )
           live.abortReasonThisTurn = { turnSeq: live.turnSeq, reason: `policy_denied:${code}` }
           if (live.session.agent.signal?.aborted !== true) live.session.agent.abort()
         }
@@ -5887,8 +5893,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.unsubTodoOutcome?.()
     live.unsubTodoOutcome = null
     await stopTypingHeartbeat(live)
+    // Captured before the abort call: `draining` flips false in drain()'s own
+    // finally once the turn it was guarding ends, so reading it here is the
+    // only reliable signal that this teardown cut off a turn actually in
+    // flight rather than an already-idle session.
+    const abortedInFlightTurn = live.draining
     try {
       await live.session.abort()
+      if (abortedInFlightTurn) {
+        logger.warn(`[channels] ${live.keyId} abort site=teardown session=${live.sessionId} reason=teardown`)
+      }
     } catch (err) {
       logger.warn(`[channels] abort failed for ${live.keyId}: ${describeError(err)}`)
     }
@@ -6003,6 +6017,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       )
       await live.session
         .abort()
+        .then(() => {
+          logger.warn(
+            `[channels] ${live.keyId} abort site=graceful_restart session=${live.sessionId} reason=graceful_restart`,
+          )
+        })
         .catch((err) => logger.error(`[channels] graceful-restart abort failed: ${describeError(err)}`))
     }
   }


### PR DESCRIPTION
## Background

A production agent went silent on five consecutive operator messages. Each turn ended with the last assistant message carrying `stopReason: 'toolUse'` and no follow-up model call — the signature of an aborted run signal rather than a normal completion.

Identifying *which* abort fired was not possible from the logs. Static tracing ruled out several candidates (the config/provider teardown path, compaction, context size, an explicit `terminate`), but the abort sites themselves emit nothing that identifies the session or the reason, so the investigation stalled at "something aborted the turn". `fireLoopAbort()` is documented as the only thing that actually stops an in-flight turn, and it logged nothing at all.

That diagnostic gap is what this PR closes. It is a prerequisite for fixing the underlying bug, not the fix itself.

## Summary

Every site that aborts an agent turn or session now emits one structured line carrying the session id, the reason string already available at that site, and a stable identifier for which site fired:

| Site | Site id |
|---|---|
| loop guard (6 call sites via `fireLoopAbort`) | `loop_guard` |
| terminal abort after a successful `channel_reply` | `terminal_after_channel_reply` |
| policy-denied send ceiling | `policy_denied_send_cap` |
| `/stop` command | `user_stop` |
| `tearDownLive` (stop / idle GC / unwind) | `teardown` |
| `markRestartAbortForAllLive` | `graceful_restart` |

Format follows each file's existing convention rather than introducing a new one — `[channels] <keyId> <event> … site=… session=… reason=…` in the router, and the bare `console.warn('[agent] …')` shape in `plugin-tools.ts`, which has no logger threaded into two of its call sites. Where a log line already existed at the site, it was enriched rather than duplicated; the pre-existing policy-denial regression tests still match on their original substrings.

Two details worth noting. `fireLoopAbort` only logs when `getAbort()` actually resolves to a function, so an unwired abort handle never reports a false abort. The `teardown` line is gated on `live.draining` captured *before* the await, so ordinary idle-session teardown doesn't emit a misleading "in-flight abort".

## What this does NOT do

- Changes no abort condition and adds or removes no abort. Diagnostics only.
- Logs no message text, tool arguments, secrets, or environment values — session id, reason, and site identifier only.
- Does not instrument HTTP/subprocess timeout `AbortController`s (`webfetch`, `mcp/client`, `hostd/client`, `update/check`, backup runner, llm-fetch observer, multimodal looker). Those abort a single fetch or spawn, not an agent turn, and their causation is already evident from their own timeout paths.
- Does not instrument TUI/websocket aborts (`server/index.ts`, `server/command-runner.ts`) or subagent lifecycle aborts (`agent/subagents.ts`, `subagent-drain.ts`, `agent/tools/subagent-cancel.ts`). Each is fired by an explicit client message or cancel path whose causation is inherent, and touching them would widen a deliberately small diagnostic change.
- Deliberately avoids the `validateChannelTurn` empty-turn region of `src/channels/router.ts`, which `fix/channel-turn-never-fails-silently` is editing concurrently. Expect a trivial rebase if that PR lands first.

## Review notes

The thing to verify is that this stayed behavior-preserving: no control flow moved, and the two enriched log lines kept the substrings their existing regression tests assert on.

New tests:
- `src/agent/plugin-tools.test.ts` — `logs a diagnostic warning identifying the session and reason when the loop guard fires an abort`, `does not log an abort warning when no abort function is wired`
- `src/channels/router.test.ts` — `policy-denial abort log identifies the session id, reason, and firing site for operator diagnosis`, `logs a diagnostic line identifying the session, reason, and site when channel_reply ends the turn`, `/stop logs a diagnostic abort line identifying the session, reason, and site`

Once this is deployed, the silent-turn incident should name its own cause on the next occurrence.
