### PR TITLE
Bound cron occurrences by a per-job timeout deadline

### DIFF
--- a/docs/content/docs/guides/first-cron.mdx
+++ b/docs/content/docs/guides/first-cron.mdx
@@ -89,6 +89,8 @@ An `exec` job runs a command instead of waking the agent:
 
 If a job is still running when its next scheduled time comes around, that next run is **skipped** for that one job — not queued up. A 25-minute job set to run every 15 minutes will run, skip, run, skip; it never piles up into a backlog. Other jobs keep firing on their own schedules independently.
 
+Each occurrence is also bounded by a one-hour deadline so a hung run cannot suppress that job forever. Set a larger positive `timeoutMs` on a job whose legitimate work needs more than an hour; when the deadline expires, that occurrence is aborted and the next scheduled occurrence can run.
+
 </Accordion>
 
 <Accordion title="Checking what's scheduled from the CLI">

--- a/docs/content/docs/reference/cron-json.mdx
+++ b/docs/content/docs/reference/cron-json.mdx
@@ -38,6 +38,7 @@ Lives at the agent folder root. Reloads live via `typeclaw reload`.
 | `scheduledByRole` | role name (string)    | yes      | role the firing session resolves as; required — rejected with an error if missing |
 | `enabled`         | `boolean`             | no       | defaults to `true`; set `false` to keep the entry but skip firing                 |
 | `timezone`        | IANA tz name (string) | no       | defaults to container `TZ` env (UTC if unset)                                     |
+| `timeoutMs`       | positive integer      | no       | per-occurrence deadline in milliseconds; defaults to 1 hour                       |
 
 ## `kind: "prompt"`
 
@@ -54,9 +55,9 @@ Lives at the agent folder root. Reloads live via `typeclaw reload`.
 
 ## Per-job coalescing
 
-If a job is still running when its next tick fires, the next tick is dropped for that specific job (and logged), not queued. Other jobs are unaffected.
+If a job is still running when its next tick fires, the next tick is dropped for that specific job (and logged), not queued. Other jobs are unaffected. Each occurrence has a one-hour deadline by default so a hung run cannot suppress that job forever; set `timeoutMs` on jobs that legitimately need longer.
 
-The scheduler is a pure clock — it just emits "this job's time has come" events. The consumer owns the per-`id` in-flight set.
+The scheduler is a pure clock — it just emits "this job's time has come" events. The consumer owns the per-`id` in-flight reservation.
 
 ## Limits
 

--- a/docs/content/docs/reference/plugin-api.mdx
+++ b/docs/content/docs/reference/plugin-api.mdx
@@ -131,6 +131,7 @@ type PluginPromptCronJob = {
   prompt: string
   enabled?: boolean
   timezone?: string
+  timeoutMs?: number // defaults to 1 hour
   subagent?: string // invoke a subagent instead of prompting
   payload?: unknown
 }
@@ -141,6 +142,7 @@ type PluginExecCronJob = {
   command: string[]
   enabled?: boolean
   timezone?: string
+  timeoutMs?: number // defaults to 1 hour
 }
 
 type PluginHandlerCronJob = {
@@ -149,10 +151,11 @@ type PluginHandlerCronJob = {
   handler: (ctx: CronHandlerContext) => Promise<void>
   enabled?: boolean
   timezone?: string
+  timeoutMs?: number // defaults to 1 hour
 }
 ```
 
-`kind: 'handler'` is plugin-only — a TypeScript function reference, so it cannot appear in `cron.json` (the schema gate limits user files to `prompt` and `exec`). Use it when a job needs imperative control flow (probe → maybe prompt → write file) in the same plugin as the logic. `CronHandlerContext` mirrors a command's LLM-call surface (`prompt`, `subagent`, `exec`) plus `jobId`, `name`, `agentDir`, `logger`, `signal`, `permissions`, and a cron-shaped `origin` that stamps provenance on anything the handler spawns.
+`kind: 'handler'` is plugin-only — a TypeScript function reference, so it cannot appear in `cron.json` (the schema gate limits user files to `prompt` and `exec`). Use it when a job needs imperative control flow (probe → maybe prompt → write file) in the same plugin as the logic. `CronHandlerContext` mirrors a command's LLM-call surface (`prompt`, `subagent`, `exec`) plus `jobId`, `name`, `agentDir`, `logger`, `signal`, `permissions`, and a cron-shaped `origin` that stamps provenance on anything the handler spawns. The signal aborts when the occurrence reaches its deadline.
 
 ### Skills
 

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -7,7 +7,7 @@ import type { AgentSession } from '@/agent'
 import type { HookBus } from '@/plugin'
 import { createStream } from '@/stream'
 
-import { createCronConsumer, type CronConsumerLogger, type CronSession } from './consumer'
+import { createCronConsumer, type CronConsumerClock, type CronConsumerLogger, type CronSession } from './consumer'
 import type { CronJob, ExecJob, PromptJob } from './schema'
 
 async function waitForFile(path: string): Promise<string> {
@@ -34,6 +34,15 @@ async function waitForCondition(predicate: () => boolean): Promise<void> {
 
 async function waitForConsumerIdle(consumer: ReturnType<typeof createCronConsumer>): Promise<void> {
   await waitForCondition(() => consumer.inFlightCount() === 0)
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
 }
 
 // Minimal AgentSession stub satisfying the surface the model-fallback helper
@@ -82,12 +91,13 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true })
 })
 
-const promptJob = (id: string, prompt: string): PromptJob => ({
+const promptJob = (id: string, prompt: string, overrides: Partial<PromptJob> = {}): PromptJob => ({
   id,
   schedule: '* * * * *',
   enabled: true,
   kind: 'prompt',
   prompt,
+  ...overrides,
 })
 
 const execJob = (id: string, command: string[]): ExecJob => ({
@@ -100,6 +110,39 @@ const execJob = (id: string, command: string[]): ExecJob => ({
 
 function publishCron(stream: ReturnType<typeof createStream>, job: CronJob): string {
   return stream.publish({ target: { kind: 'cron', jobId: job.id }, payload: job })
+}
+
+function createFakeClock(start = 1_000): CronConsumerClock & { advance: (ms: number) => Promise<void> } {
+  let now = start
+  let nextHandle = 1
+  const timers = new Map<number, { at: number; callback: () => void }>()
+  return {
+    now: () => now,
+    setTimeout: (callback, ms) => {
+      const handle = nextHandle++
+      timers.set(handle, { at: now + ms, callback })
+      return handle
+    },
+    clearTimeout: (handle) => {
+      timers.delete(handle)
+    },
+    advance: async (ms) => {
+      const target = now + ms
+      for (;;) {
+        const due = [...timers.entries()]
+          .filter(([, timer]) => timer.at <= target)
+          .sort(([, a], [, b]) => a.at - b.at)[0]
+        if (due === undefined) break
+        const [handle, timer] = due
+        timers.delete(handle)
+        now = timer.at
+        timer.callback()
+        await new Promise((resolve) => setImmediate(resolve))
+      }
+      now = target
+      await new Promise((resolve) => setImmediate(resolve))
+    },
+  }
 }
 
 function makeFakeSessionFactory(): {
@@ -282,6 +325,269 @@ describe('createCronConsumer', () => {
     expect(calls.length).toBeGreaterThanOrEqual(2)
     expect(calls.some((c) => c.startsWith('slow:') && c.includes('third'))).toBe(true)
 
+    consumer.stop()
+  })
+
+  test('bounds a hung occurrence and allows the next occurrence of that job to run', async () => {
+    const stream = createStream()
+    const clock = createFakeClock()
+    const infos: string[] = []
+    let calls = 0
+    let disposals = 0
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      clock,
+      createSessionForCron: async () => {
+        calls += 1
+        if (calls === 1) {
+          return {
+            prompt: async () => new Promise<void>(() => {}),
+            dispose: () => {
+              disposals += 1
+            },
+          }
+        }
+        return { prompt: async () => {} }
+      },
+      logger: { ...silentLogger, info: (message) => infos.push(message) },
+    })
+    consumer.start()
+    const job = promptJob('bounded', 'run', { timeoutMs: 100 })
+
+    publishCron(stream, job)
+    await new Promise((resolve) => setImmediate(resolve))
+    await clock.advance(100)
+    expect(consumer.inFlightCount()).toBe(0)
+    expect(disposals).toBe(1)
+
+    publishCron(stream, job)
+    await waitForConsumerIdle(consumer)
+
+    expect(calls).toBe(2)
+    expect(infos.some((line) => /run-start fire_id=/.test(line))).toBe(true)
+    expect(infos.some((line) => /run-end .*elapsed_ms=100 outcome=timeout/.test(line))).toBe(true)
+    expect(infos.some((line) => /run-end .*outcome=success/.test(line))).toBe(true)
+    consumer.stop()
+  })
+
+  test('does not prompt a session whose creation finishes after the occurrence deadline', async () => {
+    const stream = createStream()
+    const clock = createFakeClock()
+    let finishCreation: ((session: CronSession) => void) | undefined
+    let prompts = 0
+    let disposals = 0
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      clock,
+      createSessionForCron: async () =>
+        new Promise<CronSession>((resolve) => {
+          finishCreation = resolve
+        }),
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    publishCron(stream, promptJob('slow-create', 'run', { timeoutMs: 100 }))
+    await new Promise((resolve) => setImmediate(resolve))
+    await clock.advance(100)
+    finishCreation?.({
+      prompt: async () => {
+        prompts += 1
+      },
+      dispose: () => {
+        disposals += 1
+      },
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(prompts).toBe(0)
+    expect(disposals).toBe(1)
+    consumer.stop()
+  })
+
+  test('does not prompt after a turn-start hook finishes past the occurrence deadline', async () => {
+    const stream = createStream()
+    const clock = createFakeClock()
+    const hooks = fakeHooks([])
+    let finishTurnStart: (() => void) | undefined
+    let prompts = 0
+    let disposals = 0
+    hooks.runSessionTurnStart = async () =>
+      new Promise<void>((resolve) => {
+        finishTurnStart = resolve
+      })
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      clock,
+      createSessionForCron: async () => ({
+        prompt: async () => {
+          prompts += 1
+        },
+        hooks,
+        sessionId: 'slow-hook-session',
+        agentDir: root,
+        dispose: () => {
+          disposals += 1
+        },
+      }),
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    publishCron(stream, promptJob('slow-hook', 'run', { timeoutMs: 100 }))
+    await new Promise((resolve) => setImmediate(resolve))
+    await clock.advance(100)
+    finishTurnStart?.()
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(prompts).toBe(0)
+    expect(disposals).toBe(1)
+    consumer.stop()
+  })
+
+  test.skipIf(process.platform === 'win32')(
+    'kills a timed-out exec process group after the abort grace period',
+    async () => {
+      const stream = createStream()
+      const clock = createFakeClock()
+      const consumer = createCronConsumer({
+        stream,
+        cwd: root,
+        clock,
+        createSessionForCron: makeFakeSessionFactory().createSessionForCron,
+        logger: silentLogger,
+      })
+      consumer.start()
+      const script = [
+        'trap "" TERM',
+        'echo $$ > parent.pid',
+        `sh -c 'trap "" TERM; echo $$ > child.pid; while :; do sleep 1; done' &`,
+        'wait',
+      ].join('\n')
+
+      publishCron(stream, { ...execJob('stubborn-tree', ['sh', '-c', script]), timeoutMs: 100 })
+      const parentPid = Number((await waitForFile(join(root, 'parent.pid'))).trim())
+      const childPid = Number((await waitForFile(join(root, 'child.pid'))).trim())
+      await clock.advance(100)
+
+      expect(consumer.inFlightCount()).toBe(0)
+      expect(isProcessAlive(parentPid)).toBe(true)
+      expect(isProcessAlive(childPid)).toBe(true)
+
+      await clock.advance(5_000)
+      await waitForCondition(() => !isProcessAlive(parentPid) && !isProcessAlive(childPid))
+
+      consumer.stop()
+    },
+  )
+
+  test.skipIf(process.platform === 'win32')(
+    'keeps exec SIGKILL escalation when the parent exits but a resistant child survives',
+    async () => {
+      const stream = createStream()
+      const clock = createFakeClock()
+      const consumer = createCronConsumer({
+        stream,
+        cwd: root,
+        clock,
+        createSessionForCron: makeFakeSessionFactory().createSessionForCron,
+        logger: silentLogger,
+      })
+      consumer.start()
+      const script = [
+        `const child = Bun.spawn({ cmd: ['sh', '-c', 'trap "" TERM; while :; do sleep 1; done'], stdout: 'ignore', stderr: 'ignore' })`,
+        `await Bun.write('parent.pid', String(process.pid))`,
+        `await Bun.write('child.pid', String(child.pid))`,
+        `await child.exited`,
+      ].join('; ')
+
+      publishCron(stream, { ...execJob('exiting-parent', [process.execPath, '-e', script]), timeoutMs: 100 })
+      const parentPid = Number((await waitForFile(join(root, 'parent.pid'))).trim())
+      const childPid = Number((await waitForFile(join(root, 'child.pid'))).trim())
+      await clock.advance(100)
+      await waitForCondition(() => !isProcessAlive(parentPid))
+
+      expect(isProcessAlive(childPid)).toBe(true)
+
+      await clock.advance(5_000)
+      await waitForCondition(() => !isProcessAlive(childPid))
+
+      consumer.stop()
+    },
+  )
+
+  test('does not time out a long occurrence that finishes within its configured deadline', async () => {
+    const stream = createStream()
+    const clock = createFakeClock()
+    const infos: string[] = []
+    let release: (() => void) | undefined
+    let disposals = 0
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      clock,
+      createSessionForCron: async () => ({
+        prompt: async () =>
+          new Promise<void>((resolve) => {
+            release = resolve
+          }),
+        dispose: () => {
+          disposals += 1
+        },
+      }),
+      logger: { ...silentLogger, info: (message) => infos.push(message) },
+    })
+    consumer.start()
+
+    publishCron(stream, promptJob('long-valid', 'run', { timeoutMs: 1_000 }))
+    await new Promise((resolve) => setImmediate(resolve))
+    await clock.advance(900)
+    expect(consumer.inFlightCount()).toBe(1)
+    expect(disposals).toBe(0)
+
+    release?.()
+    await waitForConsumerIdle(consumer)
+
+    expect(disposals).toBe(1)
+    expect(infos.some((line) => /run-end .*elapsed_ms=900 outcome=success/.test(line))).toBe(true)
+    expect(infos.some((line) => /outcome=timeout/.test(line))).toBe(false)
+    consumer.stop()
+  })
+
+  test('skip logs identify the blocking fire and how long it has been active', async () => {
+    const stream = createStream()
+    const clock = createFakeClock()
+    const warnings: string[] = []
+    let release: (() => void) | undefined
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      clock,
+      createSessionForCron: async () => ({
+        prompt: async () =>
+          new Promise<void>((resolve) => {
+            release = resolve
+          }),
+      }),
+      logger: { ...silentLogger, warn: (message) => warnings.push(message) },
+    })
+    consumer.start()
+    const job = promptJob('busy-observable', 'run')
+
+    publishCron(stream, job)
+    await new Promise((resolve) => setImmediate(resolve))
+    await clock.advance(250)
+    publishCron(stream, job)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(warnings).toEqual([
+      expect.stringMatching(/busy-observable: previous run fire_id=.* active_for_ms=250, skipping/),
+    ])
+    release?.()
+    await waitForConsumerIdle(consumer)
     consumer.stop()
   })
 
@@ -801,7 +1107,7 @@ describe('createCronConsumer', () => {
     await new Promise((r) => setImmediate(r))
 
     // then
-    expect(warns).toEqual([expect.stringContaining('busy: previous run still in progress, skipping')])
+    expect(warns).toEqual([expect.stringMatching(/busy: previous run fire_id=.* active_for_ms=\d+, skipping/)])
 
     for (const r of resolvers) r()
     consumer.stop()
@@ -880,6 +1186,7 @@ describe('createCronConsumer model fallback', () => {
     try {
       const stream = createStream()
       const errors: string[] = []
+      const infos: string[] = []
       const attempted: string[] = []
       const consumer = createCronConsumer({
         stream,
@@ -895,7 +1202,7 @@ describe('createCronConsumer model fallback', () => {
             }),
           }
         },
-        logger: { ...silentLogger, error: (m) => errors.push(m) },
+        logger: { ...silentLogger, info: (m) => infos.push(m), error: (m) => errors.push(m) },
       })
       consumer.start()
 
@@ -907,6 +1214,7 @@ describe('createCronConsumer model fallback', () => {
       expect(attempted).toEqual(['openai/gpt-5.4-nano', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'])
       expect(errors.some((e) => /all 2 model\(s\) failed/.test(e))).toBe(true)
       expect(errors.some((e) => /down: fireworks/.test(e))).toBe(true)
+      expect(infos.some((line) => /run-end .*outcome=failed/.test(line))).toBe(true)
 
       consumer.stop()
     } finally {

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -557,6 +557,50 @@ describe('createCronConsumer', () => {
     consumer.stop()
   })
 
+  test('does not emit idle or retry when an aborted prompt settles after its deadline', async () => {
+    const stream = createStream()
+    const clock = createFakeClock()
+    const events: string[] = []
+    const hooks = fakeHooks(events)
+    let sessionsCreated = 0
+    let settlePrompt: (() => void) | undefined
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      clock,
+      createSessionForCron: async () => {
+        sessionsCreated += 1
+        return {
+          prompt: async () =>
+            new Promise<void>((resolve) => {
+              settlePrompt = resolve
+            }),
+          abort: async () => {
+            settlePrompt?.()
+          },
+          dispose: () => events.push('dispose'),
+          hooks,
+          sessionId: 'timed-out-session',
+          agentDir: root,
+        }
+      },
+      logger: silentLogger,
+    })
+    consumer.start()
+
+    publishCron(stream, promptJob('late-settlement', 'run', { timeoutMs: 100 }))
+    await new Promise((resolve) => setImmediate(resolve))
+    await clock.advance(100)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(sessionsCreated).toBe(1)
+    expect(events).toContain('end:timed-out-session')
+    expect(events).toContain('dispose')
+    expect(events.some((event) => event.startsWith('idle:'))).toBe(false)
+    expect(consumer.inFlightCount()).toBe(0)
+    consumer.stop()
+  })
+
   test('skip logs identify the blocking fire and how long it has been active', async () => {
     const stream = createStream()
     const clock = createFakeClock()

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -9,7 +9,7 @@ import type { Stream, Unsubscribe } from '@/stream'
 
 import type { CronJob, ExecJob, HandlerJob, PromptJob } from './schema'
 
-export type CronHandlerInvoker = (job: HandlerJob) => Promise<void>
+export type CronHandlerInvoker = (job: HandlerJob, signal: AbortSignal) => Promise<void>
 
 // `hooks`, `sessionId`, `agentDir`, and `getTranscriptPath` are optional so
 // test fakes can stay one-liners. When present, the consumer fires
@@ -21,6 +21,7 @@ export type CronHandlerInvoker = (job: HandlerJob) => Promise<void>
 // plugin's turn counter would miss cron-driven activity.
 export type CronSession = {
   prompt: (text: string) => Promise<void>
+  abort?: () => Promise<void>
   dispose?: () => void
   hooks?: HookBus
   sessionId?: string
@@ -63,7 +64,14 @@ export type CreateCronConsumerOptions = {
   // count. Optional so test fakes that don't exercise counts stay one-liners.
   countStore?: ConsumerCountStore
   now?: () => number
+  clock?: CronConsumerClock
   logger?: CronConsumerLogger
+}
+
+export type CronConsumerClock = {
+  now: () => number
+  setTimeout: (callback: () => void, ms: number) => number
+  clearTimeout: (handle: number) => void
 }
 
 export type ConsumerCountStore = {
@@ -85,6 +93,22 @@ const consoleLogger: CronConsumerLogger = {
   error: (m) => console.error(m),
 }
 
+const realClock: CronConsumerClock = {
+  now: Date.now,
+  setTimeout: (callback, ms) => setTimeout(callback, ms) as unknown as number,
+  clearTimeout: (handle) => clearTimeout(handle as unknown as ReturnType<typeof setTimeout>),
+}
+
+// A cron turn can legitimately spend many minutes researching, using tools,
+// and retrying providers, so this watchdog deliberately allows a full hour by
+// default. The deadline exists to recover from the qualitatively different
+// failure mode where session.prompt() never settles: without it, the per-job
+// reservation suppresses every later occurrence until container restart.
+// Operators with known longer workloads can widen only that job via timeoutMs;
+// other job ids remain independent throughout.
+export const DEFAULT_CRON_RUN_TIMEOUT_MS = 60 * 60 * 1_000
+const EXEC_ABORT_GRACE_MS = 5_000
+
 export function createCronConsumer({
   stream,
   cwd,
@@ -92,9 +116,11 @@ export function createCronConsumer({
   invokeHandler,
   countStore,
   now = Date.now,
+  clock,
   logger = consoleLogger,
 }: CreateCronConsumerOptions): CronConsumer {
-  const inFlight = new Set<string>()
+  const runClock = clock ?? (now === Date.now ? realClock : { ...realClock, now })
+  const inFlight = new Map<string, { fireId: string; startedAt: number }>()
   let unsubscribe: Unsubscribe | null = null
 
   return {
@@ -106,13 +132,20 @@ export function createCronConsumer({
           logger.warn(`[cron-consumer] received message ${msg.id} with invalid payload, ignoring`)
           return
         }
-        if (inFlight.has(job.id)) {
-          logger.warn(`[cron] ${job.id}: previous run still in progress, skipping`)
+        const blocking = inFlight.get(job.id)
+        if (blocking !== undefined) {
+          logger.warn(
+            `[cron] ${job.id}: previous run fire_id=${blocking.fireId} active_for_ms=${Math.max(0, runClock.now() - blocking.startedAt)}, skipping`,
+          )
           return
         }
         // Reserve before the count gate so two close occurrences can't both
         // pass the `firedCount < count` check before either increment lands.
-        inFlight.add(job.id)
+        const fireId = msg.id
+        const startedAt = runClock.now()
+        inFlight.set(job.id, { fireId, startedAt })
+        let runStarted = false
+        let outcome: 'success' | 'failed' | 'timeout' = 'success'
         try {
           if (job.count !== undefined && countStore !== undefined) {
             if (countStore.get(job.id, job) >= job.count) {
@@ -124,29 +157,37 @@ export function createCronConsumer({
             // correct tradeoff for a reminder versus over-firing on restart.
             // A false result means a reload removed/replaced the job while the
             // write was queued — skip dispatch so we never run stale config.
-            const accepted = await countStore.increment(job.id, job, now())
+            const accepted = await countStore.increment(job.id, job, runClock.now())
             if (!accepted) {
               logger.info(`[cron] ${job.id}: job no longer live, skipping dispatch`)
               return
             }
           }
-          if (job.kind === 'prompt') {
-            await runPrompt(job, createSessionForCron, stream, logger)
-          } else if (job.kind === 'exec') {
-            await runExec(job, cwd)
-          } else {
-            if (invokeHandler === undefined) {
-              throw new Error(
-                `handler job dispatched but no invokeHandler wired into the consumer (likely a misconfigured test or boot path)`,
-              )
-            }
-            await invokeHandler(job)
-          }
+          runStarted = true
+          logger.info(`[cron] ${job.id}: run-start fire_id=${fireId}`)
+          const control = createRunControl()
+          const work = dispatchJob(job, {
+            createSessionForCron,
+            stream,
+            logger,
+            cwd,
+            invokeHandler,
+            control,
+            clock: runClock,
+          })
+          await runWithDeadline(work, job.timeoutMs ?? DEFAULT_CRON_RUN_TIMEOUT_MS, control, runClock)
         } catch (err) {
+          outcome = err instanceof CronRunTimeoutError ? 'timeout' : 'failed'
           const message = err instanceof Error ? err.message : String(err)
-          logger.error(`[cron] ${job.id} failed: ${message}`)
+          if (outcome === 'timeout') logger.error(`[cron] ${job.id}: ${message}`)
+          else logger.error(`[cron] ${job.id} failed: ${message}`)
         } finally {
-          inFlight.delete(job.id)
+          if (runStarted) {
+            logger.info(
+              `[cron] ${job.id}: run-end fire_id=${fireId} elapsed_ms=${Math.max(0, runClock.now() - startedAt)} outcome=${outcome}`,
+            )
+          }
+          if (inFlight.get(job.id)?.fireId === fireId) inFlight.delete(job.id)
         }
       })
     },
@@ -160,11 +201,88 @@ export function createCronConsumer({
   }
 }
 
+type RunControl = {
+  signal: AbortSignal
+  setAbort: (abort: () => void) => () => void
+  abort: () => void
+}
+
+function createRunControl(): RunControl {
+  const controller = new AbortController()
+  let abortCurrent: (() => void) | null = null
+  return {
+    signal: controller.signal,
+    setAbort(abort) {
+      abortCurrent = abort
+      if (controller.signal.aborted) abort()
+      return () => {
+        if (abortCurrent === abort) abortCurrent = null
+      }
+    },
+    abort() {
+      controller.abort()
+      abortCurrent?.()
+    },
+  }
+}
+
+class CronRunTimeoutError extends Error {}
+
+async function runWithDeadline(
+  work: Promise<void>,
+  timeoutMs: number,
+  control: RunControl,
+  clock: CronConsumerClock,
+): Promise<void> {
+  const timedOut = Symbol('timed-out')
+  let handle: number | null = null
+  const deadline = new Promise<typeof timedOut>((resolve) => {
+    handle = clock.setTimeout(() => resolve(timedOut), timeoutMs)
+  })
+  try {
+    const result = await Promise.race([work.then(() => undefined), deadline])
+    if (result !== timedOut) return
+    control.abort()
+    throw new CronRunTimeoutError(`run timed out after ${timeoutMs}ms`)
+  } finally {
+    if (handle !== null) clock.clearTimeout(handle)
+  }
+}
+
+async function dispatchJob(
+  job: CronJob,
+  options: {
+    createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>
+    stream: Stream
+    logger: CronConsumerLogger
+    cwd: string
+    invokeHandler?: CronHandlerInvoker
+    control: RunControl
+    clock: CronConsumerClock
+  },
+): Promise<void> {
+  if (job.kind === 'prompt') {
+    await runPrompt(job, options.createSessionForCron, options.stream, options.logger, options.control)
+    return
+  }
+  if (job.kind === 'exec') {
+    await runExec(job, options.cwd, options.control, options.clock)
+    return
+  }
+  if (options.invokeHandler === undefined) {
+    throw new Error(
+      `handler job dispatched but no invokeHandler wired into the consumer (likely a misconfigured test or boot path)`,
+    )
+  }
+  await options.invokeHandler(job, options.control.signal)
+}
+
 async function runPrompt(
   job: PromptJob,
   createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>,
   stream: Stream,
   logger: CronConsumerLogger,
+  control: RunControl,
 ): Promise<void> {
   if (job.subagent !== undefined) {
     // Propagate the cron job's role and origin into the spawned subagent.
@@ -194,7 +312,7 @@ async function runPrompt(
   // chain; multi-ref configs (e.g. `"default": ["openai/...", "fireworks/..."]`)
   // drive the retry-on-failure loop inside `runPromptOnce`.
   const refs = resolveFallbackChain(getConfig().models, undefined)
-  await runPromptOnce(job, refs, createSessionForCron, logger)
+  await runPromptOnce(job, refs, createSessionForCron, logger, control)
 }
 
 async function runPromptOnce(
@@ -202,6 +320,7 @@ async function runPromptOnce(
   refs: ModelRef[],
   createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>,
   logger: CronConsumerLogger,
+  control: RunControl,
 ): Promise<void> {
   // Per-attempt lifecycle: every session we create gets full
   // turn-start → turn-end → session-end → dispose bracketing, regardless of
@@ -228,6 +347,50 @@ async function runPromptOnce(
               ...(created.origin !== undefined ? { origin: created.origin } : {}),
             }
           : undefined
+      let disposal: Promise<void> | null = null
+      let unregisterAbort = () => {}
+      const dispose = async (): Promise<void> => {
+        if (disposal !== null) return disposal
+        unregisterAbort()
+        disposal = (async () => {
+          if (created.hooks && turnEvent !== undefined) {
+            try {
+              await created.hooks.runSessionTurnEnd(turnEvent)
+            } catch (e) {
+              logger.warn(`[cron] ${job.id}: turn-end hook threw: ${describe(e)}`)
+            }
+          }
+          if (created.hooks && created.sessionId !== undefined) {
+            try {
+              await created.hooks.runSessionEnd({
+                sessionId: created.sessionId,
+                ...(created.origin !== undefined ? { origin: created.origin } : {}),
+              })
+            } catch (e) {
+              logger.warn(`[cron] ${job.id}: session-end hook threw: ${describe(e)}`)
+            }
+          }
+          created.dispose?.()
+        })()
+        return disposal
+      }
+      const abort = (): void => {
+        try {
+          const abortPromise = created.abort?.() ?? created.session?.abort()
+          void abortPromise?.catch((error) => logger.warn(`[cron] ${job.id}: session abort threw: ${describe(error)}`))
+        } catch (error) {
+          logger.warn(`[cron] ${job.id}: session abort threw: ${describe(error)}`)
+        }
+        void dispose()
+      }
+      unregisterAbort = control.setAbort(abort)
+      const throwIfAborted = async (): Promise<void> => {
+        if (!control.signal.aborted) return
+        unregisterAbort()
+        await dispose()
+        throw new Error('cron occurrence ended before prompting')
+      }
+      await throwIfAborted()
       // Per-turn memory injection for vector agents: the turn-start hook writes
       // the rendered memory block into `retrievalContext.results`, which we
       // append to the prompt text below (vector agents have no system-prompt
@@ -235,6 +398,7 @@ async function runPromptOnce(
       const retrievalContext = { results: '' }
       if (created.hooks && turnEvent !== undefined) {
         await created.hooks.runSessionTurnStart({ ...turnEvent, userPrompt: job.prompt, retrievalContext })
+        await throwIfAborted()
       }
       // Cron sessions are created fresh per fallback attempt, so the live getter
       // is still the creation-time default here — safe to read without a separate
@@ -242,6 +406,7 @@ async function runPromptOnce(
       if (created.session !== undefined) {
         applyTurnThinkingLevel(created.session, job.prompt, created.session.thinkingLevel)
       }
+      await throwIfAborted()
       // Bridge the CronSession wrapper into the AgentSession surface the
       // fallback helper expects:
       //   prompt    → CronSession.prompt (wrapper that calls AgentSession.prompt
@@ -264,26 +429,7 @@ async function runPromptOnce(
         // Per-attempt teardown. Fires turn.end and session.end for every
         // session created (success or failure), then disposes the underlying
         // resources. Hooks that throw are logged but don't prevent disposal.
-        dispose: async () => {
-          if (created.hooks && turnEvent !== undefined) {
-            try {
-              await created.hooks.runSessionTurnEnd(turnEvent)
-            } catch (e) {
-              logger.warn(`[cron] ${job.id}: turn-end hook threw: ${describe(e)}`)
-            }
-          }
-          if (created.hooks && created.sessionId !== undefined) {
-            try {
-              await created.hooks.runSessionEnd({
-                sessionId: created.sessionId,
-                ...(created.origin !== undefined ? { origin: created.origin } : {}),
-              })
-            } catch (e) {
-              logger.warn(`[cron] ${job.id}: session-end hook threw: ${describe(e)}`)
-            }
-          }
-          created.dispose?.()
-        },
+        dispose,
       }
     },
     onAttemptFailed: (attempt) => {
@@ -291,12 +437,14 @@ async function runPromptOnce(
         `[cron] ${job.id}: ${attempt.outcome} failure on ${attempt.ref}: ${attempt.errorMessage ?? 'unknown'}; falling back`,
       )
     },
+    shouldFailover: () => !control.signal.aborted,
   })
 
   if (!result.success) {
     logger.error(
       `[cron] ${job.id}: all ${result.attempts.length} model(s) failed; last error: ${result.lastError?.message ?? 'unknown'}`,
     )
+    throw result.lastError ?? new Error('all model attempts failed')
   }
 
   // session.idle fires once, only on success, and only against the session
@@ -326,7 +474,7 @@ function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-async function runExec(job: ExecJob, cwd: string): Promise<void> {
+async function runExec(job: ExecJob, cwd: string, control: RunControl, clock: CronConsumerClock): Promise<void> {
   const [cmd, ...args] = job.command
   if (!cmd) throw new Error(`exec job ${job.id}: empty command`)
   // Inject TYPECLAW_PARENT_ORIGIN_JSON so a child that proxies into the
@@ -351,11 +499,37 @@ async function runExec(job: ExecJob, cwd: string): Promise<void> {
       ...process.env,
       TYPECLAW_PARENT_ORIGIN_JSON: JSON.stringify(parentOrigin),
     },
+    detached: true,
   })
   const stderrText = new Response(proc.stderr).text()
-  const [code, stderr] = await Promise.all([proc.exited, stderrText])
+  let escalationTimer: number | null = null
+  let abortRequested = false
+  const unregisterAbort = control.setAbort(() => {
+    abortRequested = true
+    killProcessGroup(proc.pid, 'SIGTERM')
+    escalationTimer = clock.setTimeout(() => {
+      escalationTimer = null
+      killProcessGroup(proc.pid, 'SIGKILL')
+    }, EXEC_ABORT_GRACE_MS)
+  })
+  const [code, stderr] = await Promise.all([proc.exited, stderrText]).finally(() => {
+    unregisterAbort()
+    if (!abortRequested && escalationTimer !== null) clock.clearTimeout(escalationTimer)
+  })
   if (code !== 0) {
     throw new Error(`exec job ${job.id} exited with code ${code}: ${stderr.trim() || 'no stderr'}`)
+  }
+}
+
+function killProcessGroup(pid: number, signal: 'SIGTERM' | 'SIGKILL'): void {
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // The process already exited.
+    }
   }
 }
 

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -420,8 +420,14 @@ async function runPromptOnce(
       // regular method that reads `this._eventListeners`. Destructuring drops
       // the receiver.
       const sessionForHelper: AgentSession = {
-        prompt: (text: string) =>
-          created.prompt(retrievalContext.results.length > 0 ? `${text}\n\n${retrievalContext.results}` : text),
+        prompt: async (text: string) => {
+          await created.prompt(retrievalContext.results.length > 0 ? `${text}\n\n${retrievalContext.results}` : text)
+          // A deadline may win the race while abort is still unwinding the
+          // provider call. Never let that late settlement look successful:
+          // promptWithFallback would otherwise emit session.idle after this
+          // occurrence already emitted session.end and released its job slot.
+          if (control.signal.aborted) throw new Error('cron occurrence aborted after deadline')
+        },
         subscribe: created.session?.subscribe.bind(created.session) ?? (() => () => {}),
       } as unknown as AgentSession
       return {
@@ -453,6 +459,7 @@ async function runPromptOnce(
   // live session before tearing it down). Failed-chain disposal is already
   // handled by the helper's per-attempt dispose calls.
   if (result.success && lastSession !== null) {
+    if (control.signal.aborted) return
     const finalSession: CronSession = lastSession
     if (finalSession.hooks && finalSession.sessionId !== undefined) {
       try {

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -14,11 +14,13 @@ export { aggregateCronList, type CronListEntry, type CronListSource } from './li
 export {
   cronFileSchema,
   cronJobSchema,
+  cronRunTimeoutMsSchema,
   type CronFile,
   type CronJob,
   type CronParseWarning,
   type ExecJob,
   type HandlerJob,
+  MAX_CRON_RUN_TIMEOUT_MS,
   parseCronJson,
   type ParseCronMode,
   type ParseCronResult,

--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -75,6 +75,7 @@ type PromptOverrides = {
   prompt?: string
   subagent?: string
   payload?: unknown
+  timeoutMs?: number
 }
 type ExecOverrides = { enabled?: boolean; timezone?: string; command?: string[] }
 
@@ -87,6 +88,7 @@ const promptJob = (id: string, schedule: string, overrides: PromptOverrides = {}
   ...(overrides.timezone !== undefined && { timezone: overrides.timezone }),
   ...(overrides.subagent !== undefined && { subagent: overrides.subagent }),
   ...(overrides.payload !== undefined && { payload: overrides.payload }),
+  ...(overrides.timeoutMs !== undefined && { timeoutMs: overrides.timeoutMs }),
 })
 
 const execJob = (id: string, schedule: string, overrides: ExecOverrides = {}): CronJob => ({
@@ -390,6 +392,23 @@ describe('Scheduler.replaceJobs', () => {
     expect(diff.updated.map((j) => j.id).sort()).toEqual(['payload-change', 'plain-to-subagent', 'subagent-rename'])
     expect(diff.unchanged.map((j) => j.id)).toEqual(['untouched'])
 
+    scheduler.stop()
+  })
+
+  test('treats a per-job timeout change as an update', () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const scheduler = createScheduler({
+      jobs: [promptJob('bounded', '* * * * *', { timeoutMs: 60_000 })],
+      onFire: recorder.onFire,
+      clock,
+      logger: silentLogger,
+    })
+    scheduler.start()
+
+    const diff = scheduler.replaceJobs([promptJob('bounded', '* * * * *', { timeoutMs: 120_000 })])
+
+    expect(diff.updated.map((job) => job.id)).toEqual(['bounded'])
     scheduler.stop()
   })
 

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -203,6 +203,7 @@ function jobFingerprint(job: CronJob): string {
     count: job.count ?? null,
     enabled: job.enabled,
     timezone: job.timezone ?? null,
+    timeoutMs: job.timeoutMs ?? null,
     kind: job.kind,
     payload: jobPayload(job),
   })

--- a/src/cron/schema.test.ts
+++ b/src/cron/schema.test.ts
@@ -44,6 +44,36 @@ describe('cronFileSchema', () => {
     expect(parsed.jobs[0]?.enabled).toBe(false)
   })
 
+  test('accepts a positive per-job timeoutMs override', () => {
+    const parsed = cronFileSchema.parse({
+      jobs: [{ id: 'j', schedule: '* * * * *', kind: 'prompt', prompt: 'x', timeoutMs: 7_200_000 }],
+    })
+    expect(parsed.jobs[0]?.timeoutMs).toBe(7_200_000)
+  })
+
+  test('rejects a non-positive or fractional timeoutMs', () => {
+    expect(() =>
+      cronFileSchema.parse({ jobs: [{ id: 'j', schedule: '* * * * *', kind: 'prompt', prompt: 'x', timeoutMs: 0 }] }),
+    ).toThrow()
+    expect(() =>
+      cronFileSchema.parse({ jobs: [{ id: 'j', schedule: '* * * * *', kind: 'prompt', prompt: 'x', timeoutMs: 1.5 }] }),
+    ).toThrow()
+  })
+
+  test('accepts the largest safe timer delay and rejects an overflowing timeoutMs', () => {
+    const maximum = 2_147_483_647
+    expect(() =>
+      cronFileSchema.parse({
+        jobs: [{ id: 'j', schedule: '* * * * *', kind: 'prompt', prompt: 'x', timeoutMs: maximum }],
+      }),
+    ).not.toThrow()
+    expect(() =>
+      cronFileSchema.parse({
+        jobs: [{ id: 'j', schedule: '* * * * *', kind: 'prompt', prompt: 'x', timeoutMs: maximum + 1 }],
+      }),
+    ).toThrow(/timeoutMs must be at most 2147483647/)
+  })
+
   test('rejects missing id', () => {
     expect(() => cronFileSchema.parse({ jobs: [{ schedule: '* * * * *', kind: 'prompt', prompt: 'x' }] })).toThrow()
   })

--- a/src/cron/schema.ts
+++ b/src/cron/schema.ts
@@ -6,6 +6,12 @@ import { validateSubagentPayload } from '@/agent/subagents'
 import type { CronHandlerContext } from '@/plugin/types'
 
 const idPattern = /^[a-zA-Z0-9_-]+$/
+export const MAX_CRON_RUN_TIMEOUT_MS = 2_147_483_647
+export const cronRunTimeoutMsSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(MAX_CRON_RUN_TIMEOUT_MS, `timeoutMs must be at most ${MAX_CRON_RUN_TIMEOUT_MS}`)
 
 const baseJob = z.object({
   id: z.string().min(1).regex(idPattern, 'id must contain only letters, digits, hyphens, or underscores'),
@@ -23,6 +29,7 @@ const baseJob = z.object({
   count: z.number().int().positive().optional(),
   enabled: z.boolean().default(true),
   timezone: z.string().optional(),
+  timeoutMs: cronRunTimeoutMsSchema.optional(),
   scheduledByRole: z.string().optional(),
   // Audit snapshot of the SessionOrigin that scheduled this job. Persisted
   // as opaque z.unknown() because SessionOrigin is recursive (a cron origin

--- a/src/plugin/registry.test.ts
+++ b/src/plugin/registry.test.ts
@@ -146,6 +146,34 @@ describe('registerContributions', () => {
     }
   })
 
+  test('preserves timeout overrides for every plugin cron job kind', () => {
+    const opts = makeOptions('bounded-work', {
+      cronJobs: {
+        prompt: { schedule: '* * * * *', kind: 'prompt', prompt: 'run', timeoutMs: 1_000 },
+        exec: { schedule: '* * * * *', kind: 'exec', command: ['run'], timeoutMs: 2_000 },
+        handler: { schedule: '* * * * *', kind: 'handler', handler: async () => {}, timeoutMs: 3_000 },
+      },
+    })
+    registerContributions(opts)
+
+    expect(opts.registry.cronJobs.map(({ job }) => [job.kind, job.timeoutMs])).toEqual([
+      ['prompt', 1_000],
+      ['exec', 2_000],
+      ['handler', 3_000],
+    ])
+  })
+
+  test('rejects invalid plugin cron timeout overrides', () => {
+    for (const timeoutMs of [0, 1.5, 2_147_483_648]) {
+      const opts = makeOptions('invalid-timeout', {
+        cronJobs: {
+          job: { schedule: '* * * * *', kind: 'prompt', prompt: 'run', timeoutMs },
+        },
+      })
+      expect(() => registerContributions(opts)).toThrow(/timeoutMs/)
+    }
+  })
+
   test('records plugin commands declared on DefinedPlugin', () => {
     const cmd = defineCommand({
       surface: 'host',

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs'
 import { z } from 'zod'
 
 import { BUILTIN_COMMAND_NAMES } from '@/cli/builtins'
-import type { CronJob, PromptJob } from '@/cron'
+import { cronRunTimeoutMsSchema, type CronJob, type PromptJob } from '@/cron'
 
 import type { HookBus } from './hooks'
 import type {
@@ -244,6 +244,7 @@ function toCronJob(globalId: string, spec: PluginCronJob): CronJob {
   // would lose every security bypass. Hand-authored cron.json entries take
   // a different path and must declare scheduledByRole explicitly.
   const scheduledByRole: PromptJob['scheduledByRole'] = 'owner'
+  const timeoutMs = parsePluginCronTimeout(globalId, spec.timeoutMs)
   if (spec.kind === 'prompt') {
     const job: PromptJob = {
       id: globalId,
@@ -253,6 +254,7 @@ function toCronJob(globalId: string, spec: PluginCronJob): CronJob {
       prompt: spec.prompt,
       scheduledByRole,
       ...(spec.timezone !== undefined ? { timezone: spec.timezone } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(spec.subagent !== undefined ? { subagent: spec.subagent } : {}),
       ...(spec.payload !== undefined ? { payload: spec.payload } : {}),
     }
@@ -267,6 +269,7 @@ function toCronJob(globalId: string, spec: PluginCronJob): CronJob {
       command: spec.command,
       scheduledByRole,
       ...(spec.timezone !== undefined ? { timezone: spec.timezone } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     }
   }
   return {
@@ -277,5 +280,15 @@ function toCronJob(globalId: string, spec: PluginCronJob): CronJob {
     handler: spec.handler,
     scheduledByRole,
     ...(spec.timezone !== undefined ? { timezone: spec.timezone } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
   }
+}
+
+function parsePluginCronTimeout(globalId: string, timeoutMs: number | undefined): number | undefined {
+  if (timeoutMs === undefined) return undefined
+  const parsed = cronRunTimeoutMsSchema.safeParse(timeoutMs)
+  if (parsed.success) return parsed.data
+  throw new Error(
+    `plugin cron job "${globalId}" has invalid timeoutMs: ${parsed.error.issues[0]?.message ?? 'invalid value'}`,
+  )
 }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -79,6 +79,7 @@ export type PluginPromptCronJob = {
   prompt: string
   enabled?: boolean
   timezone?: string
+  timeoutMs?: number
   subagent?: string
   payload?: unknown
 }
@@ -89,6 +90,7 @@ export type PluginExecCronJob = {
   command: string[]
   enabled?: boolean
   timezone?: string
+  timeoutMs?: number
 }
 
 // In-process handler. Invoked directly by the cron consumer; no shell-out, no
@@ -107,6 +109,7 @@ export type PluginHandlerCronJob = {
   handler: (ctx: CronHandlerContext) => Promise<void>
   enabled?: boolean
   timezone?: string
+  timeoutMs?: number
 }
 
 export type PluginCronJob = PluginPromptCronJob | PluginExecCronJob | PluginHandlerCronJob
@@ -116,14 +119,10 @@ export type PluginCronJob = PluginPromptCronJob | PluginExecCronJob | PluginHand
 // CLI-shaped fields (stdin/stdout/stderr, args, exit code) because cron has
 // no caller to pipe to.
 //
-// `signal` is reserved for future cancellation and is currently never aborted
-// by the runtime — the consumer matches the existing prompt/exec cron jobs
-// which also let in-flight work finish on container shutdown. The signal IS
-// already threaded into `ctx.prompt` and `ctx.exec`, so the moment the
-// runtime starts aborting it (e.g. via a future graceful-shutdown path),
-// propagation works without handler-author changes. Handler authors who
-// want to respect future cancellation should still check `ctx.signal.aborted`
-// in long-running loops; nothing fires it today.
+// `signal` aborts when the occurrence reaches its per-job `timeoutMs` or the
+// runtime's default cron deadline. `ctx.prompt` and `ctx.exec` propagate it
+// automatically. Custom async work and long-running loops must cooperate by
+// checking the signal or passing it to abort-aware APIs.
 //
 // `origin` is a cron-shaped SessionOrigin so any session the handler spawns
 // via `ctx.prompt` carries the cron job's provenance — same role-inheritance

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -684,12 +684,11 @@ async function startAgentRuntime(
       // the unreachable case where a fire somehow predates the holder.
       increment: (id, job, at) => cronCountStore?.increment(id, job, at) ?? Promise.resolve(false),
     },
-    invokeHandler: async (job) => {
+    invokeHandler: async (job, signal) => {
       const snap = pluginRuntime.get()
       const registered = snap.registry.cronJobs.find((j) => j.globalId === job.id)
       const pluginName = registered?.pluginName ?? '<unknown>'
       const logger = createPluginLogger(pluginName)
-      const abortController = new AbortController()
       const origin: SessionOrigin = {
         kind: 'cron',
         jobId: job.id,
@@ -702,7 +701,7 @@ async function startAgentRuntime(
         name: pluginName,
         agentDir: cwd,
         logger,
-        signal: abortController.signal,
+        signal,
         permissions: pluginsLoaded.permissions,
         origin,
         prompt: (text: string) =>
@@ -712,7 +711,7 @@ async function startAgentRuntime(
             runtime: pluginRuntime,
             agentDir: cwd,
             permissions: pluginsLoaded.permissions,
-            signal: abortController.signal,
+            signal,
             runtimeVersion: runtimeVersionOpt.runtimeVersion,
             containerName: containerNameOpt.containerName,
             sessionFactory,
@@ -724,7 +723,7 @@ async function startAgentRuntime(
             spawnedByOrigin: origin,
           }),
         exec: (strings: TemplateStringsArray, ...values: unknown[]) =>
-          runExecForCommand(strings, values, { cwd, signal: abortController.signal }),
+          runExecForCommand(strings, values, { cwd, signal }),
       }
       await job.handler(ctx)
     },
@@ -784,6 +783,7 @@ async function startAgentRuntime(
       })
       return {
         prompt: (text) => session.prompt(text),
+        abort: () => session.abort(),
         dispose: () => {
           liveSessionRegistry.unregister(sessionId)
           session.dispose()

--- a/src/skills/typeclaw-cron/SKILL.md
+++ b/src/skills/typeclaw-cron/SKILL.md
@@ -15,7 +15,7 @@ This is a **best-effort scheduler**. Concretely:
 
 - **Missed ticks are not replayed.** If the container was down at 23:30 and starts at 23:45, the 23:30 fire is lost forever.
 - **Overlapping fires are skipped, not queued.** If a job is still running when its next tick arrives, the new tick is dropped (logged) and the next attempt is the tick after that.
-- **There are no retries, no timeouts, no failure hooks.** A job that throws is logged and forgotten until its next scheduled fire.
+- **There are no retries or failure hooks.** Each occurrence has a one-hour deadline by default; a timeout aborts that occurrence and the next scheduled fire can run normally. Use `timeoutMs` for a known longer workload.
 
 Tell the user this if they ask about reliability. Do not invent guarantees the runtime does not give them.
 
@@ -25,15 +25,16 @@ Tell the user this if they ask about reliability. Do not invent guarantees the r
 
 ### Shared fields (all jobs)
 
-| Field      | Required     | Notes                                                                                                                                           |
-| ---------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`       | yes          | Unique. Letters, digits, hyphens, underscores. Used in logs and to coalesce.                                                                    |
-| `schedule` | one of these | Standard 5-field cron expression (`min hr dom mon dow`) or 6-field with seconds. Recurring. See "Schedule syntax" below.                        |
-| `at`       | one of these | One-shot ISO instant — fires **once** then retires. Mutually exclusive with `schedule`; set exactly one. See "One-shot reminders (`at`)" below. |
-| `until`    | no           | Recurring only. Absolute ISO instant; last allowed fire (inclusive). The job retires after this.                                                |
-| `count`    | no           | Recurring only. Stop after N accepted fires. Coexists with `until` — whichever boundary is reached first wins.                                  |
-| `enabled`  | no           | Defaults to `true`. Set to `false` to keep a job in the file but skip it.                                                                       |
-| `timezone` | no           | IANA name like `Asia/Seoul`. Recurring (`schedule`) only — NOT valid with `at`. Defaults to UTC (the container's timezone).                     |
+| Field       | Required     | Notes                                                                                                                                           |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | yes          | Unique. Letters, digits, hyphens, underscores. Used in logs and to coalesce.                                                                    |
+| `schedule`  | one of these | Standard 5-field cron expression (`min hr dom mon dow`) or 6-field with seconds. Recurring. See "Schedule syntax" below.                        |
+| `at`        | one of these | One-shot ISO instant — fires **once** then retires. Mutually exclusive with `schedule`; set exactly one. See "One-shot reminders (`at`)" below. |
+| `until`     | no           | Recurring only. Absolute ISO instant; last allowed fire (inclusive). The job retires after this.                                                |
+| `count`     | no           | Recurring only. Stop after N accepted fires. Coexists with `until` — whichever boundary is reached first wins.                                  |
+| `enabled`   | no           | Defaults to `true`. Set to `false` to keep a job in the file but skip it.                                                                       |
+| `timezone`  | no           | IANA name like `Asia/Seoul`. Recurring (`schedule`) only — NOT valid with `at`. Defaults to UTC (the container's timezone).                     |
+| `timeoutMs` | no           | Positive integer occurrence deadline in milliseconds. Defaults to 1 hour. Increase only for work that legitimately needs longer.                |
 
 **`schedule` XOR `at`:** every job has exactly one of `schedule` (recurring) or `at` (one-shot). Setting both, or neither, is rejected. `at` jobs may not set `until`, `timezone`, or `count` > 1 (the instant already pins the single fire).
 
@@ -409,7 +410,7 @@ If you finished an edit and the user only sees an in-flight job from the previou
 - **Do not edit `cron.json` from inside an `exec` job's `command`.** Exec jobs run without an LLM and have no way to call the `reload` tool, so the file mutation will not take effect until something else triggers a reload. If you genuinely need scheduled cron-management, write a `prompt` job whose prompt is "edit cron.json to ..." and let the prompt-fire's session call `reload` itself.
 - **Do not put secrets in `prompt` or `command`.** `cron.json` is committed to git. Reference env vars or files instead (`["sh", "-c", "curl -H \"Authorization: Bearer $TOKEN\" ..."]`).
 - **Do not promise sub-second precision or guaranteed execution.** This is best-effort — see "What cron actually does" above.
-- **Do not invent fields the schema doesn't support** (no `retry`, `timeout`, `onFailure`, `concurrency`, etc.). They will be silently ignored at best, or rejected at worst.
+- **Do not invent fields the schema doesn't support** (no `retry`, `timeout`, `onFailure`, `concurrency`, etc.). Use the supported `timeoutMs` field for an occurrence deadline.
 
 ## When the user says "every X" or "do X once"
 

--- a/src/skills/typeclaw-plugins/SKILL.md
+++ b/src/skills/typeclaw-plugins/SKILL.md
@@ -330,7 +330,7 @@ type CronHandlerContext = {
   readonly name: string // plugin name that registered the job
   readonly agentDir: string // /agent in container
   readonly logger: PluginLogger
-  readonly signal: AbortSignal // reserved for future cancellation; currently inert
+  readonly signal: AbortSignal // aborts when this cron occurrence reaches its deadline
   readonly permissions: PermissionService // live service — has() gating, see "permissions: [...] — declaring and gating" in §5.7 below
   readonly origin: SessionOrigin // { kind: 'cron', jobKind: 'handler', ... }
   readonly prompt: (text: string) => Promise<string> // full agent session, slim system prompt mode


### PR DESCRIPTION
## Correction (2026-08-31)

**This PR does NOT fix the 2026-08-28 outage**, and the specific "wedged forever" scenario in the Background section below did not happen. This PR was opened during the investigation of that outage on the hypothesis that a hung cron run had wedged the `swmaestro-summary` job's `inFlight` reservation, permanently suppressing later fires. Host logs, not available at the time, show the cron job never wedged: it fired every 30 minutes across the whole window, including hours after the suspected wedge. The ~50% apparent skip rate was a plugin-level activity gate ("no recent Webex activity or opensoma notices — skipping"), not a cron failure. See the full retraction and assessment in the PR comment.

The proven root cause of the 08-28 outage was an unrelated mechanism: a poisoned Discord channel session that stayed registered as live after going structurally dead. That's tracked in **#184** ("In-memory poisoned channel session can outlive its restart-only escape hatch," reopened), fix in review at **#1413** ("Gate poisoned-session recovery on fingerprint").

**Does the underlying fix still stand on its own?** The property this PR guards against is real and verifiable independent of this incident: `src/cron/consumer.ts` only clears `inFlight` in the `finally` block after a run completes, and cron's `session.prompt()` call (`src/agent/model-fallback.ts`) has no timeout of its own. A run that genuinely never settles — a hung provider call, a stuck exec child — would wedge that job id indefinitely with no recovery short of a container restart. It just isn't what happened on 08-28. See the PR comment for the maintainer decision this needs: keep as defense-in-depth with the corrected rationale, or close.

---

## Background

A hung cron occurrence never released the per-job in-flight reservation. `session.prompt()` (or an exec child or handler) that never settled left `inFlight` holding that job id forever, so every later occurrence of the same job was skipped until container restart.

## Summary

- Add a positive per-job `timeoutMs` override with a one-hour global default.
- Abort or dispose only the expired occurrence and release only its job-id reservation, preserving overlap between different jobs.
- Log run start with `fire_id`, run end with `fire_id`, `elapsed_ms`, and `outcome`, and coalesced skips with the blocking fire id and `active_for_ms`.
- Treat timeout-only edits as scheduler updates and document the deadline across cron and plugin guidance.
- Prevent late prompt settlement after abort from emitting `session.idle` or triggering fallback after the timed-out occurrence has released its slot.

## Why one hour

Cron prompts can legitimately spend many minutes researching, using tools, and retrying providers. One hour is deliberately generous: the deadline recovers runs that never settle without aggressively killing normal long work. Jobs known to need longer can widen `timeoutMs` independently.

## Tests

Both required directions are covered with injected clocks rather than real sleeps:

1. A hung occurrence reaches its deadline, is disposed, releases its reservation, and the next occurrence of the same job runs.
2. A long-running occurrence that finishes before its configured deadline is not killed and completes successfully.

Additional coverage checks schema bounds, deadline-only reload fingerprinting, cross-job concurrency, skip duration logs, success/failure/timeout completion logs, and late settlement after abort.

## Verification

- `bun run typecheck`
- `bun run lint` — 0 errors (existing warnings only)
- `bun run format` and `bun run format:check`
- `bun run test src/cron` — 201 pass
- `bun run test` — 13,310 pass / 31 skip / 0 fail
</content>
