### PR TITLE
Credit sticky to the surface a reply is published on

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2218,6 +2218,129 @@ describe('ChannelRouter sticky credits', () => {
     expect(sessions[0]!.prompts[0]).toContain('You are in a group chat and are woken on every message')
   })
 
+  test('a reply published to the room root wakes the author there, not in the thread it was answered from', async () => {
+    // given a root room where BOTH humans have spoken, so the solo-human
+    // fallback is off and sticky is the only thing that can engage a plain
+    // follow-up, and alice engaged the bot inside a thread
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ authorId: 'bob', externalMessageId: 'bob-1', isBotMention: true, text: 'bot hi' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value = 1100
+    await router.route(inbound({ authorId: 'alice', externalMessageId: 'alice-1', isBotMention: true, text: 'bot yo' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+
+    const threadKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't1' }
+    nowRef.value = 1200
+    await router.route(
+      inbound({ thread: 't1', authorId: 'alice', externalMessageId: 'alice-t1', isBotMention: true, text: 'bot look' }),
+    )
+    await router.__testing!.flushDebounce(threadKey)
+
+    // when the answer is PUBLISHED to the room root while still being accounted
+    // to the thread session (the post_github_review fallback-comment shape)
+    nowRef.value = 1500
+    const result = await router.send(
+      { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, text: 'here is the review' },
+      { accountingTarget: threadKey },
+    )
+    expect(result.ok).toBe(true)
+
+    // then alice's plain follow-up on the root — the only surface she can see
+    // that reply on — engages instead of being silently observed
+    nowRef.value = 2000
+    await router.route(
+      inbound({ authorId: 'alice', externalMessageId: 'alice-2', isBotMention: false, text: 'answered your point' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sessions[0]!.prompts[0]).toContain('answered your point')
+  })
+
+  test('a divergent-thread send credits only the delivery key, leaving no stranded thread credit', async () => {
+    // given the same divergent send as above
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    const threadKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't1' }
+    await router.route(
+      inbound({ thread: 't1', authorId: 'alice', externalMessageId: 'alice-t1', isBotMention: true, text: 'bot look' }),
+    )
+    await router.__testing!.flushDebounce(threadKey)
+    nowRef.value = 1500
+    await router.send(
+      { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, text: 'here is the review' },
+      { accountingTarget: threadKey },
+    )
+
+    // then the credit exists on the root and nothing is left on the thread, so a
+    // later disengage on either surface cannot strand a half of a paired grant
+    expect(router.clearSticky(threadKey).cleared).toBe(0)
+    expect(router.clearSticky(KEY).cleared).toBe(1)
+  })
+
+  test('a cross-chat send still credits its accounting session, not the destination', async () => {
+    // given a turn in c1 whose reply is delivered to a different chat entirely
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ authorId: 'alice', externalMessageId: 'alice-1', isBotMention: true, text: 'bot hi' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    nowRef.value = 1500
+    await router.send(
+      { adapter: 'discord-bot', workspace: 'g1', chat: 'c2', thread: null, text: 'relaying this over here' },
+      { accountingTarget: KEY },
+    )
+
+    // then the delivery redirect does not apply: author ids are namespaced per
+    // room, so the credit stays where the turn actually happened
+    expect(router.clearSticky({ adapter: 'discord-bot', workspace: 'g1', chat: 'c2', thread: null }).cleared).toBe(0)
+    expect(router.clearSticky(KEY).cleared).toBe(1)
+  })
+
+  test('a root-published reply credits only its reply targets, not everyone in the room', async () => {
+    // given the divergent send answering alice, in a 2-human root room where
+    // the solo-human fallback is off
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ authorId: 'bob', externalMessageId: 'bob-1', isBotMention: true, text: 'bot hi' }))
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value = 1100
+    await router.route(inbound({ authorId: 'alice', externalMessageId: 'alice-1', isBotMention: true, text: 'bot yo' }))
+    await router.__testing!.flushDebounce(KEY)
+    const threadKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't1' }
+    nowRef.value = 1200
+    await router.route(
+      inbound({ thread: 't1', authorId: 'alice', externalMessageId: 'alice-t1', isBotMention: true, text: 'bot look' }),
+    )
+    await router.__testing!.flushDebounce(threadKey)
+    nowRef.value = 1500
+    await router.send(
+      { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, text: 'here is the review' },
+      { accountingTarget: threadKey },
+    )
+    sessions[0]!.prompts.length = 0
+
+    // when uncredited bob posts a plain comment on the root
+    nowRef.value = 2000
+    await router.route(
+      inbound({ authorId: 'bob', externalMessageId: 'bob-2', isBotMention: false, text: 'unrelated chatter' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+
+    // then it stays observed — the grant followed the reply target, not the room
+    expect(sessions[0]!.prompts).toHaveLength(0)
+  })
+
   test('clearSticky drops the credit so a plain follow-up is no longer auto-engaged', async () => {
     // given a 2-human group where the bot just replied in alice's turn,
     // granting alice a sticky credit (mirrors the test above)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4941,6 +4941,35 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       accountingTarget.thread === (msg.thread ?? null)
     const keyId = channelKeyId(accountingTarget)
     const live = liveSessions.get(keyId)
+    // Credit sticky where the reply was PUBLISHED, not where it was accounted.
+    // The two diverge when a caller answers from one sub-surface but publishes
+    // to another in the same room — `postDuplicateRequestChangesComment` sends
+    // with `thread: null` while passing the review-thread session as
+    // `accountingTarget`. An inbound is keyed from its OWN tuple, so the human's
+    // follow-up consumes the root key and finds nothing: the reply was observed
+    // and silently dropped.
+    //
+    // Delivery-only, not both. A dual grant cannot be undone atomically —
+    // `clearSticky` clears one key, so `channel_disengage` on the originating
+    // thread would strand the root credit. It also buys nothing here: GitHub
+    // review-comment inbounds set `suppressSticky`, so they never reach the
+    // sticky gate and engage via `replyToBotMessageId` instead.
+    //
+    // Same adapter/workspace/chat only. `targets` are authors of the ACCOUNTING
+    // turn and author ids are namespaced per adapter, so redirecting a genuine
+    // cross-channel send would credit ids that cannot appear in that room.
+    const stickyGrantKeyId =
+      !deliveryMatchesAccounting &&
+      accountingTarget.adapter === msg.adapter &&
+      accountingTarget.workspace === msg.workspace &&
+      accountingTarget.chat === msg.chat
+        ? channelKeyId({
+            adapter: msg.adapter,
+            workspace: msg.workspace,
+            chat: msg.chat,
+            thread: msg.thread ?? null,
+          })
+        : keyId
     const sendKey = consecutiveSendKey(accountingTarget.chat, accountingTarget.thread)
     // Tool-source sends consume the captured quote candidate exactly
     // once per turn — the intervening-observed check runs HERE against
@@ -5151,7 +5180,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           }
         }
         if (targets.size > 0) {
-          grantStickyForReplyTargets(stickyLedger, keyId, Array.from(targets), adapterConfig.engagement, now())
+          grantStickyForReplyTargets(
+            stickyLedger,
+            stickyGrantKeyId,
+            Array.from(targets),
+            adapterConfig.engagement,
+            now(),
+          )
         }
       }
       const turnCount = live.consecutiveSends.get(sendKey) ?? 0


### PR DESCRIPTION
## Background

A deployed agent posted a code-review comment on a pull request as a PR-level top-level comment (not inside a review thread). The PR author replied 6m44s later. The reply was ingested and passed every filter, then `decideEngagement` returned `observe` (src/channels/engagement.ts:242) — the agent never responded.

Root-cause mechanism:

`postDuplicateRequestChangesComment` (src/agent/tools/post-github-review.ts:145-163) calls `router.send` with `thread: null` — publishing a PR-level top-level comment — while passing the originating review-thread session as `accountingTarget`. In `send` (src/channels/router.ts:4931-4943), the sticky grant key was derived from the accounting target, so the credit landed on `…:pr:<n>:<threadId>` while the message was only visible on `…:pr:<n>:`. `channelKeyId` builds keys as `${adapter}:${workspace}:${chat}:${thread ?? ''}` (src/channels/types.ts:594). An inbound is keyed from its own tuple, so the author's follow-up consumed the root key, found no credit, and fell through to `observe`.

No other trigger covers this gap on GitHub:
- `issue_comment` inbounds are built with `thread: null` and never set `replyToBotMessageId`, so the `reply` trigger is structurally unreachable.
- The solo-human fallback (engagement.ts:240) is off, because GitHub membership resolves to the repo collaborator list (src/channels/adapters/github/membership.ts) rather than the actual participants in the thread.

Sticky was the only remaining path to engagement, and it was crediting the wrong surface.

## Summary

Grant sticky on the delivery key when it differs from the accounting key by thread alone, scoped to the same adapter + workspace + chat.

**Why not credit both keys.** `clearSticky` clears exactly one key (router.ts:~6596), so a paired grant could strand the root credit when the thread session later disengages. The thread half would also be inert: GitHub review-comment inbounds set `suppressSticky`, so they never reach the sticky gate at all — they engage via `replyToBotMessageId` instead.

**Cross-channel scope guard.** Cross-chat and cross-adapter sends keep crediting their accounting session, not the delivery target. `targets` are authors of the accounting turn, and author ids are namespaced per adapter, so redirecting a genuine cross-channel send would credit ids that can't appear in the destination room.

## What this does NOT do

- Does not touch formal reviews submitted via `router.submitReview` — those still grant sticky to nobody. `SubmitReviewRequest` carries no target author, and blanket-crediting every PR author on an auto-reviewing agent would be a new engagement policy, not a fix to mis-keyed credit. Left alone deliberately.
- Does not change `reply`-trigger or solo-human-fallback semantics for any other adapter.

## Review notes

4 tests added in `src/channels/router.test.ts` under `ChannelRouter sticky credits`:
- 2 fail on `main` and pass with this fix (verified by stashing the router change): the divergent-publish-wakes-the-author case, and the divergent-send-credits-only-the-delivery-key case.
- 2 are regression guards that pass both ways: cross-chat isolation, and "credits reply targets, not the whole room."

**Related.** #1389 documents the same underlying thread-keyed-`ChannelKey` design from the opposite direction — session fan-out causing duplicate publications. This PR addresses the siloing direction (a single publication crediting the wrong surface). Not a fix or conflict with #1389.

Verification: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and `bun run test` — 13227 pass / 31 skip / 0 fail.