### PR TITLE
Make prior-turn channel attachments actually resolvable

### DIFF
--- a/src/channels/adapters/discord-classify.ts
+++ b/src/channels/adapters/discord-classify.ts
@@ -95,17 +95,29 @@ const GROUP_MENTION_PATTERN = /@(?:everyone|here)/
 type SplitInbound = { text: string; attachments: InboundAttachment[] }
 
 function splitInbound(event: DiscordInboundMessageEvent): SplitInbound {
-  const attachments = (event.attachments ?? []).map((attachment, index) => ({
+  return splitDiscordAttachments(event.content, event)
+}
+
+// Structural so the REST history shape and the gateway event shape share one
+// implementation. Exported because `discord.ts`'s history mapper bypasses the
+// classifier: without reusing this, an already-posted image renders with no
+// `#N` placeholder and registers no ref, so look_at_channel_attachment can
+// never resolve it. Same contract discord-bot/slack-bot already document.
+export type DiscordAttachmentCarrier = {
+  attachments?: readonly { url: string; filename: string; content_type?: string }[]
+}
+
+export function splitDiscordAttachments(text: string, carrier: DiscordAttachmentCarrier): SplitInbound {
+  const attachments = (carrier.attachments ?? []).map((attachment, index) => ({
     id: index + 1,
     kind: 'file' as const,
     ref: attachment.url,
     filename: attachment.filename,
     ...(attachment.content_type !== undefined ? { mimetype: attachment.content_type } : {}),
   }))
-  if (attachments.length === 0) return { text: event.content, attachments: [] }
+  if (attachments.length === 0) return { text, attachments: [] }
   const summary = attachments.map(renderPlaceholder).join('\n')
-  const text = event.content === '' ? summary : `${event.content}\n${summary}`
-  return { text, attachments }
+  return { text: text === '' ? summary : `${text}\n${summary}`, attachments }
 }
 
 function renderPlaceholder(attachment: InboundAttachment): string {

--- a/src/channels/adapters/discord.test.ts
+++ b/src/channels/adapters/discord.test.ts
@@ -7,7 +7,7 @@ import { channelsSchema } from '@/channels/schema'
 import type { InboundMessage, OutboundCallback } from '@/channels/types'
 import type { DiscordAccountRecord } from '@/secrets/schema'
 
-import { createDiscordAdapter, type DiscordAdapterLogger } from './discord'
+import { createDiscordAdapter, createDiscordHistoryCallback, type DiscordAdapterLogger } from './discord'
 
 const config = channelsSchema.parse({ discord: {} }).discord!
 
@@ -447,6 +447,98 @@ describe('createDiscordAdapter', () => {
     expect(listener.stopped).toBe(true)
     expect(r.unregistered).toContain('outbound:discord')
     expect(r.unregistered).toContain('remove-reaction:discord')
+  })
+})
+
+describe('createDiscordHistoryCallback', () => {
+  function historyMessage(overrides: Record<string, unknown> = {}) {
+    return {
+      id: '400000000000000004',
+      channel_id: '300000000000000003',
+      author: { id: '500000000000000005', username: 'alice' },
+      content: 'hello',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    }
+  }
+
+  async function fetchHistory(messages: unknown[]) {
+    const callback = createDiscordHistoryCallback({
+      client: { getMessages: async () => messages } as unknown as Parameters<
+        typeof createDiscordHistoryCallback
+      >[0]['client'],
+      logger: logger(),
+    })
+    return await callback({ chat: '300000000000000003', thread: null, limit: 10 })
+  }
+
+  test('a captionless image in history is addressable and carries its CDN ref', async () => {
+    const result = await fetchHistory([
+      historyMessage({
+        content: '',
+        attachments: [
+          {
+            id: '1',
+            filename: 'image.png',
+            size: 1024,
+            url: 'https://cdn.discordapp.com/attachments/1/2/image.png',
+            content_type: 'image/webp',
+          },
+        ],
+      }),
+    ])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const [message] = result.messages
+    expect(message?.text).toBe('[Discord attachment #1: file image/webp name=image.png]')
+    expect(message?.attachments).toEqual([
+      {
+        id: 1,
+        kind: 'file',
+        ref: 'https://cdn.discordapp.com/attachments/1/2/image.png',
+        filename: 'image.png',
+        mimetype: 'image/webp',
+      },
+    ])
+  })
+
+  test('placeholder ids line up one-to-one with the structured refs', async () => {
+    const result = await fetchHistory([
+      historyMessage({
+        content: 'two files',
+        attachments: [
+          { id: '1', filename: 'a.png', size: 1, url: 'https://cdn.discordapp.com/attachments/1/2/a.png' },
+          {
+            id: '2',
+            filename: 'b.pdf',
+            size: 1,
+            url: 'https://cdn.discordapp.com/attachments/1/3/b.pdf',
+            content_type: 'application/pdf',
+          },
+        ],
+      }),
+    ])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const message = result.messages[0]
+    expect(message?.text).toBe(
+      'two files\n[Discord attachment #1: file name=a.png]\n[Discord attachment #2: file application/pdf name=b.pdf]',
+    )
+    expect(message?.attachments?.map((a) => [a.id, a.ref])).toEqual([
+      [1, 'https://cdn.discordapp.com/attachments/1/2/a.png'],
+      [2, 'https://cdn.discordapp.com/attachments/1/3/b.pdf'],
+    ])
+  })
+
+  test('text-only history messages are untouched and carry no attachments key', async () => {
+    const result = await fetchHistory([historyMessage()])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.messages[0]?.text).toBe('hello')
+    expect(result.messages[0]?.attachments).toBeUndefined()
   })
 })
 

--- a/src/channels/adapters/discord.ts
+++ b/src/channels/adapters/discord.ts
@@ -36,7 +36,12 @@ import type { DiscordAccountRecord } from '@/secrets/schema'
 import { describeError } from '../describe-error'
 import { createDiscordAuthorResolver } from './discord-author-resolver'
 import { createDiscordChannelResolver } from './discord-channel-resolver'
-import { classifyInbound, type InboundDropReason } from './discord-classify'
+import {
+  classifyInbound,
+  type DiscordAttachmentCarrier,
+  type InboundDropReason,
+  splitDiscordAttachments,
+} from './discord-classify'
 import { createDiscordUserEditMessageCallback } from './discord-edit'
 import { createDiscordReactionCallback, createDiscordRemoveReactionCallback } from './discord-reactions'
 
@@ -437,23 +442,30 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
   }
 }
 
-// WORKAROUND: the SDK's `DiscordMessage` type omits `author.bot`, but the REST
-// API returns it and the client passes the body through unchanged, so it's
-// present at runtime. `=== true` fails closed to human if absent. This flag
-// feeds history-derived membership (deriveMembershipFromHistory), which
-// otherwise miscounts peer bots as humans and inflates effectiveHumans.
-type RawDiscordMessage = DiscordMessage & { author: { bot?: boolean } }
+// WORKAROUND: the SDK's `DiscordMessage` type omits `author.bot` and
+// `attachments`, but the REST API returns both and the client passes the body
+// through unchanged, so they are present at runtime. `=== true` fails closed to
+// human if absent. That flag feeds history-derived membership
+// (deriveMembershipFromHistory), which otherwise miscounts peer bots as humans
+// and inflates effectiveHumans.
+type RawDiscordMessage = DiscordMessage & DiscordAttachmentCarrier & { author: { bot?: boolean } }
 
 function mapDiscordHistoryMessage(msg: DiscordMessage): ChannelHistoryMessage {
   const raw = msg as RawDiscordMessage
+  // The REST history fetch bypasses the inbound classifier, so attachments on
+  // already-posted messages must be mapped here too — otherwise they are
+  // silently dropped and look_at_channel_attachment can never resolve them,
+  // even though its error text tells the agent channel_history is the fix.
+  const { text, attachments } = splitDiscordAttachments(msg.content, raw)
   return {
     externalMessageId: msg.id,
     authorId: msg.author.id,
     authorName: msg.author.username,
-    text: msg.content,
+    text,
     ts: parseDiscordTimestamp(msg.timestamp),
     isBot: raw.author.bot === true,
     replyToBotMessageId: null,
+    ...(attachments.length > 0 ? { attachments } : {}),
   }
 }
 

--- a/src/channels/adapters/slack-classify.ts
+++ b/src/channels/adapters/slack-classify.ts
@@ -1,8 +1,8 @@
-import type { SlackRTMMessageEvent } from 'agent-messenger/slack'
+import type { SlackFile, SlackRTMMessageEvent } from 'agent-messenger/slack'
 
 import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
-import type { InboundMessage } from '@/channels/types'
+import type { InboundAttachment, InboundMessage } from '@/channels/types'
 
 import { slackTsToMillis } from './slack-bot-time'
 import { encodeSlackReactionRef } from './slack-reactions'
@@ -89,6 +89,38 @@ function classifyConversation(
 
 export function isRouteableSlackMessageSubtype(subtype: string | undefined): boolean {
   return subtype === undefined || subtype === 'me_message'
+}
+
+// The REST history fetch bypasses the inbound classifier, so files on
+// already-posted messages must be described here too. Registering the ref
+// without also baking a `#N` placeholder into the text is not enough: the
+// agent has no way to learn the id exists, so look_at_channel_attachment stays
+// unreachable in practice. Kept in the classifier module so the live inbound
+// path can adopt the same rendering.
+export function splitSlackFiles(text: string, files: readonly SlackFile[] | undefined): SplitSlackFiles {
+  const attachments = (files ?? []).map(describeSlackFile)
+  if (attachments.length === 0) return { text, attachments: [] }
+  const summary = attachments.map(renderPlaceholder).join('\n')
+  return { text: text === '' ? summary : `${text}\n${summary}`, attachments }
+}
+
+type SplitSlackFiles = { text: string; attachments: InboundAttachment[] }
+
+function describeSlackFile(file: SlackFile, index: number): InboundAttachment {
+  return {
+    id: index + 1,
+    kind: 'file',
+    ref: file.id,
+    filename: file.name,
+    mimetype: file.mimetype,
+  }
+}
+
+function renderPlaceholder(attachment: InboundAttachment): string {
+  const parts: string[] = [`Slack attachment #${attachment.id}: ${attachment.kind}`]
+  if (attachment.mimetype !== undefined) parts.push(attachment.mimetype)
+  if (attachment.filename !== undefined) parts.push(`name=${attachment.filename}`)
+  return `[${parts.join(' ')}]`
 }
 
 const MENTION_PATTERN = /<@([UW][A-Z0-9]+)(?:\|[^>]*)?>/g

--- a/src/channels/adapters/slack.test.ts
+++ b/src/channels/adapters/slack.test.ts
@@ -8,7 +8,7 @@ import { channelsSchema } from '@/channels/schema'
 import type { InboundMessage, OutboundCallback } from '@/channels/types'
 import type { SlackAccountRecord } from '@/secrets/schema'
 
-import { createSlackAdapter, type SlackAdapterLogger } from './slack'
+import { createSlackAdapter, createSlackHistoryCallback, type SlackAdapterLogger } from './slack'
 
 const config = channelsSchema.parse({ slack: {} }).slack!
 
@@ -351,6 +351,73 @@ describe('createSlackAdapter', () => {
     expect(r.unregistered).toContain('outbound:slack')
     expect(log.lines).toContain('error:[slack] listener error: invalid_auth')
     expect(log.lines.some((line) => line.includes('[object'))).toBe(false)
+  })
+})
+
+describe('createSlackHistoryCallback', () => {
+  function file(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'F0001',
+      name: 'image.png',
+      title: 'image.png',
+      mimetype: 'image/png',
+      size: 1024,
+      url_private: 'https://files.slack.com/files-pri/T1-F0001/image.png',
+      created: 1,
+      user: 'U123',
+      ...overrides,
+    }
+  }
+
+  async function fetchHistory(messages: unknown[]) {
+    const callback = createSlackHistoryCallback({
+      client: { getMessages: async () => messages } as unknown as Parameters<
+        typeof createSlackHistoryCallback
+      >[0]['client'],
+      logger: logger(),
+    })
+    return await callback({ chat: 'C123', thread: null, limit: 10 })
+  }
+
+  test('a captionless file in history is addressable by the id it renders', async () => {
+    const result = await fetchHistory([{ ts: '1700000000.000100', text: '', type: 'message', files: [file()] }])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.messages[0]?.text).toBe('[Slack attachment #1: file image/png name=image.png]')
+    expect(result.messages[0]?.attachments).toEqual([
+      { id: 1, kind: 'file', ref: 'F0001', filename: 'image.png', mimetype: 'image/png' },
+    ])
+  })
+
+  test('placeholder ids line up one-to-one with the structured refs', async () => {
+    const result = await fetchHistory([
+      {
+        ts: '1700000000.000100',
+        text: 'two files',
+        type: 'message',
+        files: [file(), file({ id: 'F0002', name: 'b.pdf', mimetype: 'application/pdf' })],
+      },
+    ])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.messages[0]?.text).toBe(
+      'two files\n[Slack attachment #1: file image/png name=image.png]\n[Slack attachment #2: file application/pdf name=b.pdf]',
+    )
+    expect(result.messages[0]?.attachments?.map((a) => [a.id, a.ref])).toEqual([
+      [1, 'F0001'],
+      [2, 'F0002'],
+    ])
+  })
+
+  test('text-only history messages are untouched and carry no attachments key', async () => {
+    const result = await fetchHistory([{ ts: '1700000000.000100', text: 'hello', type: 'message' }])
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.messages[0]?.text).toBe('hello')
+    expect(result.messages[0]?.attachments).toBeUndefined()
   })
 })
 

--- a/src/channels/adapters/slack.ts
+++ b/src/channels/adapters/slack.ts
@@ -38,7 +38,7 @@ import { downloadSlackAttachment, type SlackAttachmentFetch } from './slack-atta
 import { createSlackAuthorResolver } from './slack-author-resolver'
 import { slackTsToMillis } from './slack-bot-time'
 import { createSlackChannelResolver } from './slack-channel-resolver'
-import { classifyInbound, type InboundDropReason, type SlackConversationType } from './slack-classify'
+import { classifyInbound, type InboundDropReason, type SlackConversationType, splitSlackFiles } from './slack-classify'
 import { createSlackUserEditMessageCallback } from './slack-edit'
 import { createSlackReactionCallback, createSlackRemoveReactionCallback } from './slack-reactions'
 
@@ -461,18 +461,12 @@ async function defaultReadFile(path: string): Promise<Buffer> {
 }
 
 function mapSlackHistoryMessage(msg: SlackMessage): ChannelHistoryMessage {
-  const attachments = (msg.files ?? []).map((file, index) => ({
-    id: index + 1,
-    kind: 'file' as const,
-    ref: file.id,
-    filename: file.name,
-    mimetype: file.mimetype,
-  }))
+  const { text, attachments } = splitSlackFiles(msg.text, msg.files)
   return {
     externalMessageId: msg.ts,
     authorId: msg.user ?? msg.username ?? 'unknown',
     authorName: msg.username ?? msg.user ?? 'unknown',
-    text: msg.text,
+    text,
     ts: slackTsToMillis(msg.ts),
     isBot: false,
     replyToBotMessageId: null,

--- a/src/channels/adapters/webex-bot-classify.ts
+++ b/src/channels/adapters/webex-bot-classify.ts
@@ -2,7 +2,9 @@ import type { WebexBotListenerEventMap } from 'agent-messenger/webexbot'
 
 import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
-import type { InboundAttachment, InboundMessage } from '@/channels/types'
+import type { InboundMessage } from '@/channels/types'
+
+import { splitWebexFiles } from './webex-format'
 
 export type WebexInboundMessage = WebexBotListenerEventMap['message_created'][0]
 
@@ -27,7 +29,7 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'self_author' }
   }
 
-  const { text, attachments } = splitInbound(event)
+  const { text, attachments } = splitWebexFiles(event.text, event.files)
   if (text === '') return { kind: 'drop', reason: 'empty_content' }
 
   if (botPersonRef === null) {
@@ -77,35 +79,4 @@ function isSelfAuthor(event: WebexInboundMessage, botPersonRef: string | null, b
     return event.personEmail.toLowerCase() === botPersonEmail.toLowerCase()
   }
   return false
-}
-
-type SplitInbound = { text: string; attachments: InboundAttachment[] }
-
-function splitInbound(event: WebexInboundMessage): SplitInbound {
-  const attachments = event.files.map((ref, index) => ({
-    id: index + 1,
-    kind: 'file' as const,
-    ref,
-    filename: filenameFromUrl(ref) ?? `webex-file-${index + 1}`,
-  }))
-  if (attachments.length === 0) return { text: event.text, attachments: [] }
-  const summary = attachments.map(renderPlaceholder).join('\n')
-  const text = event.text === '' ? summary : `${event.text}\n${summary}`
-  return { text, attachments }
-}
-
-function filenameFromUrl(ref: string): string | null {
-  try {
-    const url = new URL(ref)
-    const name = url.pathname.split('/').filter(Boolean).pop()
-    return name === undefined || name === '' ? null : name
-  } catch {
-    return null
-  }
-}
-
-function renderPlaceholder(attachment: InboundAttachment): string {
-  const parts: string[] = [`Webex attachment #${attachment.id}: ${attachment.kind}`]
-  if (attachment.filename !== undefined) parts.push(`name=${attachment.filename}`)
-  return `[${parts.join(' ')}]`
 }

--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -241,6 +241,35 @@ describe('webex history and membership', () => {
     expect(result.nextCursor).toBeUndefined()
   })
 
+  test('numbers every history file so each is separately addressable', async () => {
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async () => [
+          webexMessage({
+            id: 'files-blob',
+            ref: 'files',
+            text: 'two files',
+            files: ['https://webexapis.com/v1/contents/AAA/photo.png', 'https://webexapis.com/v1/contents/BBB/doc.pdf'],
+          }),
+        ],
+      },
+      logger: logger(),
+      botPersonIdRef: () => 'bot-1',
+    })
+
+    const result = await cb({ chat: 'room-1', thread: null, limit: 10 })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages[0]?.text).toBe(
+      'two files\n[Webex attachment #1: file name=photo.png]\n[Webex attachment #2: file name=doc.pdf]',
+    )
+    expect(result.messages[0]?.attachments?.map((a) => [a.id, a.ref])).toEqual([
+      [1, 'https://webexapis.com/v1/contents/AAA/photo.png'],
+      [2, 'https://webexapis.com/v1/contents/BBB/doc.pdf'],
+    ])
+  })
+
   test('returns ok false on history failure', async () => {
     const cb = createWebexHistoryCallback({
       client: { listMessages: async () => Promise.reject(new Error('down')) },
@@ -751,6 +780,7 @@ function webexMessageShape() {
     personRef: 'user-1',
     personEmail: 'user@example.com',
     created: '2026-01-01T00:00:00Z',
+    files: [] as string[],
   }
 }
 

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -39,7 +39,7 @@ import { createWebexChannelNameResolver } from './webex-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-bot-classify'
 import { enrichWebexMessageReference } from './webex-bot-reference'
 import { createWebexEditMessageCallback } from './webex-edit'
-import { resolveWebexBodyText } from './webex-format'
+import { resolveWebexBodyText, splitWebexFiles } from './webex-format'
 import { createWebexPrefetchLimiter, isWebexRateLimitError, type WebexPrefetchLimiter } from './webex-prefetch-limiter'
 
 export type WebexBotAdapterLogger = {
@@ -462,9 +462,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
 }
 
 function mapWebexHistoryMessage(msg: WebexMessage, botPersonId: string | null): ChannelHistoryMessage {
-  const attachments = (msg.files ?? []).map((ref, index) => ({ id: index + 1, kind: 'file' as const, ref }))
-  const body = resolveWebexBodyText(msg)
-  const text = attachments.length === 0 ? body : body === '' ? '[Webex attachment]' : `${body}\n[Webex attachment]`
+  const { text, attachments } = splitWebexFiles(resolveWebexBodyText(msg), msg.files)
   const ts = Date.parse(msg.created)
   return {
     externalMessageId: msg.ref,

--- a/src/channels/adapters/webex-classify.ts
+++ b/src/channels/adapters/webex-classify.ts
@@ -3,7 +3,9 @@ import type { WebexListenerEventMap } from 'agent-messenger/webex'
 
 import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
-import type { InboundAttachment, InboundMessage } from '@/channels/types'
+import type { InboundMessage } from '@/channels/types'
+
+import { splitWebexFiles } from './webex-format'
 
 export type WebexInboundMessage = WebexListenerEventMap['message_created'][0]
 
@@ -33,7 +35,7 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'self_author' }
   }
 
-  const { text, attachments } = splitInbound(event)
+  const { text, attachments } = splitWebexFiles(event.text, event.files)
   if (text === '') return { kind: 'drop', reason: 'empty_content' }
 
   if (botPersonRef === null) {
@@ -85,35 +87,4 @@ function isSelfAuthor(event: WebexInboundMessage, botPersonRef: string | null, b
     return event.personEmail.toLowerCase() === botPersonEmail.toLowerCase()
   }
   return false
-}
-
-type SplitInbound = { text: string; attachments: InboundAttachment[] }
-
-function splitInbound(event: WebexInboundMessage): SplitInbound {
-  const attachments = event.files.map((ref: string, index: number) => ({
-    id: index + 1,
-    kind: 'file' as const,
-    ref,
-    filename: filenameFromUrl(ref) ?? `webex-file-${index + 1}`,
-  }))
-  if (attachments.length === 0) return { text: event.text, attachments: [] }
-  const summary = attachments.map(renderPlaceholder).join('\n')
-  const text = event.text === '' ? summary : `${event.text}\n${summary}`
-  return { text, attachments }
-}
-
-function filenameFromUrl(ref: string): string | null {
-  try {
-    const url = new URL(ref)
-    const name = url.pathname.split('/').filter(Boolean).pop()
-    return name === undefined || name === '' ? null : name
-  } catch {
-    return null
-  }
-}
-
-function renderPlaceholder(attachment: InboundAttachment): string {
-  const parts: string[] = [`Webex attachment #${attachment.id}: ${attachment.kind}`]
-  if (attachment.filename !== undefined) parts.push(`name=${attachment.filename}`)
-  return `[${parts.join(' ')}]`
 }

--- a/src/channels/adapters/webex-format.test.ts
+++ b/src/channels/adapters/webex-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { normalizeWebexHtmlFallbackText, resolveWebexBodyText } from './webex-format'
+import { normalizeWebexHtmlFallbackText, resolveWebexBodyText, splitWebexFiles } from './webex-format'
 
 describe('normalizeWebexHtmlFallbackText', () => {
   test('decodes named and numeric entities', () => {
@@ -47,5 +47,39 @@ describe('resolveWebexBodyText', () => {
   test('returns empty string when no body present', () => {
     expect(resolveWebexBodyText({ text: undefined, markdown: undefined, html: undefined })).toBe('')
     expect(resolveWebexBodyText({ text: '', markdown: '', html: '' })).toBe('')
+  })
+})
+
+describe('splitWebexFiles', () => {
+  test('numbers every file so each one is separately addressable', () => {
+    const { text, attachments } = splitWebexFiles('two files', [
+      'https://webexapis.com/v1/contents/AAA/photo.png',
+      'https://webexapis.com/v1/contents/BBB/report.pdf',
+    ])
+
+    expect(text).toBe(
+      'two files\n[Webex attachment #1: file name=photo.png]\n[Webex attachment #2: file name=report.pdf]',
+    )
+    expect(attachments.map((a) => [a.id, a.ref])).toEqual([
+      [1, 'https://webexapis.com/v1/contents/AAA/photo.png'],
+      [2, 'https://webexapis.com/v1/contents/BBB/report.pdf'],
+    ])
+  })
+
+  test('a captionless file becomes the whole body', () => {
+    expect(splitWebexFiles('', ['https://webexapis.com/v1/contents/AAA/photo.png']).text).toBe(
+      '[Webex attachment #1: file name=photo.png]',
+    )
+  })
+
+  test('falls back to a positional filename when the ref has no usable path', () => {
+    expect(splitWebexFiles('', ['not-a-url']).attachments).toEqual([
+      { id: 1, kind: 'file', ref: 'not-a-url', filename: 'webex-file-1' },
+    ])
+  })
+
+  test('leaves text untouched when there are no files', () => {
+    expect(splitWebexFiles('hello', undefined)).toEqual({ text: 'hello', attachments: [] })
+    expect(splitWebexFiles('hello', [])).toEqual({ text: 'hello', attachments: [] })
   })
 })

--- a/src/channels/adapters/webex-format.ts
+++ b/src/channels/adapters/webex-format.ts
@@ -1,5 +1,7 @@
 import type { WebexMessage } from 'agent-messenger/webex'
 
+import type { InboundAttachment } from '@/channels/types'
+
 // Webex's E2E (internal conversation) path renders agent markdown as an HTML
 // `content` field that some clients display verbatim, so messages sent with
 // `markdown: true` leak literal `<br/>` and `&apos;`. typeclaw sends plain text
@@ -13,6 +15,40 @@ export function resolveWebexBodyText(msg: Pick<WebexMessage, 'text' | 'markdown'
   if (msg.markdown !== undefined && msg.markdown !== '') return msg.markdown
   if (msg.html !== undefined && msg.html !== '') return normalizeWebexHtmlFallbackText(msg.html)
   return ''
+}
+
+// Shared by both Webex classifiers and both Webex history mappers so a file
+// carries the same `#N` in every surface the agent can read. History used to
+// emit a single un-numbered `[Webex attachment]` regardless of file count,
+// which registered refs the agent could never name in
+// look_at_channel_attachment.
+export function splitWebexFiles(text: string, files: readonly string[] | undefined): SplitWebexFiles {
+  const attachments = (files ?? []).map(describeWebexFile)
+  if (attachments.length === 0) return { text, attachments: [] }
+  const summary = attachments.map(renderPlaceholder).join('\n')
+  return { text: text === '' ? summary : `${text}\n${summary}`, attachments }
+}
+
+type SplitWebexFiles = { text: string; attachments: InboundAttachment[] }
+
+function describeWebexFile(ref: string, index: number): InboundAttachment {
+  return { id: index + 1, kind: 'file', ref, filename: filenameFromUrl(ref) ?? `webex-file-${index + 1}` }
+}
+
+function filenameFromUrl(ref: string): string | null {
+  try {
+    const url = new URL(ref)
+    const name = url.pathname.split('/').filter(Boolean).pop()
+    return name === undefined || name === '' ? null : name
+  } catch {
+    return null
+  }
+}
+
+function renderPlaceholder(attachment: InboundAttachment): string {
+  const parts: string[] = [`Webex attachment #${attachment.id}: ${attachment.kind}`]
+  if (attachment.filename !== undefined) parts.push(`name=${attachment.filename}`)
+  return `[${parts.join(' ')}]`
 }
 
 export function normalizeWebexHtmlFallbackText(value: string): string {

--- a/src/channels/adapters/webex.test.ts
+++ b/src/channels/adapters/webex.test.ts
@@ -424,6 +424,27 @@ describe('createWebexHistoryCallback reply attribution', () => {
     return res.messages
   }
 
+  test('numbers every history file so each is separately addressable', async () => {
+    const history = await historyOf(
+      [
+        message({
+          ref: 'm-1',
+          text: 'two files',
+          files: ['https://webexapis.com/v1/contents/AAA/photo.png', 'https://webexapis.com/v1/contents/BBB/doc.pdf'],
+        }),
+      ],
+      'bot-1',
+    )
+
+    expect(history[0]?.text).toBe(
+      'two files\n[Webex attachment #1: file name=photo.png]\n[Webex attachment #2: file name=doc.pdf]',
+    )
+    expect(history[0]?.attachments?.map((a) => [a.id, a.ref])).toEqual([
+      [1, 'https://webexapis.com/v1/contents/AAA/photo.png'],
+      [2, 'https://webexapis.com/v1/contents/BBB/doc.pdf'],
+    ])
+  })
+
   test('leaves replyToBotMessageId null when the threaded parent was authored by a human', async () => {
     const parent = message({ id: 'parent-blob', ref: 'parent-1', personId: 'human-blob-1', personRef: 'human-1' })
     const child = message({

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -43,7 +43,7 @@ import { describeError } from '../describe-error'
 import { createWebexChannelNameResolver } from './webex-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-classify'
 import { createWebexEditMessageCallback } from './webex-edit'
-import { resolveWebexBodyText } from './webex-format'
+import { resolveWebexBodyText, splitWebexFiles } from './webex-format'
 import { createWebexPrefetchLimiter, isWebexRateLimitError, type WebexPrefetchLimiter } from './webex-prefetch-limiter'
 import { enrichWebexMessageReference } from './webex-reference'
 
@@ -534,9 +534,7 @@ function mapWebexHistoryMessage(
   botPersonId: string | null,
   authorById: ReadonlyMap<string, string>,
 ): ChannelHistoryMessage {
-  const attachments = (msg.files ?? []).map((ref, index) => ({ id: index + 1, kind: 'file' as const, ref }))
-  const body = resolveWebexBodyText(msg)
-  const text = attachments.length === 0 ? body : body === '' ? '[Webex attachment]' : `${body}\n[Webex attachment]`
+  const { text, attachments } = splitWebexFiles(resolveWebexBodyText(msg), msg.files)
   const ts = Date.parse(msg.created)
   return {
     externalMessageId: msg.ref,

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -20,6 +20,7 @@ import { readContinuationState } from '@/agent/todo/continuation-state'
 import { recordTurnOutcome } from '@/agent/todo/continuation-wiring'
 import { resolveTodoScope } from '@/agent/todo/scope'
 import { writeTodos } from '@/agent/todo/store'
+import { createChannelHistoryTool } from '@/agent/tools/channel-history'
 import { createChannelReplyTool } from '@/agent/tools/channel-reply'
 import { createPostGithubReviewTool } from '@/agent/tools/post-github-review'
 import {
@@ -32,6 +33,7 @@ import type { PermissionService } from '@/permissions'
 import type { HookBus, SessionIdleEvent } from '@/plugin'
 import { waitFor } from '@/test-helpers/wait-for'
 
+import { createDiscordHistoryCallback } from './adapters/discord'
 import {
   __resetReviewVerdictGuardForTest,
   configureReviewVerdictCoordinator,
@@ -16362,6 +16364,62 @@ describe('ChannelRouter history attachment registry', () => {
     expect(resolved).not.toBeNull()
     expect(resolved!.ref).toBe(HIST_PHOTO.ref)
     expect(router.listInboundAttachmentIds(KEY)).toEqual([1])
+  })
+
+  // End-to-end guard for the production failure this registry exists to
+  // prevent: the agent was told by look_at_channel_attachment's own error text
+  // to "call channel_history first", did exactly that, and still could not
+  // resolve the image because the Discord user adapter's history mapper never
+  // carried the attachment. Wiring the REAL adapter callback and the REAL tool
+  // is the point — a fake history callback would have passed the whole time.
+  test('an id the agent reads in rendered channel_history output resolves to that ref', async () => {
+    const DISCORD_KEY: ChannelKey = { adapter: 'discord', workspace: 'g1', chat: 'c1', thread: null }
+    const { router } = makeRouter(await tempDir())
+    await router.route(inbound({ adapter: 'discord', text: 'open session' }))
+    await router.__testing!.flushDebounce(DISCORD_KEY)
+
+    router.registerHistory(
+      'discord',
+      createDiscordHistoryCallback({
+        client: {
+          getMessages: async () => [
+            {
+              id: 'm-image',
+              channel_id: 'c1',
+              author: { id: 'alice', username: 'alice' },
+              content: '',
+              timestamp: '2026-01-01T00:00:00.000Z',
+              attachments: [
+                {
+                  id: '1',
+                  filename: 'image.png',
+                  size: 10,
+                  url: 'https://cdn.discordapp.com/attachments/1/2/image.png',
+                  content_type: 'image/webp',
+                },
+              ],
+            },
+          ],
+        } as unknown as Parameters<typeof createDiscordHistoryCallback>[0]['client'],
+        logger: { info: () => {}, warn: () => {}, error: () => {} },
+      }),
+    )
+
+    const tool = createChannelHistoryTool({ router, origin: DISCORD_KEY })
+    const result = await tool.execute(
+      'call-1',
+      { scope: 'channel' },
+      undefined,
+      undefined,
+      {} as Parameters<typeof tool.execute>[4],
+    )
+
+    const rendered = result.content.map((part) => ('text' in part ? part.text : '')).join('\n')
+    const renderedId = /attachment #(\d+):/.exec(rendered)?.[1]
+    expect(renderedId).toBe('1')
+
+    const resolved = router.lookupInboundAttachment({ ...DISCORD_KEY, id: Number(renderedId) })
+    expect(resolved?.ref).toBe('https://cdn.discordapp.com/attachments/1/2/image.png')
   })
 
   test('a live current-turn #1 still wins over a registered history #1', async () => {


### PR DESCRIPTION
## Background

A user posted an image in a Discord channel, then asked the agent about it on the next message. The agent replied:

> I can see that an image was sent, but Discord didn't make the actual attachment available to me to view this time 😭 Could you resend it?

Discord had made it available. We dropped it.

From the session transcript (origin `{kind: 'channel', adapter: 'discord'}`), the agent did everything right:

1. Turn 1's context buffer rendered the upload correctly — `[Discord attachment #1: file image/webp name=image.png]`.
2. On the next turn that buffer was not re-rendered, so the placeholder was gone.
3. The agent called `channel_history`. The image message came back with **completely empty text** — no placeholder, no attachment.
4. The agent called `look_at_channel_attachment({attachment_id: 1})` and got:
   `no attachment with id=1 (no attachments are resolvable right now). For an attachment from an earlier message, call channel_history first to make it resolvable`
5. It had just done that. So it gave up and blamed Discord to the user.

**Root cause.** `mapDiscordHistoryMessage` returned `text: msg.content` and never mapped `msg.attachments`. `channel_history` calls `router.registerHistoryAttachments(origin, result.messages)`, which reads `ChannelHistoryMessage.attachments` — always `undefined` here — so nothing was registered and nothing was visible. The recovery path the tool advertises in its own error string was a dead end on this adapter.

This is a known defect class that was fixed on the **bot** adapters and never applied to the **user** adapters. `discord-bot.ts` and `slack-bot.ts` both already carry the fix, each with a comment saying exactly this: *"The REST history fetch bypasses the inbound classifier, so attachments … must be mapped here too — otherwise they are silently dropped and look_at_channel_attachment can never resolve them."*

Auditing every history mapper turned up two more instances of the same broken contract:

| adapter | history `attachments` | `#N` placeholder in text |
|---|---|---|
| discord-bot, slack-bot, kakaotalk | yes | yes |
| **discord (user)** | **no** | **no** — the reported bug |
| **slack (user)** | yes | **no** — ref registered, but the agent can never learn the id exists |
| **webex, webex-bot** | yes | one un-numbered `[Webex attachment]` regardless of file count |

The invariant all three violate is the same: **history is only recoverable when `text` and `attachments` describe the same ids.** Registering a ref the agent cannot name is indistinguishable from not registering it.

## Summary

Each adapter reuses its own classifier's split so the live inbound path and the REST history path number files identically. No cross-platform abstraction: the placeholder is platform-branded (`[Discord attachment #N: …]` vs `[Webex attachment #N: …]`) and the metadata differs per platform, so a generic helper would add indirection without preventing the omission — the two bot adapters had already established "export the classifier's describer, reuse it in the history mapper" as the in-repo pattern.

Webex is the one place a helper moved: `webex-classify` and `webex-bot-classify` carried byte-identical private copies of `splitInbound`/`filenameFromUrl`/`renderPlaceholder`, so the single implementation now lives in `webex-format`, which both already imported. That commit is a pure refactor with no behavior delta; the behavior change lands separately.

The Slack helper is deliberately placed in `slack-classify` rather than next to the history mapper, so the live inbound fix (see below) can adopt the identical rendering instead of forking a second one.

## Review notes

The load-bearing change is `src/channels/router.test.ts` → *"an id the agent reads in rendered channel_history output resolves to that ref"*. It wires the **real** Discord history callback and the **real** `channel_history` tool against a live router and asserts the id parsed out of the rendered text resolves via `lookupInboundAttachment`. Verified to fail in both directions:

- revert the adapter fix → fails
- delete `router.registerHistoryAttachments(...)` from the tool → fails

Please don't "simplify" that test's real callback into a fake — a fake history callback would have passed throughout this entire bug.

Both halves of that seam were already covered individually (`router.test.ts` history-attachment registry, the adapter callback tests). Only the seam between them was not, which is exactly where this shipped.

Not addressed, deliberately, each filed separately:

- **Slack live inbound is separately broken.** `slack-classify.ts:38` drops files-only events as `empty_text` and ignores files on text-bearing events, so a captionless Slack image is invisible live — even though `slack` registers a working fetch callback. Changes engagement and delivery behavior, so it needs its own PR and its own tests.
- **History attachment ids are ambiguous across a page.** Ids are per-message `index + 1` and `registerHistoryAttachments` dedups by id keeping the newest. A page with five messages each carrying `#1` renders five identical ids while only one resolves. Arguably worse than this bug, but the fix is router-owned session-stable ids keyed by message identity — renumbering within a page would still break under pagination.
- **`CHANNEL_MEDIA_PLACEHOLDER_RE` (`router.ts`) omits Webex** from its alternation, so live Webex placeholders already leak into quote anchors today. Pre-existing; history placeholders don't pass through quote-candidate capture, so this PR doesn't worsen it.
- **`discord.ts` `handleMessage` re-derives attachments inline** and overwrites the classifier's, near-identically. Cleanup, not required for recovery.

Discord labels every attachment `kind: 'file'` even for `image/webp`. Confirmed harmless: `look_at_channel_attachment` fetches by ref and builds the image part from the fetched MIME type, never from `kind`.

## What this does NOT do

- No change to any live inbound path — every adapter's `classifyInbound` behaves exactly as before.
- No change to the router's registry, id-allocation, or eviction policy.
- No new adapter capability, no config surface, no CLI surface.
- Does not touch `teams`, `line`, `instagram`, or `github`: they register no usable fetch-attachment callback, so a history placeholder there would advertise an id that can never resolve.
