### PR TITLE
Isolate GitHub CLI home in run tests

### DIFF
--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { mkdtemp } from 'node:fs/promises'
+import { mkdir, mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,15 +8,32 @@ import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from 
 import { createChannelRouter, type ChannelManager, type ChannelManagerOptions } from '@/channels'
 import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 import type { CronFile, CronJob, LoadCronResult, Scheduler } from '@/cron'
-import { SecretsBackend } from '@/secrets'
+import { exportGithubCliStoreForAgent, SecretsBackend } from '@/secrets'
 import type { SessionFactory } from '@/sessions'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 import type { TuiOptions } from '@/tui'
 import type { TunnelManager, TunnelManagerOptions } from '@/tunnels'
 
-import { type LoadCronFn, type SchedulerFactory, startAgent, type TuiFactory } from './index'
+import {
+  type LoadCronFn,
+  type SchedulerFactory,
+  startAgent as startAgentRuntime,
+  type StartAgentOptions,
+  type TuiFactory,
+} from './index'
 
 const noCron: LoadCronFn = async () => ({ ok: true, file: null }) as LoadCronResult
+
+let githubCliHomeDir: string
+
+function startAgent(options: StartAgentOptions) {
+  return startAgentRuntime({
+    ...options,
+    exportGithubCliStore:
+      options.exportGithubCliStore ??
+      ((exportOptions) => exportGithubCliStoreForAgent({ ...exportOptions, homeDir: githubCliHomeDir })),
+  })
+}
 
 function stubScheduler(): Scheduler {
   return {
@@ -30,7 +47,8 @@ function stubScheduler(): Scheduler {
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
 let savedBrokerToken: string | undefined
 
-beforeEach(() => {
+beforeEach(async () => {
+  githubCliHomeDir = await mkdtemp(join(tmpdir(), 'typeclaw-run-home-'))
   // startAgent boots the agent-browser plugin. Keep the broker token absent so
   // these run-loop tests do not publish a reserved dashboard forward request
   // into an unrelated in-process bus subscriber.
@@ -42,10 +60,12 @@ afterEach(async () => {
   resetDashboardForwardRequest()
   if (savedBrokerToken === undefined) delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
   else process.env['TYPECLAW_HOSTD_BROKER_TOKEN'] = savedBrokerToken
-  if (!running) return
-  running.tuiPromise?.catch(() => {})
-  await running.stop()
-  running = null
+  if (running) {
+    running.tuiPromise?.catch(() => {})
+    await running.stop()
+    running = null
+  }
+  await rmTempDir(githubCliHomeDir)
 })
 
 describe('startAgent', () => {
@@ -69,6 +89,30 @@ describe('startAgent', () => {
     const res = await fetch(`http://localhost:${running.server.port}`)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('typeclaw agent')
+  })
+
+  test('keeps the host GitHub CLI store untouched when the agent has no stored credential', async () => {
+    const hostHomeDir = await mkdtemp(join(tmpdir(), 'typeclaw-run-host-home-'))
+    const hostTarget = join(hostHomeDir, '.config', 'gh', 'hosts.yml')
+    const runtimeTarget = join(githubCliHomeDir, '.config', 'gh', 'hosts.yml')
+    const sentinel = 'host credential sentinel\n'
+    const savedHome = process.env.HOME
+
+    await mkdir(join(hostHomeDir, '.config', 'gh'), { recursive: true })
+    await mkdir(join(githubCliHomeDir, '.config', 'gh'), { recursive: true })
+    await Bun.write(hostTarget, sentinel)
+    await Bun.write(runtimeTarget, 'stale runtime credential\n')
+    process.env.HOME = hostHomeDir
+    try {
+      running = await startAgent({ port: 0, attachTui: false, cwd: testCwd, loadCron: noCron })
+
+      expect(await Bun.file(hostTarget).text()).toBe(sentinel)
+      expect(existsSync(runtimeTarget)).toBe(false)
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME
+      else process.env.HOME = savedHome
+      await rmTempDir(hostHomeDir)
+    }
   })
 
   test('awaits provider-OAuth refresh before any session consumer starts, so a lock-holding refresh cannot ELOCKED a boot auth read', async () => {

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -6,18 +6,31 @@ import { join } from 'node:path'
 import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from '@/bundled-plugins/agent-browser'
 import { createChannelRouter, type ChannelManager } from '@/channels'
 import type { LoadCronResult } from '@/cron'
+import { exportGithubCliStoreForAgent } from '@/secrets'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 import type { TunnelManager } from '@/tunnels'
 
-import { startAgent, type LoadCronFn } from './index'
+import { type LoadCronFn, startAgent as startAgentRuntime, type StartAgentOptions } from './index'
 
 const noCron: LoadCronFn = async () => ({ ok: true, file: null }) as LoadCronResult
+
+let githubCliHomeDir: string
+
+function startAgent(options: StartAgentOptions) {
+  return startAgentRuntime({
+    ...options,
+    exportGithubCliStore:
+      options.exportGithubCliStore ??
+      ((exportOptions) => exportGithubCliStoreForAgent({ ...exportOptions, homeDir: githubCliHomeDir })),
+  })
+}
 
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
 let agentDir: string | null = null
 let savedBrokerToken: string | undefined
 
-beforeEach(() => {
+beforeEach(async () => {
+  githubCliHomeDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-home-'))
   // startAgent boots the agent-browser plugin. Keep the broker token absent so
   // these run-loop tests do not publish a reserved dashboard forward request
   // into an unrelated in-process bus subscriber.
@@ -27,7 +40,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   if (running) {
-    running.stop()
+    await running.stop()
     running.tuiPromise?.catch(() => {})
     running = null
   }
@@ -35,6 +48,7 @@ afterEach(async () => {
     await rmTempDir(agentDir)
     agentDir = null
   }
+  await rmTempDir(githubCliHomeDir)
   resetDashboardForwardRequest()
   if (savedBrokerToken === undefined) delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
   else process.env['TYPECLAW_HOSTD_BROKER_TOKEN'] = savedBrokerToken


### PR DESCRIPTION
## Background

`src/run/index.test.ts` and `src/run/plugin.test.ts` call `startAgent()` without overriding `exportGithubCliStore`, so the default `exportGithubCliStoreForAgent` ran against `homedir()` — the real developer/CI machine's home directory. When a test agent has no stored GitHub CLI credential, that exporter calls `removeRuntimeStore`, which deletes the real `~/.config/gh/hosts.yml`. Running these tests could silently wipe a developer's actual `gh auth login` session.

## Summary

Both test files now inject a per-test temp `githubCliHomeDir` (via `mkdtemp`, cleaned up in `afterEach`) into `exportGithubCliStore`, wrapping `startAgent` so every call defaults to that isolated home unless a test explicitly overrides it. A new regression test in `src/run/index.test.ts` sets `process.env.HOME` to a temporary simulated host directory, plants a sentinel `hosts.yml` there, and pre-populates the isolated runtime home with a stale `hosts.yml`. After `startAgent()` runs with no stored credential, it asserts the simulated host's sentinel is preserved and the stale isolated runtime `hosts.yml` has been removed.

`src/run/plugin.test.ts`'s `afterEach` also now awaits `running.stop()` instead of firing it without awaiting, so the isolated home directory is not removed while the stop sequence (which may still touch it) is in flight.

## What this does NOT do

- Does not change `exportGithubCliStoreForAgent` or `removeRuntimeStore` behavior — the fix is entirely in test isolation, not runtime logic.
- Does not add home-directory isolation to other test suites; only the two files that boot a real `startAgent()`.

## Review notes

The regression test is the load-bearing addition: both the simulated host HOME and the isolated runtime home it exercises are temporary fixtures, not the developer's actual home directory. It plants a sentinel at the simulated host's `hosts.yml` path and a stale credential at the isolated runtime's `hosts.yml` path, then asserts that a `startAgent()` call with no stored credential leaves the host sentinel untouched while removing the stale isolated runtime file — exactly the scenario that, before this isolation existed, risked touching the real home directory via `removeRuntimeStore`.

## Verification

- `bun run typecheck` — clean
- `bun run format:check` — clean
- `bun run lint` — 0 errors (70 pre-existing warnings, none in changed files)
- `bun test --parallel src/run/index.test.ts src/run/plugin.test.ts src/secrets/export-github-cli-store.test.ts` — 51 pass, 0 fail
- Full `bun run test` was not completed: it reaches the existing `src/agent/plugin-tools.test.ts` and hangs there, timing out locally with no preceding failures. This is unrelated to the two files changed here.