### PR TITLE
Settle in-flight drains in flushDebounce

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -16815,6 +16815,41 @@ describe('resumeRestartHandoff', () => {
     expect(prompts.some((p) => p.includes('researcher') && p.includes('lost when the container'))).toBe(true)
   })
 
+  test('flushDebounce settles a drain already in flight, not merely one it starts', async () => {
+    // given: the same coalesced-restart shape as above, but the fire-and-forget
+    //   drain's FIRST turn parks on a macrotask. The racing inbound is queued
+    //   behind it, so its prompt can only land on a later iteration of that same
+    //   drain — which flushDebounce's own `drain()` call cannot reach, because
+    //   drain() no-ops while `live.draining` is set. The park makes that window
+    //   deterministic instead of contention-dependent: it is the oversubscribed-
+    //   CI flake reproduced on purpose.
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const { router, sessions } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+      onSessionCreated: (fake) => {
+        fake.onPrompt = async () => {
+          if (fake.prompts.length > 1) return
+          await new Promise<void>((resolve) => setTimeout(resolve, 25))
+        }
+      },
+    })
+    const reservation = router.reserveRestartHandoff(channelHandoff({ interruptedSubagents: ['researcher'] }))!
+    const inboundDone = router.route(inbound({ authorId: 'alice', authorName: 'alice', text: 'hi there' }))
+    await waitFor(() => reservation.sawInbound)
+
+    // when
+    await reservation.resume()
+    await inboundDone
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: both turns the in-flight drain owed had landed before the flush
+    // returned — no polling, because the seam settles rather than merely starts
+    const prompts = sessions[0]!.prompts
+    expect(prompts.some((p) => p.includes('researcher') && p.includes('lost when the container'))).toBe(true)
+    expect(prompts.some((p) => p.includes('hi there'))).toBe(true)
+  })
+
   test('delivers the notice even when the racing inbound is observe-only (never engages)', async () => {
     // given: a handoff with interrupted names and a racing inbound that will NOT
     //   engage (not a mention, not a reply, mentions no one). sawInbound flips

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1152,10 +1152,14 @@ describe('ChannelRouter session lifecycle', () => {
     // Release the held prompt: the stale session tears down (finishing only the
     // in-flight prompt), and a fresh successor is created that processes the
     // post-reload message exactly once.
+    // Asserted synchronously off the flush promise, with no polling: the
+    // successor is created inside the predecessor's own drain tail, so
+    // flushDebounce must follow the handoff to the replacement session and
+    // settle ITS drain too before returning.
     releaseFirstPrompt()
     await drainPromise
-    await waitFor(() => sessions.length === 2)
-    await waitFor(() => sessions[1]!.prompts.length > 0)
+    expect(sessions).toHaveLength(2)
+    expect(sessions[1]!.prompts.length).toBeGreaterThan(0)
     expect(sessions[0]!.prompts.length).toBe(1)
     expect(sessions[1]!.prompts.some((p) => p.includes('after reload'))).toBe(true)
     expect(router.liveCount()).toBe(1)
@@ -13327,6 +13331,53 @@ describe('ChannelRouter role-claim bypass', () => {
 })
 
 describe('ChannelRouter injectSubagentCompletionReminder', () => {
+  test('a rejected fire-and-forget drain is reported, and does not wedge or reject the settle seam', async () => {
+    // given: a live session, plus a permission service that can be armed to
+    //   throw from the per-turn role resolution `drain()` performs OUTSIDE the
+    //   prompt-level catch — so the whole drain rejects rather than being
+    //   absorbed as a prompt error
+    const dir = await tempDir()
+    const logs: string[] = []
+    let failRoleDescribe = false
+    const permissions: PermissionService = {
+      ...grantAllPermissions,
+      describe: () => {
+        if (failRoleDescribe) throw new Error('role describe boom')
+        return { role: 'owner', permissions: ['channel.respond'] }
+      },
+    }
+    const { router, sessions } = makeRouter(dir, { logs, permissions })
+    await router.route(inbound())
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: a completion wake starts a fire-and-forget `void drain(live)` that
+    // rejects. Nothing awaits that promise, so this is the only path on which
+    // the failure can still be seen.
+    failRoleDescribe = true
+    expect(
+      router.injectSubagentCompletionReminder({
+        parentSessionId: 'ses_fake_1',
+        subagent: 'explorer',
+        taskId: 'bg_drain_boom',
+        ok: true,
+        durationMs: 100,
+      }).kind,
+    ).toBe('delivered')
+
+    // then: the failure is reported rather than swallowed by the tracking, and
+    // settling resolves — one failed drain must not reject an unrelated waiter
+    await expect(router.__testing!.flushDebounce(KEY)).resolves.toBeUndefined()
+    expect(
+      logs.some((l) => l.startsWith('error:') && l.includes('drain failed') && l.includes('role describe boom')),
+    ).toBe(true)
+
+    // and: the settled entry did not leak into the tracking set, so a later
+    // flush still returns instead of waiting forever on a dead promise
+    failRoleDescribe = false
+    await expect(router.__testing!.flushDebounce(KEY)).resolves.toBeUndefined()
+  })
+
   test('matching parentSessionId wakes the channel session with a <system-reminder> turn even when no user inbound is queued', async () => {
     // given a live channel session whose sessionId is the factory-stamped `ses_fake_1`
     const dir = await tempDir()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3852,12 +3852,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const drain = (live: LiveSession): Promise<void> => {
     if (live.draining || live.destroyed) return Promise.resolve()
     const running = runDrain(live)
-    // Rejection is swallowed on the tracked copy only: settlement waiters must
-    // not re-surface a failure the starting caller already owns. `running` is
-    // what callers get back, so their rejection semantics are unchanged.
+    // Attaching this handler marks `running` handled, so a drain-tail throw can
+    // no longer reach the runtime's unhandled-rejection reporter — every
+    // production call site is `void drain(live)` and catches nothing. Log it
+    // here so the failure stays visible rather than disappearing into the
+    // tracking. The settlement copy must still RESOLVE: `settleDrains` waits on
+    // unrelated turns too, and one failed drain must not reject a waiter that
+    // has nothing to do with it. Callers keep `running`, so an awaiting caller
+    // still sees the original rejection.
     const settled = running.then(
       () => undefined,
-      () => undefined,
+      (err: unknown) => {
+        logger.error(`[channels] ${live.keyId}: drain failed: ${describeError(err)}`)
+      },
     )
     live.activeDrains.add(settled)
     void settled.then(() => live.activeDrains.delete(settled))
@@ -6912,7 +6919,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       githubReviewRoundFor: (key: ChannelKey) => liveSessions.get(channelKeyId(key))?.githubReviewRound,
       pendingReminderCount: (key: ChannelKey) => liveSessions.get(channelKeyId(key))?.pendingSystemReminders.length,
       flushDebounce: async (key: ChannelKey) => {
-        const live = liveSessions.get(channelKeyId(key))
+        const keyId = channelKeyId(key)
+        let live = liveSessions.get(keyId)
         if (!live) return
         if (live.debounceTimer) {
           clearTimeout(live.debounceTimer)
@@ -6926,9 +6934,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // would still be mid-turn when this returned, and the caller would assert
         // on a prompt that has not landed. Same defect shape as the `persist()`
         // race below: this seam has to mean "settled", not "started".
-        await settleDrains(live)
-        await drain(live)
-        await settleDrains(live)
+        //
+        // Re-resolved by key each round because settling is not a property of one
+        // object: a deferred reload teardown drops this session mid-drain and
+        // `handOffToSuccessor` replays the carried work onto a REPLACEMENT live
+        // session with its own `activeDrains`. Watching only the session captured
+        // at entry would return with the successor's prompt still in flight.
+        for (;;) {
+          await settleDrains(live)
+          await drain(live)
+          await settleDrains(live)
+          const current = liveSessions.get(keyId)
+          if (current === undefined || current === live) break
+          live = current
+        }
         // Settle the fire-and-forget `void persist()` from scheduleDebouncedDrain
         // (the lastInboundAt write). Draining alone doesn't await that promise, so
         // a test reading sessions.json right after would race the disk write — the

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -888,6 +888,12 @@ type LiveSession = {
   historyTimedAttachments: readonly TimedAttachment[]
   historyAttachments: InboundAttachment[]
   draining: boolean
+  // Every drain invocation still running, including the tail it executes after
+  // `draining` flips back to false. `drain()` deliberately no-ops while a drain
+  // owns the session, so a fire-and-forget `void drain(live)` is otherwise
+  // unobservable; this is the only handle a caller can await to know the turn
+  // actually landed. Entries remove themselves on settle.
+  activeDrains: Set<Promise<void>>
   debounceTimer: ReturnType<typeof setTimeout> | null
   typingTimer: ReturnType<typeof setInterval> | null
   typingStartedAt: number
@@ -2448,6 +2454,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         historyTimedAttachments: [],
         historyAttachments: [],
         draining: false,
+        activeDrains: new Set(),
         debounceTimer: null,
         typingTimer: null,
         typingStartedAt: 0,
@@ -3464,8 +3471,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.qualifyingWorkThisLogicalTurn = false
   }
 
-  const drain = async (live: LiveSession): Promise<void> => {
-    if (live.draining || live.destroyed) return
+  const runDrain = async (live: LiveSession): Promise<void> => {
     live.draining = true
     try {
       // `!live.pendingTeardown`: once a reload marks this draining session for
@@ -3836,6 +3842,34 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       liveSessions.delete(live.keyId)
       await tearDownLive(live)
       await handOffToSuccessor(live.key, carriedInbounds, carriedObserved, carriedReminders)
+    }
+  }
+
+  // No-op while a drain already owns the session: that loop re-checks both
+  // queues every iteration, so work landing behind it is picked up without a
+  // second concurrent drain. Registers the running invocation on `activeDrains`
+  // so `settleDrains` can await a turn started fire-and-forget.
+  const drain = (live: LiveSession): Promise<void> => {
+    if (live.draining || live.destroyed) return Promise.resolve()
+    const running = runDrain(live)
+    // Rejection is swallowed on the tracked copy only: settlement waiters must
+    // not re-surface a failure the starting caller already owns. `running` is
+    // what callers get back, so their rejection semantics are unchanged.
+    const settled = running.then(
+      () => undefined,
+      () => undefined,
+    )
+    live.activeDrains.add(settled)
+    void settled.then(() => live.activeDrains.delete(settled))
+    return running
+  }
+
+  // Resolves once no drain is running. Loops because a drain's post-`draining`
+  // tail can start a rival, and because work queued during one turn opens the
+  // next; a snapshot `Promise.all` would return with that successor in flight.
+  const settleDrains = async (live: LiveSession): Promise<void> => {
+    while (live.activeDrains.size > 0) {
+      await Promise.all(live.activeDrains)
     }
   }
 
@@ -6885,7 +6919,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.debounceTimer = null
         }
         live.firstUnprocessedAt = 0
+        // Settle a drain that is ALREADY in flight before starting our own, then
+        // again after. `drain()` no-ops while one owns the session, so a
+        // fire-and-forget `void drain(live)` raised elsewhere — the restart-resume
+        // lost-work notice, a promoted review carrier, a subagent-completion wake —
+        // would still be mid-turn when this returned, and the caller would assert
+        // on a prompt that has not landed. Same defect shape as the `persist()`
+        // race below: this seam has to mean "settled", not "started".
+        await settleDrains(live)
         await drain(live)
+        await settleDrains(live)
         // Settle the fire-and-forget `void persist()` from scheduleDebouncedDrain
         // (the lastInboundAt write). Draining alone doesn't await that promise, so
         // a test reading sessions.json right after would race the disk write — the


### PR DESCRIPTION
## Background

The `flake guard (oversubscribed parallel)` lane failed on [run 33086034314](https://github.com/typeclaw/typeclaw/actions/runs/33086034314/job/98565793519):

```
(fail) resumeRestartHandoff > delivers the interrupted-subagent notice even when a real inbound coalesced [9.84ms]
```

One of the two concurrent suites failed; the other passed all 13312 tests. Classic contention flake — and exactly what that lane exists to surface.

The mechanism is in `drain()`. It is a deliberate no-op while `live.draining` is already set, which is correct in production: the running loop re-checks `promptQueue` and `pendingSystemReminders` every iteration, so work landing behind it gets picked up without a second concurrent drain. The cost is that a fire-and-forget `void drain(live)` becomes **unobservable** — nothing hands back a handle on the turn it started.

That is precisely the shape of the restart-resume path. When a real inbound coalesces onto a restart reservation, `resume()` queues the interrupted-subagent notice and starts one of those fire-and-forget drains; the racing inbound then queues behind it. `flushDebounce` called `drain(live)`, received the immediate no-op, and returned **while that first drain was still mid-turn**. The test then asserted on prompts that had not landed yet.

So the test was passing on scheduling luck. Normally the drain finishes during `await persistChain`; under an oversubscribed runner its own I/O lags further than the persist chain, and the assertion loses. Nothing was wrong with the production behavior — the notice is delivered either way. The seam was lying about what "flush" means.

## Summary

Track every running drain on `live.activeDrains`, and have `flushDebounce` settle them before and after its own round.

- The **pre-round** settle drains what is already in flight — the actual failure above.
- The **post-round** settle covers a rival drain started during another drain's tail, which runs after `draining` has already flipped back to false. A snapshot `Promise.all` would return with that successor still running, hence the loop.

**Why harden the seam and not just poll in the test.** Both fix the red build. Polling fixes one test; `86f59b57` already settled this question for this exact function, when it taught `flushDebounce` to await the fire-and-forget `void persist()` instead of leaving the test to poll for the `lastInboundAt` write:

> Make flushDebounce await persistChain (the same drain stop() and tearDownAllLive already use), so the write is guaranteed on disk when it returns. The test helper then drops the poll and asserts directly.

Same defect, same seam, one fire-and-forget away. The comment that fix left behind now sits directly under the one added here. The failing test is **unmodified** — the seam change alone makes it deterministic, which is the point.

**Production semantics are untouched.** `drain()` still no-ops while a drain owns the session. Splitting it into a sync wrapper plus `runDrain` keeps `live.draining = true` synchronous (an async body runs synchronously to its first await), so the re-entrancy guard fires on exactly the same tick as before. Callers still get the original promise back, so rejection behavior is unchanged; only the tracked copy swallows, so a later settle can't re-surface a failure the starting caller already owns. Every `void drain(...)` call site ignores the return value.

## What this does NOT do

- Does not change when or whether the interrupted-subagent notice is delivered. That was already correct.
- Does not touch `drain()`'s no-op-while-draining contract, or add a second concurrent drain.
- Does not convert other tests to the settled seam. Several sites (the subagent-completion reminder tests, the GitHub review failover tests) currently lean on incidental drain ownership or their own `waitFor`; they now benefit from the harder seam, but were left alone to keep this diff to the reported failure.
- Does not add a production-facing API. `activeDrains` is internal state; `settleDrains` is only reached through the existing `__testing` seam.

## Review notes

The load-bearing change is the pre/post `settleDrains` pair in `__testing.flushDebounce`, plus registration in `drain()`. Invariant to verify: `drain()` must still return **before** the drain completes for normal callers (it returns `running`, not `settled`), while `flushDebounce` must return only **after** every drain has fully settled, including the post-`draining` tail.

The new test reproduces the race deterministically by parking the first turn on a macrotask, rather than hoping a loaded runner reproduces it. Verified both directions:

- With the seam reverted to `await drain(live)`, it fails in 10.86ms — the same signature as the CI failure's 9.84ms.
- With the fix, it passes, as does the full suite run twice concurrently (the flake-guard shape) at 13313 tests, 0 fail.
