### PR TITLE
Fix no-reply reaction cleanup

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3142,11 +3142,10 @@ describe('disengageReactionEmojiFor', () => {
   })
 })
 
-describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
+describe('ChannelRouter reaction cleanup on deliberate silence', () => {
   const REACTION_REF: ReactionRef = { adapter: 'discord-bot', value: 'msg-ref' }
 
-  // discord-bot is typing-capable, so route() adds no eager engage :eyes: — every
-  // captured reaction is the silent-ack, keeping these assertions unambiguous.
+  // discord-bot is typing-capable, so route() adds no eager engage :eyes:.
   const setupSilentTurn = async (
     dir: string,
   ): Promise<{
@@ -3166,7 +3165,7 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     return { router, sessions, captured }
   }
 
-  test('skip_response leaves an :eyes: on the triggering message', async () => {
+  test('skip_response leaves no :eyes: on the triggering message', async () => {
     const dir = await tempDir()
     const { router, sessions, captured } = await setupSilentTurn(dir)
     sessions[0]!.onPrompt = () => {
@@ -3175,11 +3174,10 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    await waitFor(() => captured.length > 0)
-    expect(captured[0]).toMatchObject({ adapter: 'discord-bot', chat: 'c1', emoji: 'eyes', reactionRef: REACTION_REF })
+    expect(captured).toHaveLength(0)
   })
 
-  test('an explicit NO_REPLY leaves an :eyes: on the triggering message', async () => {
+  test('an explicit NO_REPLY leaves no :eyes: on the triggering message', async () => {
     const dir = await tempDir()
     const { router, sessions, captured } = await setupSilentTurn(dir)
     sessions[0]!.onPrompt = () => {
@@ -3187,11 +3185,10 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    await waitFor(() => captured.length > 0)
-    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+    expect(captured).toHaveLength(0)
   })
 
-  test('(NO_REPLY) with parens leaves an :eyes:', async () => {
+  test('(NO_REPLY) with parens leaves no :eyes:', async () => {
     const dir = await tempDir()
     const { router, sessions, captured } = await setupSilentTurn(dir)
     sessions[0]!.onPrompt = () => {
@@ -3199,11 +3196,10 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    await waitFor(() => captured.length > 0)
-    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+    expect(captured).toHaveLength(0)
   })
 
-  test('a plain-text skip_response(...) leak leaves an :eyes: (deliberate silence)', async () => {
+  test('a plain-text skip_response(...) leak leaves no :eyes:', async () => {
     const dir = await tempDir()
     const { router, sessions, captured } = await setupSilentTurn(dir)
     sessions[0]!.onPrompt = () => {
@@ -3211,8 +3207,7 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    await waitFor(() => captured.length > 0)
-    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+    expect(captured).toHaveLength(0)
   })
 
   test('does not react when the silent turn carries no triggering reactionRef', async () => {
@@ -3276,13 +3271,7 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     expect(called).toBe(false)
   })
 
-  test('on a typing-less adapter, the silent-ack :eyes: is added AFTER the transient engage :eyes: is removed', async () => {
-    // given a typing-less adapter (engage :eyes: IS added on route, then removed
-    // at turn end) whose engage add resolves to a removable instance ref. Both
-    // the engage add and the silent-ack add target the SAME triggering message /
-    // emoji, so the guard is the ORDER: the final event must be the silent-ack
-    // add, never a removal. Pre-fix (fire-and-forget drop) the order raced to
-    // add,add,remove — the trailing remove would strip the ack on toggle adapters.
+  test('on a typing-less adapter, NO_REPLY removes the transient engage :eyes:', async () => {
     const dir = await tempDir()
     const engageInstanceRef: ReactionRef = { adapter: 'discord-bot', value: 'engage-instance' }
     const events: string[] = []
@@ -3303,8 +3292,8 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    await waitFor(() => events.length === 3)
-    expect(events).toEqual(['add-eyes', 'remove-eyes', 'add-eyes'])
+    await waitFor(() => events.length === 2)
+    expect(events).toEqual(['add-eyes', 'remove-eyes'])
   })
 
   test('an ambient (unaddressed) NO_REPLY leaves NO :eyes:', async () => {
@@ -3351,7 +3340,7 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     expect(called).toBe(false)
   })
 
-  test('a DM NO_REPLY still leaves an :eyes: (explicitly addressed)', async () => {
+  test('a DM NO_REPLY leaves no :eyes:', async () => {
     const dir = await tempDir()
     const { router, sessions, captured } = await (async () => {
       const { router, sessions } = makeRouter(dir)
@@ -3370,11 +3359,10 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    await waitFor(() => captured.length > 0)
-    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+    expect(captured).toHaveLength(0)
   })
 
-  test('a reply-to-bot NO_REPLY still leaves an :eyes: (explicitly addressed)', async () => {
+  test('a reply-to-bot NO_REPLY leaves no :eyes:', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
     router.setTypingCapability('discord-bot', true)
@@ -3391,8 +3379,7 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    await waitFor(() => captured.length > 0)
-    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+    expect(captured).toHaveLength(0)
   })
 
   const ADDRESSED_REF: ReactionRef = { adapter: 'discord-bot', value: 'addressed-msg' }
@@ -3425,9 +3412,7 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     expect(called).toBe(false)
   })
 
-  test('ambient then addressed coalesced: the :eyes: lands on the final addressed message', async () => {
-    // given an ambient message and a later addressed one coalescing into ONE turn.
-    // batch[last] is the addressed tail, so the ack must fire AND target its ref.
+  test('ambient then addressed coalesced: NO_REPLY leaves no :eyes:', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
     router.setTypingCapability('discord-bot', true)
@@ -3446,181 +3431,193 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    // then the ack fires on the final addressed message's ref, not the ambient one
-    await waitFor(() => captured.length > 0)
-    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: ADDRESSED_REF })
+    expect(captured).toHaveLength(0)
   })
 })
 
-describe('ChannelRouter retires the persistent silent-ack :eyes: on a later reply', () => {
-  const REF_A: ReactionRef = { adapter: 'discord-bot', value: 'msg-a' }
-  const REF_B: ReactionRef = { adapter: 'discord-bot', value: 'msg-b' }
-  const SILENT_ACK_INSTANCE: ReactionRef = { adapter: 'discord-bot', value: 'silent-ack-instance' }
-
-  // discord-bot is typing-capable, so route() adds no eager engage :eyes: — every
-  // add is the silent-ack, and the add resolves to a removable instance ref so a
-  // later reply can retire it. Removals are captured to assert cleanup.
-  const setup = (
-    dir: string,
-  ): {
-    router: ReturnType<typeof makeRouter>['router']
-    sessions: ReturnType<typeof makeRouter>['sessions']
-    added: ReactionRequest[]
-    removed: ReactionRef[]
-  } => {
+describe('ChannelRouter persistent output acknowledgements', () => {
+  test('keeps a GitHub review acknowledgement until a later channel reply', async () => {
+    const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
-    router.setTypingCapability('discord-bot', true)
+    const key: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    const triggerRef: ReactionRef = { adapter: 'github', value: 'review-request' }
+    const acknowledgementRef: ReactionRef = { adapter: 'github', value: 'review-ack' }
     const added: ReactionRequest[] = []
     const removed: ReactionRef[] = []
-    router.registerReaction('discord-bot', async (req) => {
+    router.setTypingCapability('github', true)
+    router.registerReaction('github', async (req) => {
       added.push(req)
-      return { ok: true, reactionRef: SILENT_ACK_INSTANCE }
+      return { ok: true, reactionRef: acknowledgementRef }
     })
-    router.registerRemoveReaction('discord-bot', async (req) => {
+    router.registerRemoveReaction('github', async (req) => {
       removed.push(req.reactionRef)
       return { ok: true }
     })
-    router.registerOutbound('discord-bot', async () => ({ ok: true }))
-    return { router, sessions, added, removed }
-  }
+    router.registerOutbound('github', async () => ({ ok: true }))
 
-  test('a silent turn plants an :eyes: that a later reply removes', async () => {
-    const dir = await tempDir()
-    const { router, sessions, added, removed } = setup(dir)
-
-    // given a first turn that deliberately stays silent
-    await router.route(inbound({ reactionRef: REF_A }))
-    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
-    await router.__testing!.flushDebounce(KEY)
-    await waitFor(() => added.some((r) => r.emoji === 'eyes'))
-
-    // when a later turn in the same conversation replies for real
-    sessions[0]!.onPrompt = async () => {
-      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
-      sessions[0]!.setAssistantText('here you go')
+    await router.route(inbound({ ...key, isBotMention: true, reactionRef: triggerRef }))
+    sessions[0]!.onPrompt = () => {
+      router.noteGithubReviewOutput({
+        sessionId: 'ses_fake_1',
+        workspace: 'acme/repo',
+        prNumber: 672,
+        state: 'APPROVE',
+      })
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'review already published' })
+      sessions[0]!.setAssistantText('')
     }
-    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
-    await router.__testing!.flushDebounce(KEY)
+    await router.__testing!.flushDebounce(key)
 
-    // then the stale silent-ack :eyes: is retired
-    await waitFor(() => removed.length > 0)
-    expect(removed).toContainEqual(SILENT_ACK_INSTANCE)
-  })
+    await waitFor(() => added.length === 1)
+    expect(added[0]).toMatchObject({ emoji: 'eyes', reactionRef: triggerRef })
 
-  test('a reply retires ALL outstanding silent-ack :eyes: in the conversation', async () => {
-    const dir = await tempDir()
-    const { router, sessions, added, removed } = setup(dir)
-
-    // given two separate silent turns, each planting its own :eyes:
-    await router.route(inbound({ reactionRef: REF_A }))
-    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
-    await router.__testing!.flushDebounce(KEY)
-    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 1)
-
-    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
-    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
-    await router.__testing!.flushDebounce(KEY)
-    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 2)
-
-    // when a third turn finally replies
     sessions[0]!.onPrompt = async () => {
-      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'done' })
-      sessions[0]!.setAssistantText('done')
+      await router.send({ ...key, text: 'Review complete.' })
+      sessions[0]!.setAssistantText('Review complete.')
     }
-    await router.route(inbound({ externalMessageId: 'm3', reactionRef: REF_A }))
-    await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ ...key, externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(key)
 
-    // then both silent-ack markers are removed, not just the latest
-    await waitFor(() => removed.length === 2)
-    expect(removed).toEqual([SILENT_ACK_INSTANCE, SILENT_ACK_INSTANCE])
+    await waitFor(() => removed.length === 1)
+    expect(removed).toEqual([acknowledgementRef])
   })
 
-  test('a later silent turn does NOT remove the earlier silent-ack :eyes:', async () => {
-    const dir = await tempDir()
-    const { router, sessions, added, removed } = setup(dir)
-
-    await router.route(inbound({ reactionRef: REF_A }))
-    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
-    await router.__testing!.flushDebounce(KEY)
-    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 1)
-
-    // when a second turn is ALSO silent
-    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
-    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
-    await router.__testing!.flushDebounce(KEY)
-    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 2)
-
-    // then nothing is removed — silence never contradicts a prior "seen" ack
-    expect(removed).toHaveLength(0)
-  })
-
-  test('a Korean silent turn then a reply retires the :eyes: (language-agnostic)', async () => {
-    const dir = await tempDir()
-    const { router, sessions, added, removed } = setup(dir)
-
-    // given a Korean inbound the agent silently acks
-    await router.route(inbound({ text: '확인만 해주세요', reactionRef: REF_A }))
-    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
-    await router.__testing!.flushDebounce(KEY)
-    await waitFor(() => added.some((r) => r.emoji === 'eyes'))
-
-    // when a later Korean turn replies
-    sessions[0]!.onPrompt = async () => {
-      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '네, 처리했어요' })
-      sessions[0]!.setAssistantText('네, 처리했어요')
-    }
-    await router.route(inbound({ externalMessageId: 'm2', text: '고마워요', reactionRef: REF_B }))
-    await router.__testing!.flushDebounce(KEY)
-
-    // then the marker is retired regardless of message language
-    await waitFor(() => removed.length > 0)
-    expect(removed).toContainEqual(SILENT_ACK_INSTANCE)
-  })
-
-  test('a reply removes the :eyes: even when the silent-ack add resolves AFTER cleanup starts', async () => {
-    // Regression for the race: reactOnSilentAck stores the add PROMISE (not its
-    // resolved ref), so a reply that runs cleanup before a slow add resolves
-    // still awaits it and removes the mark. Here the add is held open until the
-    // reply turn has already drained, forcing cleanup to see an unresolved entry.
+  test('adds a persistent acknowledgement after removing a typing-less engage reaction', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
-    router.setTypingCapability('discord-bot', true)
+    const key: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    const triggerRef: ReactionRef = { adapter: 'github', value: 'review-request' }
+    const acknowledgementRef: ReactionRef = { adapter: 'github', value: 'review-ack' }
+    const events: string[] = []
+    router.registerReaction('github', async (req) => {
+      events.push(`add-${req.emoji}`)
+      return { ok: true, reactionRef: acknowledgementRef }
+    })
+    router.registerRemoveReaction('github', async () => {
+      events.push('remove-eyes')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ ...key, isBotMention: true, reactionRef: triggerRef }))
+    sessions[0]!.onPrompt = () => {
+      router.noteGithubReviewOutput({
+        sessionId: 'ses_fake_1',
+        workspace: 'acme/repo',
+        prNumber: 672,
+        state: 'APPROVE',
+      })
+      sessions[0]!.setAssistantText('')
+    }
+    await router.__testing!.flushDebounce(key)
+
+    await waitFor(() => events.length === 3)
+    expect(events).toEqual(['add-eyes', 'remove-eyes', 'add-eyes'])
+  })
+
+  test('removes a slow persistent acknowledgement when a later reply races its add', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const key: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    const acknowledgementRef: ReactionRef = { adapter: 'github', value: 'review-ack' }
     const removed: ReactionRef[] = []
-    let releaseSilentAckAdd: (() => void) | null = null
-    const silentAckAddGate = new Promise<void>((resolve) => {
-      releaseSilentAckAdd = resolve
+    let releaseAdd: (() => void) | null = null
+    const addGate = new Promise<void>((resolve) => {
+      releaseAdd = resolve
     })
     let addCount = 0
-    router.registerReaction('discord-bot', async () => {
+    router.setTypingCapability('github', true)
+    router.registerReaction('github', async () => {
       addCount++
-      await silentAckAddGate
-      return { ok: true, reactionRef: SILENT_ACK_INSTANCE }
+      await addGate
+      return { ok: true, reactionRef: acknowledgementRef }
     })
-    router.registerRemoveReaction('discord-bot', async (req) => {
+    router.registerRemoveReaction('github', async (req) => {
       removed.push(req.reactionRef)
       return { ok: true }
     })
-    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    router.registerOutbound('github', async () => ({ ok: true }))
 
-    // given a silent turn whose :eyes: add is still in flight (gated)
-    await router.route(inbound({ reactionRef: REF_A }))
-    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
-    await router.__testing!.flushDebounce(KEY)
+    await router.route(
+      inbound({ ...key, isBotMention: true, reactionRef: { adapter: 'github', value: 'review-request' } }),
+    )
+    sessions[0]!.onPrompt = () => {
+      router.noteGithubReviewOutput({
+        sessionId: 'ses_fake_1',
+        workspace: 'acme/repo',
+        prNumber: 672,
+        state: 'APPROVE',
+      })
+      sessions[0]!.setAssistantText('')
+    }
+    await router.__testing!.flushDebounce(key)
     await waitFor(() => addCount === 1)
 
-    // when a later turn replies while the add is STILL unresolved
     sessions[0]!.onPrompt = async () => {
-      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'done' })
-      sessions[0]!.setAssistantText('done')
+      await router.send({ ...key, text: 'Review complete.' })
+      sessions[0]!.setAssistantText('Review complete.')
     }
-    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
-    await router.__testing!.flushDebounce(KEY)
-    // let the gated add resolve only now — after cleanup has already begun
-    releaseSilentAckAdd!()
+    await router.route(inbound({ ...key, externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(key)
+    releaseAdd!()
 
-    // then cleanup still awaits the add and retires the mark (no strand)
-    await waitFor(() => removed.length > 0)
-    expect(removed).toContainEqual(SILENT_ACK_INSTANCE)
+    await waitFor(() => removed.length === 1)
+    expect(removed).toEqual([acknowledgementRef])
+  })
+
+  test('a later reply removes all outstanding persistent acknowledgements', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const key: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    const acknowledgementRefs: ReactionRef[] = [
+      { adapter: 'github', value: 'review-ack-1' },
+      { adapter: 'github', value: 'review-ack-2' },
+    ]
+    const removed: ReactionRef[] = []
+    let addCount = 0
+    router.setTypingCapability('github', true)
+    router.registerReaction('github', async () => {
+      const reactionRef = acknowledgementRefs[addCount]
+      if (!reactionRef) throw new Error('unexpected persistent acknowledgement')
+      addCount++
+      return { ok: true, reactionRef }
+    })
+    router.registerRemoveReaction('github', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+    router.registerOutbound('github', async () => ({ ok: true }))
+
+    for (let index = 0; index < 2; index++) {
+      await router.route(
+        inbound({
+          ...key,
+          externalMessageId: `m${index + 1}`,
+          isBotMention: true,
+          reactionRef: { adapter: 'github', value: `review-request-${index + 1}` },
+        }),
+      )
+      sessions[0]!.onPrompt = () => {
+        router.noteGithubReviewOutput({
+          sessionId: 'ses_fake_1',
+          workspace: 'acme/repo',
+          prNumber: 672,
+          state: 'APPROVE',
+        })
+        sessions[0]!.setAssistantText('')
+      }
+      await router.__testing!.flushDebounce(key)
+      await waitFor(() => addCount === index + 1)
+    }
+
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ ...key, text: 'Review complete.' })
+      sessions[0]!.setAssistantText('Review complete.')
+    }
+    await router.route(inbound({ ...key, externalMessageId: 'm3' }))
+    await router.__testing!.flushDebounce(key)
+
+    await waitFor(() => removed.length === 2)
+    expect(removed).toEqual(acknowledgementRefs)
   })
 })
 
@@ -3661,8 +3658,7 @@ describe('ChannelRouter model react only when replying', () => {
 
   test('drops a queued channel_react reaction when the turn stays silent', async () => {
     // given a typing-capable adapter (no eager engage :eyes:) whose model queues
-    // a reaction but sends no reply. The queued reaction uses a DISTINCT emoji so
-    // it is separable from the silent-ack :eyes: a NO_REPLY turn now leaves.
+    // a reaction but sends no reply.
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
     router.setTypingCapability('discord-bot', true)
@@ -17712,15 +17708,25 @@ describe('ChannelRouter background-child await suppression', () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
+    const reactions: ReactionRequest[] = []
     const { router, sessions } = makeRouter(dir, { logs, newestRunningChildSubagentStartedAt: runningChild })
+    router.setTypingCapability('discord-bot', true)
+    router.registerReaction('discord-bot', async (req) => {
+      reactions.push(req)
+      return { ok: true }
+    })
     router.registerOutbound('discord-bot', async (msg) => {
       sent.push(msg.text ?? '')
       return { ok: true }
     })
 
     // given: the model does tool work (spawning a background child), then ends the turn empty
-    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘' }))
-    sessions[0]!.onPrompt = () => strandOnUnansweredToolUse(sessions[0]!, 'background-child')
+    const reactionRef: ReactionRef = { adapter: 'discord-bot', value: 'review-request' }
+    await router.route(inbound({ isBotMention: true, text: 'PR 좀 리뷰해줘', reactionRef }))
+    sessions[0]!.onPrompt = () => {
+      strandOnUnansweredToolUse(sessions[0]!, 'background-child')
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'waiting for background child' })
+    }
     await router.__testing!.flushDebounce(KEY)
 
     // then: the recovery ladder does not manufacture a status message
@@ -17729,6 +17735,8 @@ describe('ChannelRouter background-child await suppression', () => {
     expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
     expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
     expect(logs.some((m) => m.includes('empty_turn_suppressed cause=awaiting_background_child'))).toBe(true)
+    await waitFor(() => reactions.length === 1)
+    expect(reactions[0]).toMatchObject({ emoji: 'eyes', reactionRef })
   })
 
   test('a more_work_this_turn ack is not re-nudged into a second status post while the child runs', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -230,12 +230,7 @@ export function disengageReactionEmojiFor(adapter: AdapterId): string {
   return DISENGAGE_REACTION_EMOJI_OVERRIDES[adapter] ?? DISENGAGE_REACTION_EMOJI
 }
 
-type SilentAckReason =
-  | 'skip_response'
-  | 'no_reply'
-  | 'skip_response_text_leak'
-  | 'github_review_output'
-  | 'awaiting_background_child'
+type SilentAckReason = 'github_review_output' | 'awaiting_background_child'
 
 // Wake nudge pushed into a resumed channel session at boot so drain() has a
 // non-empty batch and fires a turn. The substantive instruction the model acts
@@ -929,14 +924,13 @@ type LiveSession = {
   // `currentTurnReactionRef` points at — last item of the drained batch) was
   // EXPLICITLY addressed to the bot: a DM, an @-mention/alias (`isBotMention`
   // folds plain-name matching in at the adapter classify layer), or a reply to
-  // the bot's own message. Gates the PERSISTENT silent-ack :eyes: (see
-  // `armSilentTurnAck`): a deliberate silence on a message aimed AT us earns a
-  // courteous "seen, nothing to add" 👀, but staying quiet during ambient
-  // human-to-human chatter (sticky observation, solo-human fallback) must leave
-  // NO mark — otherwise a busy room accumulates stale 👀 on messages the bot
-  // was never part of. Computed from the SAME message the reaction targets so
-  // eligibility and target can never disagree. Reset with `currentTurnReactionRef`
-  // in the drain finally; preserved across reminder-only iterations exactly like it.
+  // the bot's own message. Gates the PERSISTENT :eyes: for deferred background
+  // work (see `armSilentTurnAck`): an addressed request may retain a progress
+  // marker while a child runs, but ambient human-to-human chatter must leave no
+  // mark. Explicit NO_REPLY and skip_response turns never use this flag to add a
+  // reaction. Computed from the SAME message the reaction targets so eligibility
+  // and target cannot disagree. Reset with `currentTurnReactionRef` in the drain
+  // finally; preserved across reminder-only iterations exactly like it.
   currentTurnExplicitlyAddressed: boolean
   // Typing-status anchor of the inbound that triggered THIS turn (last item in
   // the drained batch, mirroring `currentTurnReactionRef`). Adapter-opaque ts
@@ -962,16 +956,12 @@ type LiveSession = {
   // discarded on silence (skip_response / empty / errored turns) so the bot never
   // leaves a reaction on a message it merely looked at (e.g. cron lookaround).
   pendingTurnReactions: ReactionRequest[]
-  // Armed by `validateChannelTurn` on a DELIBERATE silent turn (skip_response or
-  // an explicit NO_REPLY), stamped with `turnSeq` so a stale flag from a crashed
-  // turn cannot leak into the next one. Read in drain's per-turn finally — AFTER
-  // the transient engage :eyes: is dropped — to leave a PERSISTENT :eyes: on the
-  // triggering message: "I saw this and intentionally chose not to reply." Null
-  // on every non-deliberate outcome (a real reply, a model malfunction, a
-  // plumbing leak, a retry, a synthetic turn). Firing after the engage-drop is
-  // load-bearing: adapters that collapse a same-actor same-emoji reaction into
-  // one toggle would otherwise have the engage-drop remove the only visible
-  // :eyes:. See `reactOnSilentAck`.
+  // Armed when output landed outside the channel (a GitHub review) or was
+  // deliberately deferred to a background child. Explicit NO_REPLY and
+  // skip_response turns do not arm it: opting out must leave no reaction behind.
+  // Stamped with `turnSeq` so a stale flag from a crashed turn cannot leak into
+  // the next one. Fired after the transient engage :eyes: is dropped because
+  // adapters may collapse a same-actor same-emoji reaction into one toggle.
   silentAckTurn: { turnSeq: number; reason: SilentAckReason } | null
   // One silent-ack-:eyes:-add promise per PERSISTENT ack `reactOnSilentAck` has
   // planted on a trigger message, each resolving to its removable ref (or null).
@@ -980,16 +970,15 @@ type LiveSession = {
   // sees every in-flight add and awaits it before removing — storing only the
   // resolved ref raced (cleanup could snapshot an empty array, then a slow add
   // append its ref afterward, stranding the :eyes:). Cross-turn state on purpose:
-  // a silent turn means "seen, not replying FOR NOW", and once the same sticky
-  // conversation gets a genuine reply those marks read as stale/contradictory —
-  // so they are retired on the next replied turn (see dropSilentAckReactions).
+  // the mark means output is external or deferred, and once the same sticky
+  // conversation gets a genuine reply it reads as stale — so it is retired on
+  // the next replied turn (see dropSilentAckReactions).
   // Conversation-scoped, NOT per-trigger-message: coalescing means the silent
   // turn's trigger (message N) and the eventual reply's trigger (message N+1)
   // routinely differ, so exact-message scoping would strand the mark. NOT reset
   // in drain's outer per-turn finally. On teardown the entries are dropped
-  // WITHOUT removing the reactions: a session that ends without ever replying
-  // legitimately keeps its "seen, not replying" ack, unlike the transient
-  // engage :eyes: which teardown must strip.
+  // WITHOUT removing the reactions, unlike the transient engage :eyes: which
+  // teardown must strip.
   activeSilentAckReactions: Array<Promise<ReactionRef | null>>
   // One add promise per willingness status posted by the agent, resolving to
   // the removable reaction-instance ref. Cross-turn state on purpose: the
@@ -3749,15 +3738,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // (observe-after-engage). Leaving it only on the reply path stranded the
           // ack permanently on messages the agent looked at but never answered.
           const dropDone = dropEngageReactions(live, engageAddPromises)
-          // A DELIBERATE silent turn (skip_response / NO_REPLY) leaves a
-          // PERSISTENT :eyes: acking "seen, intentionally not replying". On a
-          // typing-less adapter it reuses the same message/emoji/actor as the
-          // transient engage :eyes:, and adapters that collapse that into one
-          // toggle would let a still-in-flight engage removal strip the ack — so
-          // the silent path AWAITS every engage removal reaching the adapter
-          // before adding the persistent one. Only silent turns pay that wait:
-          // normal/reply turns keep the engage drop fire-and-forget (`void`), so
-          // turn-end never blocks on the reaction API off the silent path.
+          // A turn whose output landed outside the channel or was deferred to a
+          // background child leaves a persistent :eyes:. On a typing-less adapter
+          // it reuses the transient engage reaction's message/emoji/actor, so wait
+          // for that removal to reach the adapter before adding the persistent one.
           if (live.silentAckTurn?.turnSeq === live.turnSeq) await dropDone
           else void dropDone
           reactOnSilentAck(live)
@@ -5232,6 +5216,45 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.pendingSystemReminders.push(retryReminder(WILLINGNESS_NUDGE))
   }
 
+  const armRetainedOutputAckIfEligible = (
+    live: LiveSession,
+    successfulSendsBeforePrompt: number,
+    explicitlySkipped: boolean,
+  ): boolean => {
+    // A formal GitHub review is user-facing output delivered outside the channel.
+    // Preserve its acknowledgement even when the model closes the turn through
+    // skip_response after publishing the review.
+    if (
+      live.githubReviewOutputTurn === live.turnSeq &&
+      live.successfulChannelSends === successfulSendsBeforePrompt &&
+      live.currentTurnAuthorId !== null
+    ) {
+      logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=github_review_output_this_turn`)
+      armSilentTurnAck(live, 'github_review_output')
+      return true
+    }
+
+    // An active child means delivery is deferred rather than dropped. Normally a
+    // completed prose leaf still goes through reply recovery, but skip_response is
+    // authoritative: its prose is intentionally discarded, while the progress
+    // acknowledgement must remain until the child reports back.
+    const awaitLeaf = recoverableAssistantText(live.session)
+    const awaitLeafIsUnfinishedToolUse = awaitLeaf?.source === 'mid-turn' || awaitLeaf?.source === 'pre-tool'
+    if (
+      live.currentTurnAuthorId !== null &&
+      (explicitlySkipped ||
+        awaitLeaf === null ||
+        awaitLeafIsUnfinishedToolUse ||
+        endsWithNoReplySignal(awaitLeaf.text)) &&
+      isAwaitingBackgroundChild(live, 'empty_turn_recovery')
+    ) {
+      logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=awaiting_background_child`)
+      armSilentTurnAck(live, 'awaiting_background_child')
+      return true
+    }
+    return false
+  }
+
   const validateChannelTurn = async (live: LiveSession, successfulSendsBeforePrompt: number): Promise<void> => {
     // `skip_response` short-circuit. Honoring it bypasses recovery entirely.
     // Stale-flag protection: only honor when stamped on the just-completed
@@ -5249,8 +5272,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq && !skipContested) {
       const { reason } = live.skippedTurn
       live.skippedTurn = null
+      armRetainedOutputAckIfEligible(live, successfulSendsBeforePrompt, true)
       logger.info(`[channels] ${live.keyId} skipped_by_tool reason=${JSON.stringify(reason)}`)
-      armSilentTurnAck(live, 'skip_response')
       void dropContinuationReactions(live)
       return
     }
@@ -5264,52 +5287,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.stagedFallbackCause = { cause, sendCountAtStage: live.successfulChannelSends }
     }
 
-    // A formal GitHub review already landed this logical turn (APPROVE /
-    // REQUEST_CHANGES / COMMENT, stamped via noteGithubReviewOutput). That review IS
-    // the turn's user-facing output — it just went through the GitHub review API, not
-    // channel_reply/channel_send, so `successfulChannelSends` never moved. An empty
-    // completion afterward is the agent legitimately having nothing more to say, NOT
-    // a dead turn: skip the empty-turn retries AND the "I got stuck" fallback and
-    // treat it as silent completion. Gated on no channel send this turn so a turn
-    // that ALSO replied in-channel still runs the normal reply-recovery below.
-    if (
-      live.githubReviewOutputTurn === live.turnSeq &&
-      live.successfulChannelSends === successfulSendsBeforePrompt &&
-      live.currentTurnAuthorId !== null
-    ) {
-      logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=github_review_output_this_turn`)
-      armSilentTurnAck(live, 'github_review_output')
-      return
-    }
-
-    // A background child spawned by this session is still running, and the turn
-    // produced no user-facing output. That is `spawn_subagent`'s contract being
-    // honored ("you will receive a system-reminder when it completes"), not the
-    // empty-completion degeneration every branch below exists to repair — so the
-    // recovery ladder must not manufacture the status prose the model
-    // deliberately withheld. Each nudge re-enters with the child STILL running,
-    // so the budgets stack (MAX_EMPTY_TURN_RETRIES + MAX_WILLINGNESS_NUDGES) into
-    // several "still working…" messages for one request; on GitHub, where a
-    // channel reply IS a public PR comment, that shipped as duplicate review
-    // acknowledgements. The completion reminder re-wakes this session with the
-    // real result, so silence here is delivery deferred, not delivery dropped.
-    // Bounded by the same stuck-child backstop as GC/rollover: a wedged child
-    // stops pinning and the normal ladder resumes. A completed `stop` leaf
-    // carrying real text is deliberately NOT covered — recovering an answer the
-    // model already wrote is still correct while a child runs. Unfinished
-    // toolUse narration is covered because it is no longer publishable as an
-    // answer on any path.
     const awaitLeaf = recoverableAssistantText(live.session)
-    const awaitLeafIsUnfinishedToolUse = awaitLeaf?.source === 'mid-turn' || awaitLeaf?.source === 'pre-tool'
-    if (
-      live.currentTurnAuthorId !== null &&
-      (awaitLeaf === null || awaitLeafIsUnfinishedToolUse || endsWithNoReplySignal(awaitLeaf.text)) &&
-      isAwaitingBackgroundChild(live, 'empty_turn_recovery')
-    ) {
-      logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=awaiting_background_child`)
-      armSilentTurnAck(live, 'awaiting_background_child')
-      return
-    }
+    if (armRetainedOutputAckIfEligible(live, successfulSendsBeforePrompt, false)) return
 
     // Suppress a leaked tool call (never post the plumbing) and, while budget
     // remains, push a self-correction reminder so the same logical turn
@@ -5691,7 +5670,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
       const leakedReasoning = !isNoReplySignal(assistantText)
       logger.info(`[channels] ${live.keyId} no_reply${leakedReasoning ? ' (with_leaked_reasoning)' : ''}`)
-      armSilentTurnAck(live, 'no_reply')
       void dropContinuationReactions(live)
       return
     }
@@ -5737,7 +5715,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger.warn(
         `[channels] ${live.keyId}: suppressed plain_text_tool_call_leak (silent) text_len=${assistantText.length}`,
       )
-      armSilentTurnAck(live, 'skip_response_text_leak')
       return
     }
     if (plainTextToolCallKind === 'suppress-warn') {
@@ -6687,11 +6664,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const armSilentTurnAck = (live: LiveSession, reason: SilentAckReason): void => {
-    // A GitHub review IS its own emoji-shaped output, so it always earns the
-    // 👀; every other deliberate silence earns one ONLY when the triggering
-    // message was addressed to the bot. Staying quiet in ambient chatter leaves
-    // no mark, so a busy room never accumulates stale 👀 on messages the bot
-    // was never part of.
+    // A GitHub review is user-facing output, so it always earns the 👀; deferred
+    // background work earns one only when the triggering message addressed the
+    // bot. Ambient chatter stays unmarked.
     const eligible =
       reason === 'github_review_output' ? live.key.adapter === 'github' : live.currentTurnExplicitlyAddressed
     if (!eligible) return
@@ -6731,8 +6706,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   // Retire every persistent silent-ack :eyes: outstanding in this live session
-  // once the agent posts a genuine reply — the "seen, not replying" mark is now
-  // contradicted. Snapshot-and-clear the promise array BEFORE awaiting, so a
+  // once the agent posts a genuine reply. Snapshot-and-clear the promise array
+  // BEFORE awaiting, so a
   // concurrent later silent turn appending a fresh add is never swept by this
   // in-flight cleanup. Each entry is AWAITED to its resolved ref before removal,
   // so an add still in flight when the reply lands is still retired. Failures are


### PR DESCRIPTION
## Background

A production incident showed a successful `skip_response` leaving a persistent :eyes: reaction on the triggering message — a "seen, intentionally not replying" marker on a turn that, from the operator's perspective, had nothing to acknowledge. The reaction only clears when the same conversation later gets a genuine reply, so on a conversation that never replies again, the mark is permanent.

The marker was armed by `armSilentTurnAck` on three "deliberate silence" reasons: `skip_response`, an explicit `NO_REPLY` (and its leaked-reasoning variant), and a leaked `skip_response(...)` plain-text tool call. All three are turns where the agent chose not to respond — they are not turns that produced output somewhere else. Reusing the same persistent-ack mechanism for "chose silence" and "output landed elsewhere" conflated two different situations under one reaction.

## Summary

`skip_response`, both `NO_REPLY` variants, and a leaked `skip_response(...)` text call no longer arm the persistent :eyes:. Their three `armSilentTurnAck(...)` call sites are removed; each path still logs its reason and drops continuation reactions exactly as before, it just no longer plants a mark.

`SilentAckReason` is narrowed from five values to two: `github_review_output` and `awaiting_background_child`. Those are the only remaining callers of `armSilentTurnAck`, and both are cases where the turn genuinely produced output — a GitHub review, or work handed to a background child — so a persistent "I did something, watch this thread" marker is still the right signal. The eligibility comment and the removal/cleanup comments on `LiveSession` are updated to describe "output landed elsewhere" rather than "deliberate silence" as the thing being acknowledged.

The ordering guard is unchanged: on a typing-less adapter that collapses same-actor same-emoji reactions into one toggle, the transient engage :eyes: removal is still awaited before the persistent add, so a still-in-flight engage-drop can never strip the ack.

## What this does NOT do

- Does not change the GitHub-review or background-child acknowledgement behavior — both still arm and clear the persistent :eyes: exactly as before.
- Does not change the transient engage :eyes: (added on route, dropped at turn end) for any turn kind.
- Does not touch `dropSilentAckReactions` semantics — a genuine reply still retires every outstanding persistent ack in the conversation, now scoped to just the two remaining reasons.

## Review notes

- `armSilentTurnAck`'s eligibility check is unchanged in shape (`github_review_output` always qualifies on the `github` adapter; `awaiting_background_child` requires the triggering message to have explicitly addressed the bot) — only the set of callers shrank.
- Regression coverage: typing-capable and typing-less adapters, the slow-add-races-a-later-reply case, multi-ack cleanup on a single reply, GitHub review output, and the background-child await path all have updated or new assertions in `src/channels/router.test.ts`.

## Verification

- `bun run lint` — 0 errors (pre-existing warnings only)
- `bun run format:check` — clean
- `bun run typecheck` — clean
- `bun run test` — 13,276 pass / 31 skip / 0 fail
