### PR TITLE
Generalize Korean -(으)ㄹ게 volitional across 하/보/두/놓/드리

### DIFF
--- a/src/channels/continuation-willingness.test.ts
+++ b/src/channels/continuation-willingness.test.ts
@@ -58,6 +58,31 @@ describe('detectContinuationWillingness — positive (self-directed future inten
     '바로 티켓 AC 업데이트하겠습니다 🙏',
     '설정 값 수정하겠습니다.',
     '업데이트할게요',
+    // Open X하다 class reached by the -(으)ㄹ게 morpheme pass, not by any table entry.
+    // Enumeration could never cover these: every new action verb a user invents
+    // ("머지", "롤백", "재시작") composes with 하다 and inherits 할게 for free.
+    '바로 배포할게요',
+    '이 브랜치 롤백할게',
+    '충돌만 정리하고 머지할게요',
+    '컨테이너 재시작할게요.',
+    '그 파일 삭제할게',
+    // The remaining -겠 stems in their -(으)ㄹ게 form: 두 → 둘게, 놓 → 놓을게.
+    '크론 타이밍 반영해둘게요',
+    '설정 값 미리 맞춰놓을게',
+    // Playful -용 politeness particle, and banmal mid-sentence continuation.
+    '배포할게용',
+    '배포할게 지금 바로',
+    // 드리 humble auxiliary, the one -(으)ㄹ게 stem outside the -겠 set.
+    '알려드릴게요',
+    '나머지는 제가 정리해서 알려드릴게',
+    // 안 that opens or closes an unrelated word must not read as negation. 안내/안전
+    // start one, 방안/제안 end one; all four carry a genuine promise.
+    '안내해드릴게요',
+    '안전하게 배포할게요',
+    '방안 확인할게요',
+    '제안 확인할게요',
+    // A negator binds only its own verb — the promise in the following clause stands.
+    '배포는 안 하고 확인만 할게요',
   ]
 
   for (const text of willing) {
@@ -238,6 +263,46 @@ describe('detectContinuationWillingness — negative (final / descriptive / othe
     '잘 모르겠어.',
     // Descriptive casual past — an already-done report, not a promise to act.
     '이미 확인했어, 문제 없어.',
+    // -게 forms that are NOT the volitional ending. These are why the ㄹ게 pattern is
+    // anchored to the 하/보/두/놓 stems instead of matching any ㄹ-batchim syllable:
+    // the adverbial -게 sits on a bare adjective stem (힘들게/길게/멀게), 별게 is a noun
+    // + 이, and -게 되다/만들다 is a change-of-state auxiliary. All are clause-medial,
+    // so a sentence-final lookahead would NOT have excluded them — the space after 게
+    // is one character wide and a lookahead cannot see past it.
+    '힘들게 찾았지만 결국 됐어요.',
+    '로그가 길게 나와서 잘라서 봤어요.',
+    '그건 별게 아니에요.',
+    '이제야 원인을 알게 되었습니다.',
+    '멀게 느껴지실 수 있어요.',
+    // 것이 contraction — 할 게 is two tokens ("things to do"), not the 할게 ending.
+    '아직 할 게 많이 남았습니다.',
+    // Genuine first-person -(으)ㄹ게 volitionals that promise the OPPOSITE of
+    // continuation, or no work at all. They are excluded by the stem anchor: 마치/쉬/
+    // 기다리 are not 하/보/두/놓.
+    '그럼 여기서 마칠게요.',
+    '답변 기다릴게요.',
+    // Permission-seeking question — awaits the user rather than committing to act,
+    // mirroring the Japanese 〜ますか guard.
+    '그럼 제가 배포할게요?',
+    // Reported speech — the promise belongs to someone else, not the agent.
+    '리뷰어가 "배포할게요"라고 했습니다.',
+    // Short negation 안/못 inverts the promise. These must stay false for enumerated
+    // verbs too, which is why no -게 form remains in the phrase table: a table hit
+    // returns before the negation strip and the guards ever run.
+    '네, 배포 안 할게요',
+    '그건 안 볼게요',
+    '지금은 안 해볼게요',
+    '안 업데이트할게요',
+    '그 브랜치는 안할게',
+    // Long negation -지 않을게요 — excluded structurally, 않을게 is not a stem.
+    '배포하지 않을게요',
+    // The negated -겠 sibling, same inversion.
+    '배포 안 하겠습니다',
+    // Question and quotative forms of verbs that used to sit in the phrase table and
+    // therefore short-circuited both guards.
+    '제가 처리할게요?',
+    '리뷰어가 "확인할게요"라고 했습니다.',
+    '알려드릴게요?',
     '',
     '...',
   ]

--- a/src/channels/continuation-willingness.ts
+++ b/src/channels/continuation-willingness.ts
@@ -104,47 +104,33 @@ const EN_PHRASES: readonly string[] = [
   'gimme a sec',
 ]
 
-// Korean: the -겠습니다/-겠어요 and -ㄹ게(요) verb endings are first-person
+// Korean: the -겠습니다/-겠어요 and -(으)ㄹ게(요) verb endings are first-person
 // volitional — they cannot address the listener, so they are safe self-direction
-// anchors. The -겠습니다/-겠어요 form is matched by MORPHEME_PATTERNS below (it
-// generalizes across all action verbs), so only the -ㄹ게 forms and stall idioms
-// are enumerated here. Each entry is the CASUAL (banmal) -게 base; the polite -게요
-// / -게여 forms match too because the substring pass tests `includes` (볼게 ⊂
-// 볼게요). Enumerating the casual base is deliberate over a broad `[ㄹ-final]게`
-// morpheme regex: that would also fire on the adverbial -게 of adjective stems
-// (힘들게 "hard-ly", 멀게 "far-ly", 길게 "long-ly"), violating the file's
-// prefer-false-negatives bias. Bare adverb+noun fragments ("바로 확인", "계속 확인")
-// are still excluded: without the -게 volitional they match other-directed requests
+// anchors. BOTH are matched by MORPHEME_PATTERNS below, stem-anchored to the same
+// action/auxiliary stems, so they generalize across every verb built on them. No
+// -게 form is enumerated here at all: an entry in this table would SHORT-CIRCUIT
+// the morpheme pass, because the substring pass returns before it runs, and the
+// negation / question / quotative guards that make the morpheme pass safe would
+// never execute. A table entry 처리할게 is what made 제가 처리할게요? report
+// willingness despite the question guard. Only the stall idioms — which have no
+// verb to negate or question — remain.
+//
+// The stem anchor is what keeps this narrow. A broad `[ㄹ-final]게` regex was
+// rejected: it fires on the adverbial -게 of adjective stems (힘들게 "hard-ly",
+// 멀게 "far-ly", 길게 "long-ly"), on the noun 별게 ("별게 아니에요" = "it's nothing"),
+// and on the -게 되다/만들다 construction (알게 되었습니다 = "I came to know") — none
+// of which promise work. Requiring the -게 be sentence-final does NOT rescue it,
+// because every one of those confusables is followed by a SPACE, so a lookahead
+// cannot see past it. Worse, an open-class rule also admits genuine volitionals
+// that mean the OPPOSITE of continuation (여기서 마칠게요 "I'll stop here", 이제
+// 쉴게요 "I'll rest now"), violating the file's prefer-false-negatives bias.
+//
+// Bare adverb+noun fragments ("바로 확인", "계속 확인") are still excluded: without
+// the -게 volitional they match other-directed requests
 // ("바로 확인 부탁드려요" = "please check") and descriptive progressives ("계속 확인
 // 중입니다" = "I'm still checking"). The persona speaking banmal ("확인해볼게!") was
 // the production miss that closed a Discord turn in silence.
-const KO_PHRASES: readonly string[] = [
-  '확인해볼게',
-  '확인해 볼게',
-  '확인할게',
-  '계속 진행할게',
-  '계속할게',
-  '살펴볼게',
-  '볼게',
-  '검토할게',
-  '검토해볼게',
-  '조회해볼게',
-  '찾아볼게',
-  '알아볼게',
-  '처리할게',
-  '알려드릴게',
-  // Action/config verb -게 forms (the -겠습니다 siblings are covered by the
-  // morpheme regex; these are the casual/casual-polite variants chat models emit).
-  '업데이트할게',
-  '수정할게',
-  '설정할게',
-  '반영할게',
-  '적용할게',
-  '추가할게',
-  '생성할게',
-  '잠시만요',
-  '잠깐만요',
-]
+const KO_PHRASES: readonly string[] = ['잠시만요', '잠깐만요']
 
 // The remaining languages mirror the precision-first selection above: every
 // entry pairs a FIRST-PERSON future/volitional anchor with a work verb
@@ -697,6 +683,25 @@ const MORPHEME_PATTERNS: readonly RegExp[] = [
   // Listener-directed conjecture takes the honorific 시 (피곤하시겠어요 → 시겠, not
   // 하겠), so it is excluded too.
   /(?:하|보|두|놓)겠(?:습니다|어요)/,
+  // Korean first-person volitional -(으)ㄹ게(요): the same stems as -겠 above plus the
+  // humble auxiliary 드리 (알려드릴게요), carrying the ㄹ that marks the ending
+  // (하 → 할게, 보 → 볼게, 두 → 둘게, 놓 → 놓을게, 드리 → 드릴게; consonant-final 놓 takes
+  // the -을게 allomorph). This is what generalizes across the
+  // open X하다 class the tables cannot enumerate — 배포할게요/롤백할게요/머지할게요 all
+  // reduce to 할게. The ㄹ is load-bearing for precision, not just morphology: the
+  // adverbial -게 attaches to a BARE stem (착하게 "kindly", never 착할게), so 할게/볼게
+  // have no adjective reading at all, and the 여기서 마칠게요 ("I'll stop here") class of
+  // non-work volitionals never reaches these stems. The (?![?？]) lookahead drops the
+  // permission-seeking question form (제가 처리할게요? "shall I handle it?"), mirroring
+  // the Japanese question guard below; a question awaits the user rather than
+  // committing to act. The quotative lookahead drops reported speech
+  // ("확인할게요"라고 했습니다 = "they said they'd check"), where the promise is someone
+  // else's — an optional closing quote may sit between the ending and 라고.
+  // The (?![요여용]) is load-bearing: without it the optional particle group
+  // backtracks to empty and the guards below inspect the 요 instead of what follows
+  // it, so 배포할게요? would slip through. Forcing the particle to be consumed when
+  // present is JS's substitute for a possessive quantifier.
+  /(?:할|볼|둘|놓을|드릴)게(?:요|여|용)?(?![요여용])(?![?？])(?!["'”』]?\s*라(?:고|며|는|던))/,
   // Turkish first-person-singular future "-acağım/-eceğim" ("I will VERB").
   // Vowel harmony yields exactly these two suffixes; the y-buffer
   // ("bekleyeceğim") leaves the suffix intact.
@@ -720,6 +725,25 @@ const MORPHEME_PATTERNS: readonly RegExp[] = [
 const JA_VOLITIONAL_IDIOMS = /お願い(?:いた)?します|失礼します/g
 const JA_VOLITIONAL = /します(?![か？?])|してみます(?![か？?])/
 
+// Korean short negation 안/못 inverts the promise: 배포 안 할게요 is a commitment NOT
+// to deploy. Both Korean morpheme families are affected (안 할게요 and 안 하겠습니다),
+// so negated spans are stripped before the morpheme pass rather than guarded inside
+// each pattern — the same strip-then-test shape JA_VOLITIONAL_IDIOMS uses above.
+//
+// The negator must be its OWN token. Two lookbehind/shape constraints enforce that,
+// and both are load-bearing in opposite directions: (?<![가-힣]) rejects a 안 that ends
+// a word (방안/제안 확인할게요 = "I'll check the plan/proposal"), while requiring a space
+// before the {0,6} verb window rejects a 안 that merely STARTS one (안내해드릴게요 =
+// "I'll guide you", 안전하게 배포할게요 = "I'll deploy safely"). Without the space the
+// window swallows 내해 and suppresses a real promise. The no-space branch stays for the
+// attached spelling 안할게요.
+//
+// The {0,6} window spans the verb the negator scopes over, which may be several
+// syllables (안 업데이트할게요), but cannot cross a space, so a negator in an earlier
+// clause never reaches a later promise (배포는 안 하고 확인만 할게요 stays willing).
+// Long negation -지 않을게요 needs no entry: 않을게 is not one of the stems.
+const KO_NEGATED_VOLITIONAL = /(?<![가-힣])(?:안|못)(?:\s+[가-힣]{0,6})?(?:(?:할|볼|둘|놓을|드릴)게|(?:하|보|두|놓)겠)/g
+
 // Reply texts shorter than this are almost always a complete final answer
 // ("네", "ok", "done") where a partial match would be noise. The shortest
 // legitimate intent phrases ("on it now", "확인할게요") clear this floor.
@@ -730,6 +754,7 @@ export function detectContinuationWillingness(text: string): boolean {
   const normalized = normalize(text)
   if (normalized.length < MIN_LENGTH) return false
   if (ALL_PHRASES.some((phrase) => normalized.includes(phrase))) return true
-  if (MORPHEME_PATTERNS.some((pattern) => pattern.test(normalized))) return true
-  return JA_VOLITIONAL.test(normalized.replace(JA_VOLITIONAL_IDIOMS, ''))
+  const affirmed = normalized.replace(KO_NEGATED_VOLITIONAL, ' ')
+  if (MORPHEME_PATTERNS.some((pattern) => pattern.test(affirmed))) return true
+  return JA_VOLITIONAL.test(affirmed.replace(JA_VOLITIONAL_IDIOMS, ''))
 }


### PR DESCRIPTION
## Background

`src/channels/continuation-willingness.ts` decides whether an agent's chat reply promises to keep working this turn. A `true` result raises an hourglass reaction on the reply and permits at most one bounded "you said you'd continue" reminder nudge. The file's stated cost model prefers false negatives: a miss just leaves the status quo, while a false positive costs a wasted reminder-only turn.

Korean's first-person volitional -(으)ㄹ게 was enumerated verb by verb (~20 entries), so 업데이트할게 matched but 배포할게 / 롤백할게 / 머지할게 / 재시작할게 / 삭제할게 did not — the entire open X하다 class was invisible, and every new action verb had to be added by hand.

## Summary

Adds one morpheme pattern anchored to the same stems the existing -겠 pattern already uses, plus the humble auxiliary 드리: 하 → 할게, 보 → 볼게, 두 → 둘게, 놓 → 놓을게, 드리 → 드릴게 (놓 takes the -을게 allomorph since it ends in a consonant). Every X하다 verb now inherits 할게 for free instead of needing a per-verb entry.

Three things follow from making the ending itself matchable:

1. **Negation stripping.** Short negation inverts the promise — 배포 안 할게요 commits *not* to deploy. 안/못 spans are stripped before the morpheme pass (the same strip-then-test shape `JA_VOLITIONAL_IDIOMS` already uses). The strip covers both Korean families, which also fixes a pre-existing false positive on 안 하겠습니다 in the -겠 pattern.
2. **The -게 phrase table is gone.** A table entry short-circuits the morpheme pass, because the substring pass returns first — so the negation, question and quotative guards never execute. That is why 제가 처리할게요? reported willingness. Every -게 entry is subsumed by the guarded morpheme; only the stall idioms (잠시만요, 잠깐만요) remain, and those have no verb to negate or question.
3. **드리 joins the stems.** 알려드릴게 was the one table entry not subsumed. Adding the stem also picks up 안내해드릴게요, which the table never covered.

### Why not the general rule

A naive "any ㄹ-batchim syllable + 게" rule was tried and rejected. Mutation-testing that pattern produces 7 false positives:

- Adjective adverbial -게 (힘들게, 길게, 멀게) — this -게 attaches to a bare stem and never surfaces as -ㄹ게 (착하게, never 착할게), so anchoring on the stem list excludes it structurally.
- The noun 별게 (별게 아니에요).
- -게 되다 constructions (알게 되었습니다).
- Genuine volitionals that mean the opposite of continuation, e.g. 여기서 마칠게요 ("I'll stop here") — under the naive rule this would raise the hourglass and a keep-working nudge on what is actually a sign-off message.

A sentence-final lookahead does not rescue the naive rule either: every one of those confusables (힘들게 찾았어요, 알게 되었습니다, 별게 아니에요) is followed by a space, and a one-character lookahead can't see past it.

### Guards on the morpheme pass

Question forms are dropped the same way the Japanese ~ますか guard drops them (제가 배포할게요? asks permission rather than committing to act), and quotative 라고/라며/라는/라던 is dropped because the promise belongs to someone else. The `(?![요여용])` ahead of both stops the optional politeness particle from backtracking to empty, which would let the guards inspect 요 itself instead of what follows it.

The negator must be its own token, and the two constraints fail in opposite directions:

- `(?<![가-힣])` rejects a 안 that *ends* a word — 방안 / 제안 확인할게요 stay willing.
- requiring a space before the `{0,6}` verb window rejects a 안 that merely *starts* one — 안내해드릴게요, 안전하게 배포할게요 stay willing.
- the no-space branch still catches the attached spelling 안할게.

Because a span is stripped rather than the whole text short-circuited, 배포는 안 하고 확인만 할게요 stays willing. Long negation -지 않을게요 needs no entry — 않을게 is not a stem, so it never matched.

## What this does NOT do

- Does not touch any other language's rules in the file.
- Does not change the false-negative/false-positive cost model or the reminder-nudge budget logic.
- Does not broaden -겠 detection. The only -겠 change is the negation strip, which strictly *removes* a false positive.

## Review notes

The load-bearing decision is the stem anchor — it's what keeps this inside the file's prefer-false-negatives bias. Please read "Why not the general rule" before suggesting a broader batchim-based match; it was tried and reverted for the reasons above.

The second load-bearing invariant is ordering: `ALL_PHRASES` returns before `MORPHEME_PATTERNS`, so re-adding any -게 form to the phrase table silently disables the negation, question and quotative guards. The header comment records this.

Negative tests cover each confusable called out above. Each guard is individually load-bearing: dropping `(?![요여용])` reopens 2 false positives, `(?![?？])` reopens 1, the quotative guard reopens 1, and replacing the stem anchor with a generic `[가-힣]게` reopens all 7.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors, 0 warnings in changed files (70 pre-existing warnings elsewhere, untouched)
- `bun run format:check` — all files correctly formatted
- `bun test --parallel src/channels/` — 3170 pass, 0 fail
- `bun test --parallel src/channels/continuation-willingness.test.ts` — 232 pass, 0 fail
- `bun run test` (full suite) — 8 failures, all schema-drift guards that reproduce identically on a pristine `origin/main` worktree; unrelated to this change
- Windows CI failed once on `typeclaw inspect refuses the picker without a TTY` (30s timeout) and passed on re-run — unrelated flake
