### PR TITLE
Retain queued channel work across reload handoff failures

### DIFF
--- a/src/agent/reload-tool.test.ts
+++ b/src/agent/reload-tool.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { ReloadRegistry, type ReloadResult } from '@/reload'
 
+import { createProviderAuthReloadable } from './auth-reloadable'
 import { createReloadTool } from './reload-tool'
 
 function regWith(...results: ReloadResult[]): ReloadRegistry {
@@ -161,5 +162,54 @@ describe('createReloadTool', () => {
 
     // then
     expect(calls).toEqual(['config', 'cron'])
+  })
+
+  test('without scope arg, skips forced provider invalidation', async () => {
+    const calls: string[] = []
+    let liveSessionTeardowns = 0
+    const reg = new ReloadRegistry()
+    for (const scope of ['config', 'cron']) {
+      reg.register({
+        scope,
+        description: scope,
+        reload: async () => {
+          calls.push(scope)
+          return { scope, ok: true, summary: `${scope} ok` }
+        },
+      })
+    }
+    reg.register(
+      createProviderAuthReloadable({
+        onProviderAuthChanged: () => {
+          liveSessionTeardowns++
+        },
+      }),
+    )
+
+    const result = await execute(createReloadTool({ registry: reg }))
+
+    expect(calls).toEqual(['config', 'cron'])
+    expect(liveSessionTeardowns).toBe(0)
+    expect((result.details as { results: ReloadResult[] }).results.map((item) => item.scope)).toEqual([
+      'config',
+      'cron',
+    ])
+  })
+
+  test('explicit providers scope still forces provider invalidation', async () => {
+    let liveSessionTeardowns = 0
+    const reg = new ReloadRegistry()
+    reg.register(
+      createProviderAuthReloadable({
+        onProviderAuthChanged: () => {
+          liveSessionTeardowns++
+        },
+      }),
+    )
+
+    const result = await execute(createReloadTool({ registry: reg }), { scope: 'providers' })
+
+    expect(liveSessionTeardowns).toBe(1)
+    expect((result.details as { results: ReloadResult[] }).results.map((item) => item.scope)).toEqual(['providers'])
   })
 })

--- a/src/agent/reload-tool.ts
+++ b/src/agent/reload-tool.ts
@@ -16,9 +16,11 @@ export function createReloadTool({ registry }: CreateReloadToolOptions) {
       'all-or-nothing: invalid input leaves its live state unchanged and the failure reason is ' +
       "reported in that scope's result. Boot-only config fields (port, mounts, memory.idleMs) " +
       'are reported as restart-required. Safe to call any time. ' +
-      'Without a scope arg, runs every registered reloadable in registration order so later ' +
-      'scopes observe earlier swaps (e.g. cron sees a freshly-loaded plugins registry). ' +
-      'With a scope arg, runs only that one reloadable.',
+      'Without a scope arg, runs every non-destructive registered reloadable in registration ' +
+      'order so later scopes observe earlier swaps (e.g. cron sees a freshly-loaded plugins ' +
+      'registry). Provider credential invalidation recreates every live channel session, so it ' +
+      'runs only with an explicit scope="providers" after credentials change. With a scope arg, ' +
+      'runs only that one reloadable.',
     parameters: Type.Object({
       scope: Type.Optional(
         Type.String({
@@ -26,7 +28,8 @@ export function createReloadTool({ registry }: CreateReloadToolOptions) {
             'Optional reload scope name. Common scopes: "config" (typeclaw.json), ' +
             '"plugins" (re-resolve and re-run plugin factories), "skills" (read-only diagnostic ' +
             'reporting which skills are visible to a new session), "cron" (cron.json). ' +
-            'Omit to reload all scopes.',
+            'Use "providers" only after provider credentials change. Omit to reload all ' +
+            'non-destructive scopes.',
         }),
       ),
     }),
@@ -48,7 +51,11 @@ export function createReloadTool({ registry }: CreateReloadToolOptions) {
         }
       }
 
-      const { results } = await registry.reloadAll()
+      const results: ReloadResult[] = []
+      for (const item of items) {
+        if (item.scope === 'providers') continue
+        results.push(await registry.reloadOne(item.scope))
+      }
       return {
         content: [{ type: 'text', text: formatResults(results) }],
         details: { results },

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -424,6 +424,7 @@ function makeRouter(
     failSessionCreationAt?: readonly number[]
     handoffRetryRetentionMs?: number
     handoffRetryItemLimit?: number
+    handoffRetryByteLimit?: number
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -454,6 +455,7 @@ function makeRouter(
       ? { handoffRetryRetentionMs: options.handoffRetryRetentionMs }
       : {}),
     ...(options.handoffRetryItemLimit !== undefined ? { handoffRetryItemLimit: options.handoffRetryItemLimit } : {}),
+    ...(options.handoffRetryByteLimit !== undefined ? { handoffRetryByteLimit: options.handoffRetryByteLimit } : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
     logger: {
@@ -1303,6 +1305,7 @@ describe('ChannelRouter session lifecycle', () => {
     const logs: string[] = []
     const nowRef = { value: 1000 }
     const notices: string[] = []
+    const removed: RemoveReactionRequest[] = []
     const { router, sessions } = makeRouter(dir, {
       factoryCalls,
       failSessionCreationAt: [2],
@@ -1312,6 +1315,14 @@ describe('ChannelRouter session lifecycle', () => {
     })
     router.registerOutbound('discord-bot', async (message) => {
       notices.push(message.text ?? '')
+      return { ok: true }
+    })
+    router.registerReaction('discord-bot', async () => ({
+      ok: true,
+      reactionRef: { adapter: 'discord-bot', value: 'retained-reaction' },
+    }))
+    router.registerRemoveReaction('discord-bot', async (request) => {
+      removed.push(request)
       return { ok: true }
     })
     let releaseFirstPrompt: () => void = () => {}
@@ -1325,7 +1336,13 @@ describe('ChannelRouter session lifecycle', () => {
     const drainPromise = router.__testing!.flushDebounce(KEY)
     await waitFor(() => sessions[0]!.prompts.length > 0)
     await router.tearDownAllLive()
-    await router.route(inbound({ externalMessageId: 'm2', text: 'retained until expiry' }))
+    await router.route(
+      inbound({
+        externalMessageId: 'm2',
+        text: 'retained until expiry',
+        reactionRef: { adapter: 'discord-bot', value: 'queued-message' },
+      }),
+    )
     releaseFirstPrompt()
     await drainPromise
 
@@ -1336,6 +1353,44 @@ describe('ChannelRouter session lifecycle', () => {
     expect(notices).toHaveLength(1)
     expect(notices[0]!).toContain('could not replay 1 queued item(s)')
     expect(notices[0]!).toContain("reload({ scope: 'providers' })")
+    expect(removed).toHaveLength(1)
+    expect(removed[0]!.reactionRef).toEqual({ adapter: 'discord-bot', value: 'retained-reaction' })
+  })
+
+  test('failed reload handoff also retains observed context and system reminders', async () => {
+    const dir = await tempDir()
+    const factoryCalls: SessionFactoryArgs[] = []
+    const { router, sessions } = makeRouter(dir, { factoryCalls, failSessionCreationAt: [2] })
+    await router.route(
+      inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'prime group context' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    let releaseHeldPrompt: () => void = () => {}
+    const heldPrompt = new Promise<void>((resolve) => {
+      releaseHeldPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm-hold', text: 'hold before reload' }))
+    sessions[0]!.onPrompt = async () => {
+      await heldPrompt
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.some((prompt) => prompt.includes('hold before reload')))
+
+    await router.tearDownAllLive()
+    await router.route(
+      inbound({ isBotMention: false, externalMessageId: 'm-observed', text: 'retained ambient context' }),
+    )
+    router.__testing!.injectContinuationReminder(KEY, 'retained reminder marker')
+    releaseHeldPrompt()
+    await drainPromise
+    expect(router.liveCount()).toBe(0)
+
+    await router.route(inbound({ externalMessageId: 'm-next', text: 'new trigger after retry' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const replayed = sessions[1]!.prompts.join('\n')
+    expect(replayed.match(/retained ambient context/g)).toHaveLength(1)
+    expect(replayed.match(/retained reminder marker/g)).toHaveLength(1)
   })
 
   test('oversized reload handoff reports the whole rejected batch instead of silently trimming it', async () => {
@@ -1571,6 +1626,16 @@ describe('ChannelRouter session lifecycle', () => {
 })
 
 describe('ChannelRouter ensureLive watchdog', () => {
+  test('releases creation tokens after ordinary successful sessions settle', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(router.__testing!.creationTokenCount()).toBe(0)
+  })
+
   test('hung session factory rejects after the timeout instead of awaiting forever', async () => {
     // given a factory that never resolves (simulates a hung Discord REST chain
     // inside createForChannel — the production failure mode that bricked the

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -420,11 +420,16 @@ function makeRouter(
     runIdleContinuation?: CreateChannelRouterOptions['runIdleContinuation']
     recordTurnOutcome?: CreateChannelRouterOptions['recordTurnOutcome']
     onSessionCreated?: (session: FakeSession) => void
+    beforeSessionCreation?: (attempt: number) => Promise<void> | void
+    failSessionCreationAt?: readonly number[]
+    handoffRetryRetentionMs?: number
+    handoffRetryItemLimit?: number
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
   const origins: SessionOrigin[] = options.origins ?? []
   const nowRef = options.nowRef ?? { value: 1000 }
+  let creationAttempts = 0
   const router = createChannelRouter({
     agentDir,
     configForAdapter: () => options.config ?? baseConfig,
@@ -445,6 +450,10 @@ function makeRouter(
       : {}),
     ...(options.runIdleContinuation !== undefined ? { runIdleContinuation: options.runIdleContinuation } : {}),
     ...(options.recordTurnOutcome !== undefined ? { recordTurnOutcome: options.recordTurnOutcome } : {}),
+    ...(options.handoffRetryRetentionMs !== undefined
+      ? { handoffRetryRetentionMs: options.handoffRetryRetentionMs }
+      : {}),
+    ...(options.handoffRetryItemLimit !== undefined ? { handoffRetryItemLimit: options.handoffRetryItemLimit } : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
     logger: {
@@ -453,12 +462,17 @@ function makeRouter(
       error: (m) => options.logs?.push(`error:${m}`),
     },
     createSessionForChannel: async ({ origin, originRef, existingSessionId, existingSessionFile }) => {
+      creationAttempts++
       options.factoryCalls?.push({
         ...(existingSessionId !== undefined ? { existingSessionId } : {}),
         ...(existingSessionFile !== undefined ? { existingSessionFile } : {}),
       })
       origins.push(origin)
       options.originRefs?.push(originRef)
+      await options.beforeSessionCreation?.(creationAttempts)
+      if (options.failSessionCreationAt?.includes(creationAttempts)) {
+        throw new Error(`session creation failed at attempt ${creationAttempts}`)
+      }
       const fake = new FakeSession()
       options.onSessionCreated?.(fake)
       sessions.push(fake)
@@ -1165,6 +1179,197 @@ describe('ChannelRouter session lifecycle', () => {
     expect(sessions[0]!.prompts.length).toBe(1)
     expect(sessions[1]!.prompts.some((p) => p.includes('after reload'))).toBe(true)
     expect(router.liveCount()).toBe(1)
+  })
+
+  test('failed reload handoff retains queued inbounds for the next successful session in order', async () => {
+    const dir = await tempDir()
+    const factoryCalls: SessionFactoryArgs[] = []
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { factoryCalls, failSessionCreationAt: [2], logs })
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1', text: 'before reload' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+
+    await router.tearDownAllLive()
+    await router.route(inbound({ externalMessageId: 'm2', text: 'queued first' }))
+    await router.route(inbound({ externalMessageId: 'm3', text: 'queued second' }))
+
+    releaseFirstPrompt()
+    await drainPromise
+    expect(factoryCalls).toHaveLength(2)
+    expect(router.liveCount()).toBe(0)
+    expect(
+      logs.some((line) => line.includes('successor recreate after reload failed') && line.includes('retained')),
+    ).toBe(true)
+
+    await router.route(inbound({ externalMessageId: 'm4', text: 'new trigger' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(factoryCalls).toHaveLength(3)
+    expect(sessions).toHaveLength(2)
+    const replayed = sessions[1]!.prompts.join('\n')
+    expect(replayed.indexOf('queued first')).toBeLessThan(replayed.indexOf('queued second'))
+    expect(replayed.indexOf('queued second')).toBeLessThan(replayed.indexOf('new trigger'))
+    expect(replayed.match(/queued first/g)).toHaveLength(1)
+    expect(replayed.match(/queued second/g)).toHaveLength(1)
+  })
+
+  test('a timed-out reload successor cannot replace the retry that replayed its retained work', async () => {
+    const dir = await tempDir()
+    const factoryCalls: SessionFactoryArgs[] = []
+    let releaseLateSuccessor: () => void = () => {}
+    const lateSuccessorBlocked = new Promise<void>((resolve) => {
+      releaseLateSuccessor = resolve
+    })
+    let markLateSuccessorEntered: () => void = () => {}
+    const lateSuccessorEntered = new Promise<void>((resolve) => {
+      markLateSuccessorEntered = resolve
+    })
+    const { router, sessions } = makeRouter(dir, {
+      ensureLiveTimeoutMs: 1_000,
+      factoryCalls,
+      beforeSessionCreation: async (attempt) => {
+        if (attempt !== 2) return
+        markLateSuccessorEntered()
+        await lateSuccessorBlocked
+      },
+    })
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1', text: 'before reload' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+
+    await router.tearDownAllLive()
+    await router.route(inbound({ externalMessageId: 'm2', text: 'retained once' }))
+    releaseFirstPrompt()
+    await lateSuccessorEntered
+    await drainPromise
+
+    await router.route(inbound({ externalMessageId: 'm3', text: 'retry trigger' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(2)
+    expect(sessions[1]!.prompts.join('\n').match(/retained once/g)).toHaveLength(1)
+
+    releaseLateSuccessor()
+    await waitFor(() => sessions.length === 3 && sessions[2]!.disposed === 1)
+
+    await router.route(inbound({ externalMessageId: 'm4', text: 'still on retry' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(factoryCalls).toHaveLength(3)
+    expect(router.liveCount()).toBe(1)
+    expect(sessions[1]!.prompts.join('\n')).toContain('still on retry')
+    expect(sessions[1]!.prompts.join('\n').match(/retained once/g)).toHaveLength(1)
+  })
+
+  test('successful reload handoff delivers its queued inbound exactly once', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1', text: 'before reload' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+
+    await router.tearDownAllLive()
+    await router.route(inbound({ externalMessageId: 'm2', text: 'queued once' }))
+    releaseFirstPrompt()
+    await drainPromise
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[1]!.prompts.join('\n').match(/queued once/g)).toHaveLength(1)
+  })
+
+  test('expired reload handoff reports the loss and recovery path to the channel and operator log', async () => {
+    const dir = await tempDir()
+    const factoryCalls: SessionFactoryArgs[] = []
+    const logs: string[] = []
+    const nowRef = { value: 1000 }
+    const notices: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      factoryCalls,
+      failSessionCreationAt: [2],
+      handoffRetryRetentionMs: 100,
+      logs,
+      nowRef,
+    })
+    router.registerOutbound('discord-bot', async (message) => {
+      notices.push(message.text ?? '')
+      return { ok: true }
+    })
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1', text: 'before reload' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+    await router.tearDownAllLive()
+    await router.route(inbound({ externalMessageId: 'm2', text: 'retained until expiry' }))
+    releaseFirstPrompt()
+    await drainPromise
+
+    nowRef.value += 100
+    await router.__testing!.runIdleGc()
+
+    expect(logs.some((line) => line.includes('reload handoff retention policy discarded'))).toBe(true)
+    expect(notices).toHaveLength(1)
+    expect(notices[0]!).toContain('could not replay 1 queued item(s)')
+    expect(notices[0]!).toContain("reload({ scope: 'providers' })")
+  })
+
+  test('oversized reload handoff reports the whole rejected batch instead of silently trimming it', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const notices: string[] = []
+    const { router, sessions } = makeRouter(dir, { handoffRetryItemLimit: 1, logs })
+    router.registerOutbound('discord-bot', async (message) => {
+      notices.push(message.text ?? '')
+      return { ok: true }
+    })
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1', text: 'before reload' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+    await router.tearDownAllLive()
+    await router.route(inbound({ externalMessageId: 'm2', text: 'queued first' }))
+    await router.route(inbound({ externalMessageId: 'm3', text: 'queued second' }))
+
+    releaseFirstPrompt()
+    await drainPromise
+
+    expect(sessions).toHaveLength(1)
+    expect(router.liveCount()).toBe(0)
+    expect(logs.some((line) => line.includes('per-key item limit 1 exceeded'))).toBe(true)
+    expect(notices).toHaveLength(1)
+    expect(notices[0]!).toContain('could not replay 2 queued item(s)')
+    expect(notices[0]!).toContain('per-key item limit 1 exceeded')
   })
 
   test('stop logs teardown abort details when a prompt is in flight', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -645,6 +645,8 @@ export const ENSURE_LIVE_TIMEOUT_MS = 30_000
 const RELOAD_HANDOFF_RETENTION_MS = 15 * 60_000
 const MAX_PENDING_RELOAD_HANDOFF_KEYS = 100
 const MAX_PENDING_RELOAD_HANDOFF_ITEMS_PER_KEY = 1_000
+const MAX_PENDING_RELOAD_HANDOFF_BYTES_PER_KEY = 8 * 1024 * 1024
+const MAX_PENDING_RELOAD_HANDOFF_BYTES_TOTAL = 64 * 1024 * 1024
 
 // Thrown by ensureLive() when a teardown (roles reload or shutdown) raced
 // ahead of an in-flight creation. route() has no special handling — it
@@ -831,6 +833,7 @@ type PendingReloadHandoff = {
   observed: ObservedInbound[]
   reminders: PendingSystemReminder[]
   retainedAt: number
+  estimatedBytes: number
 }
 
 const retryReminder = (text: string): PendingSystemReminder => ({ text, kind: 'retry' })
@@ -1641,6 +1644,7 @@ export type ChannelRouter = {
     typingHeartbeatIntervalFor: (adapter: ChannelKey['adapter']) => number
     githubReviewRoundFor: (key: ChannelKey) => GithubReviewFollowupRound | null | undefined
     pendingReminderCount: (key: ChannelKey) => number | undefined
+    creationTokenCount: () => number
     runIdleGc: () => Promise<void>
     // Returns the seeded author state on the live session matching
     // `key`, or undefined when no live session exists. Tests use this
@@ -1729,6 +1733,8 @@ export type CreateChannelRouterOptions = {
   // Test seam for exercising the per-key retry-buffer capacity without
   // manufacturing a production-sized batch.
   handoffRetryItemLimit?: number
+  // Test seam for the retained payload-size guard.
+  handoffRetryByteLimit?: number
   // Test seam: per-callback ceiling for channel name resolvers; mirrors the
   // ensureLive seam so timeout paths can be exercised quickly in tests.
   resolveChannelNamesTimeoutMs?: number
@@ -1848,6 +1854,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const ensureLiveTimeoutMs = options.ensureLiveTimeoutMs ?? ENSURE_LIVE_TIMEOUT_MS
   const handoffRetryRetentionMs = options.handoffRetryRetentionMs ?? RELOAD_HANDOFF_RETENTION_MS
   const handoffRetryItemLimit = options.handoffRetryItemLimit ?? MAX_PENDING_RELOAD_HANDOFF_ITEMS_PER_KEY
+  const handoffRetryByteLimit = options.handoffRetryByteLimit ?? MAX_PENDING_RELOAD_HANDOFF_BYTES_PER_KEY
   const resolveChannelNamesTimeoutMs = options.resolveChannelNamesTimeoutMs ?? RESOLVE_CHANNEL_NAMES_TIMEOUT_MS
   const fetchHistoryTimeoutMs = options.fetchHistoryTimeoutMs ?? FETCH_HISTORY_TIMEOUT_MS
   const sessionIdleTimeoutMs = options.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS
@@ -1859,6 +1866,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const newestRunningChildSubagentStartedAt = options.newestRunningChildSubagentStartedAt ?? (() => null)
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
+  let nextCreationToken = 0
+  const activeCreationAttempts = new Map<string, number>()
   // Unlike `creating`, this marker survives the watchdog cleanup. A timed-out
   // attempt can keep running after a retry claims the key, so only the latest
   // monotonic token may persist, install, or adopt queued handoff work.
@@ -2236,6 +2245,25 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const pendingReloadHandoffItemCount = (pending: PendingReloadHandoff): number =>
     pending.inbounds.length + pending.observed.length + pending.reminders.length
 
+  const estimateReloadHandoffBytes = (
+    inbounds: QueuedInbound[],
+    observed: ObservedInbound[],
+    reminders: PendingSystemReminder[],
+  ): number => {
+    try {
+      const serializableInbounds = inbounds.map(({ engageReaction: _engageReaction, ...inbound }) => inbound)
+      return Buffer.byteLength(JSON.stringify({ inbounds: serializableInbounds, observed, reminders }), 'utf8')
+    } catch {
+      return Number.POSITIVE_INFINITY
+    }
+  }
+
+  const pendingReloadHandoffTotalBytes = (): number => {
+    let total = 0
+    for (const pending of pendingReloadHandoffs.values()) total += pending.estimatedBytes
+    return total
+  }
+
   const reportDiscardedReloadHandoff = async (pending: PendingReloadHandoff, reason: string): Promise<void> => {
     const count = pendingReloadHandoffItemCount(pending)
     const recovery =
@@ -2244,6 +2272,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     logger.error(
       `[channels] ${channelKeyId(pending.key)}: reload handoff retention policy discarded ${count} queued item(s): ${reason}. ${recovery}`,
     )
+    await dropPendingReloadHandoffEngageReactions(pending)
     const result = await send(
       {
         adapter: pending.key.adapter,
@@ -2263,12 +2292,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const expirePendingReloadHandoffs = async (): Promise<void> => {
+    const expired: Array<{ pending: PendingReloadHandoff; ageMs: number }> = []
     for (const [keyId, pending] of pendingReloadHandoffs) {
       const ageMs = now() - pending.retainedAt
       if (ageMs < handoffRetryRetentionMs) continue
       pendingReloadHandoffs.delete(keyId)
-      void reportDiscardedReloadHandoff(pending, `retention limit exceeded after ${ageMs}ms`)
+      expired.push({ pending, ageMs })
     }
+    await Promise.all(
+      expired.map(({ pending, ageMs }) =>
+        reportDiscardedReloadHandoff(pending, `retention limit exceeded after ${ageMs}ms`),
+      ),
+    )
   }
 
   const retainReloadHandoff = (
@@ -2281,19 +2316,53 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const keyId = channelKeyId(key)
     const existing = pendingReloadHandoffs.get(keyId)
     if (existing !== undefined) {
-      const incoming: PendingReloadHandoff = { key, inbounds, observed, reminders, retainedAt: now() }
+      const incoming: PendingReloadHandoff = {
+        key,
+        inbounds,
+        observed,
+        reminders,
+        retainedAt: now(),
+        estimatedBytes: estimateReloadHandoffBytes(inbounds, observed, reminders),
+      }
       if (pendingReloadHandoffItemCount(existing) + pendingReloadHandoffItemCount(incoming) > handoffRetryItemLimit) {
         void reportDiscardedReloadHandoff(incoming, `per-key item limit ${handoffRetryItemLimit} would be exceeded`)
+        return false
+      }
+      if (existing.estimatedBytes + incoming.estimatedBytes > handoffRetryByteLimit) {
+        void reportDiscardedReloadHandoff(incoming, `per-key byte limit ${handoffRetryByteLimit} would be exceeded`)
+        return false
+      }
+      if (pendingReloadHandoffTotalBytes() + incoming.estimatedBytes > MAX_PENDING_RELOAD_HANDOFF_BYTES_TOTAL) {
+        void reportDiscardedReloadHandoff(
+          incoming,
+          `global byte limit ${MAX_PENDING_RELOAD_HANDOFF_BYTES_TOTAL} would be exceeded`,
+        )
         return false
       }
       existing.inbounds.push(...inbounds)
       existing.observed.push(...observed)
       existing.reminders.push(...reminders)
+      existing.estimatedBytes += incoming.estimatedBytes
       return true
     }
-    const pending: PendingReloadHandoff = { key, inbounds, observed, reminders, retainedAt: now() }
+    const pending: PendingReloadHandoff = {
+      key,
+      inbounds,
+      observed,
+      reminders,
+      retainedAt: now(),
+      estimatedBytes: estimateReloadHandoffBytes(inbounds, observed, reminders),
+    }
     if (pendingReloadHandoffItemCount(pending) > handoffRetryItemLimit) {
       void reportDiscardedReloadHandoff(pending, `per-key item limit ${handoffRetryItemLimit} exceeded`)
+      return false
+    }
+    if (pending.estimatedBytes > handoffRetryByteLimit) {
+      void reportDiscardedReloadHandoff(pending, `per-key byte limit ${handoffRetryByteLimit} exceeded`)
+      return false
+    }
+    if (pendingReloadHandoffTotalBytes() + pending.estimatedBytes > MAX_PENDING_RELOAD_HANDOFF_BYTES_TOTAL) {
+      void reportDiscardedReloadHandoff(pending, `global byte limit ${MAX_PENDING_RELOAD_HANDOFF_BYTES_TOTAL} exceeded`)
       return false
     }
     if (pendingReloadHandoffs.size >= MAX_PENDING_RELOAD_HANDOFF_KEYS) {
@@ -2385,8 +2454,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (inFlight) return inFlight
 
     const generation = liveGeneration
-    const creationToken = (latestCreationTokens.get(keyId) ?? 0) + 1
+    const creationToken = ++nextCreationToken
     latestCreationTokens.set(keyId, creationToken)
+    activeCreationAttempts.set(keyId, (activeCreationAttempts.get(keyId) ?? 0) + 1)
     const isLatestCreation = (): boolean => latestCreationTokens.get(keyId) === creationToken
 
     let promise!: Promise<LiveSession>
@@ -2776,7 +2846,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       adoptPendingReloadHandoff(live)
       logger.info(`[channels] ${keyId}: ensureLive done (${phase})`)
       return live
-    })()
+    })().finally(() => {
+      const remaining = (activeCreationAttempts.get(keyId) ?? 1) - 1
+      if (remaining > 0) activeCreationAttempts.set(keyId, remaining)
+      else {
+        activeCreationAttempts.delete(keyId)
+        latestCreationTokens.delete(keyId)
+      }
+    })
 
     creating.set(keyId, promise)
     try {
@@ -4618,7 +4695,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // its persistent :eyes: is added strictly AFTER the transient one is removed
   // (see reactOnSilentAck). Fire-and-forget callers just `void` the result.
   const dropEngageReactions = (live: LiveSession, addPromises: Array<Promise<ReactionRef | null>>): Promise<void> => {
-    return Promise.all(addPromises.map((addPromise) => dropOneEngageReaction(live, addPromise))).then(() => undefined)
+    return Promise.all(addPromises.map((addPromise) => dropOneEngageReaction(live.key, addPromise))).then(
+      () => undefined,
+    )
   }
 
   // Only the LAST engaging inbound of a coalesced batch should carry the eager
@@ -4633,29 +4712,35 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     void dropEngageReactions(live, addPromises)
   }
 
-  const dropOneEngageReaction = (live: LiveSession, addPromise: Promise<ReactionRef | null>): Promise<void> => {
+  const dropPendingReloadHandoffEngageReactions = (pending: PendingReloadHandoff): Promise<void> => {
+    const addPromises = pending.inbounds.flatMap((item) =>
+      item.engageReaction !== undefined ? [item.engageReaction] : [],
+    )
+    for (const item of pending.inbounds) delete item.engageReaction
+    return Promise.all(addPromises.map((addPromise) => dropOneEngageReaction(pending.key, addPromise))).then(
+      () => undefined,
+    )
+  }
+
+  const dropOneEngageReaction = (key: ChannelKey, addPromise: Promise<ReactionRef | null>): Promise<void> => {
     return addPromise
       .then((reactionRef) => {
         if (reactionRef === null) return undefined
         return removeReaction({
-          adapter: live.key.adapter,
-          workspace: live.key.workspace,
-          chat: live.key.chat,
-          thread: live.key.thread,
+          adapter: key.adapter,
+          workspace: key.workspace,
+          chat: key.chat,
+          thread: key.thread,
           reactionRef,
         })
       })
       .then((result) => {
         if (result && !result.ok && result.code !== 'unsupported' && result.code !== 'not-found') {
-          logger.info(
-            `[channels] engage-unreact failed adapter=${live.key.adapter} chat=${live.key.chat}: ${result.error}`,
-          )
+          logger.info(`[channels] engage-unreact failed adapter=${key.adapter} chat=${key.chat}: ${result.error}`)
         }
       })
       .catch((err) => {
-        logger.info(
-          `[channels] engage-unreact threw adapter=${live.key.adapter} chat=${live.key.chat}: ${describeError(err)}`,
-        )
+        logger.info(`[channels] engage-unreact threw adapter=${key.adapter} chat=${key.chat}: ${describeError(err)}`)
       })
   }
 
@@ -6141,7 +6226,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const pendingHandoffs = Array.from(pendingReloadHandoffs.values())
     pendingReloadHandoffs.clear()
     for (const pending of pendingHandoffs) {
-      void reportDiscardedReloadHandoff(pending, 'router stopped before replay could complete')
+      await reportDiscardedReloadHandoff(pending, 'router stopped before replay could complete')
     }
     const all = Array.from(liveSessions.values())
     liveSessions.clear()
@@ -7052,6 +7137,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     __testing: {
       githubReviewRoundFor: (key: ChannelKey) => liveSessions.get(channelKeyId(key))?.githubReviewRound,
       pendingReminderCount: (key: ChannelKey) => liveSessions.get(channelKeyId(key))?.pendingSystemReminders.length,
+      creationTokenCount: () => latestCreationTokens.size,
       flushDebounce: async (key: ChannelKey) => {
         const keyId = channelKeyId(key)
         let live = liveSessions.get(keyId)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -642,6 +642,10 @@ function defaultMeasureTranscriptBytes(path: string): number {
 // instead of awaiting the same dead promise forever.
 export const ENSURE_LIVE_TIMEOUT_MS = 30_000
 
+const RELOAD_HANDOFF_RETENTION_MS = 15 * 60_000
+const MAX_PENDING_RELOAD_HANDOFF_KEYS = 100
+const MAX_PENDING_RELOAD_HANDOFF_ITEMS_PER_KEY = 1_000
+
 // Thrown by ensureLive() when a teardown (roles reload or shutdown) raced
 // ahead of an in-flight creation. route() has no special handling — it
 // propagates to the adapter's outer catch, dropping this one inbound. The
@@ -820,6 +824,14 @@ type ChannelAgentSession = AgentSession & { getAbortReason?: () => string | unde
 // would silently misclassify, and every future enqueue site would inherit the
 // default instead of being forced to choose.
 type PendingSystemReminder = { text: string; kind: 'retry' | 'wakeup'; githubReviewRoundKey?: string }
+
+type PendingReloadHandoff = {
+  key: ChannelKey
+  inbounds: QueuedInbound[]
+  observed: ObservedInbound[]
+  reminders: PendingSystemReminder[]
+  retainedAt: number
+}
 
 const retryReminder = (text: string): PendingSystemReminder => ({ text, kind: 'retry' })
 
@@ -1711,6 +1723,12 @@ export type CreateChannelRouterOptions = {
   // Test seam: override the ensureLive watchdog ceiling so the timeout path
   // is exercisable in <100ms instead of the 30s production default.
   ensureLiveTimeoutMs?: number
+  // Test seam for expiring a failed reload handoff without waiting for the
+  // production retention window.
+  handoffRetryRetentionMs?: number
+  // Test seam for exercising the per-key retry-buffer capacity without
+  // manufacturing a production-sized batch.
+  handoffRetryItemLimit?: number
   // Test seam: per-callback ceiling for channel name resolvers; mirrors the
   // ensureLive seam so timeout paths can be exercised quickly in tests.
   resolveChannelNamesTimeoutMs?: number
@@ -1828,6 +1846,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const now = options.now ?? Date.now
   const measureTranscriptBytes = options.measureTranscriptBytes ?? defaultMeasureTranscriptBytes
   const ensureLiveTimeoutMs = options.ensureLiveTimeoutMs ?? ENSURE_LIVE_TIMEOUT_MS
+  const handoffRetryRetentionMs = options.handoffRetryRetentionMs ?? RELOAD_HANDOFF_RETENTION_MS
+  const handoffRetryItemLimit = options.handoffRetryItemLimit ?? MAX_PENDING_RELOAD_HANDOFF_ITEMS_PER_KEY
   const resolveChannelNamesTimeoutMs = options.resolveChannelNamesTimeoutMs ?? RESOLVE_CHANNEL_NAMES_TIMEOUT_MS
   const fetchHistoryTimeoutMs = options.fetchHistoryTimeoutMs ?? FETCH_HISTORY_TIMEOUT_MS
   const sessionIdleTimeoutMs = options.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS
@@ -1839,6 +1859,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const newestRunningChildSubagentStartedAt = options.newestRunningChildSubagentStartedAt ?? (() => null)
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
+  // Unlike `creating`, this marker survives the watchdog cleanup. A timed-out
+  // attempt can keep running after a retry claims the key, so only the latest
+  // monotonic token may persist, install, or adopt queued handoff work.
+  const latestCreationTokens = new Map<string, number>()
+  // A deferred reload splices post-reload work off the stale session before it
+  // recreates the successor. If that recreation times out, returning from the
+  // handoff used to discard the only copy and produce the production symptom
+  // "the agent stopped responding." Keep one ordered batch per channel key so
+  // the next successful ensureLive adopts it before any newer inbound. Entries
+  // expire and the key count is capped; crossing either bound reports the loss
+  // to both logs and the channel instead of silently trimming user work.
+  const pendingReloadHandoffs = new Map<string, PendingReloadHandoff>()
   // Restart-resume reservations, keyed by channelKeyId. Installed by
   // reserveRestartHandoff BEFORE channel adapters start receiving, so an
   // inbound that races the boot resume coalesces onto the reservation (via the
@@ -2201,6 +2233,95 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return true
   }
 
+  const pendingReloadHandoffItemCount = (pending: PendingReloadHandoff): number =>
+    pending.inbounds.length + pending.observed.length + pending.reminders.length
+
+  const reportDiscardedReloadHandoff = async (pending: PendingReloadHandoff, reason: string): Promise<void> => {
+    const count = pendingReloadHandoffItemCount(pending)
+    const recovery =
+      "Re-send the affected messages. If provider credentials changed, run reload({ scope: 'providers' }); " +
+      'otherwise check the channel logs and retry after session creation is healthy.'
+    logger.error(
+      `[channels] ${channelKeyId(pending.key)}: reload handoff retention policy discarded ${count} queued item(s): ${reason}. ${recovery}`,
+    )
+    const result = await send(
+      {
+        adapter: pending.key.adapter,
+        workspace: pending.key.workspace,
+        chat: pending.key.chat,
+        thread: pending.key.thread,
+        text: `⚠️ TypeClaw could not replay ${count} queued item(s) after reload: ${reason}. ${recovery}`,
+      },
+      { source: 'system', outputKind: 'meta' },
+    ).catch((err) => {
+      logger.error(`[channels] ${channelKeyId(pending.key)}: reload handoff loss notice threw: ${describeError(err)}`)
+      return null
+    })
+    if (result !== null && !result.ok) {
+      logger.error(`[channels] ${channelKeyId(pending.key)}: reload handoff loss notice failed: ${result.error}`)
+    }
+  }
+
+  const expirePendingReloadHandoffs = async (): Promise<void> => {
+    for (const [keyId, pending] of pendingReloadHandoffs) {
+      const ageMs = now() - pending.retainedAt
+      if (ageMs < handoffRetryRetentionMs) continue
+      pendingReloadHandoffs.delete(keyId)
+      void reportDiscardedReloadHandoff(pending, `retention limit exceeded after ${ageMs}ms`)
+    }
+  }
+
+  const retainReloadHandoff = (
+    key: ChannelKey,
+    inbounds: QueuedInbound[],
+    observed: ObservedInbound[],
+    reminders: PendingSystemReminder[],
+  ): boolean => {
+    void expirePendingReloadHandoffs()
+    const keyId = channelKeyId(key)
+    const existing = pendingReloadHandoffs.get(keyId)
+    if (existing !== undefined) {
+      const incoming: PendingReloadHandoff = { key, inbounds, observed, reminders, retainedAt: now() }
+      if (pendingReloadHandoffItemCount(existing) + pendingReloadHandoffItemCount(incoming) > handoffRetryItemLimit) {
+        void reportDiscardedReloadHandoff(incoming, `per-key item limit ${handoffRetryItemLimit} would be exceeded`)
+        return false
+      }
+      existing.inbounds.push(...inbounds)
+      existing.observed.push(...observed)
+      existing.reminders.push(...reminders)
+      return true
+    }
+    const pending: PendingReloadHandoff = { key, inbounds, observed, reminders, retainedAt: now() }
+    if (pendingReloadHandoffItemCount(pending) > handoffRetryItemLimit) {
+      void reportDiscardedReloadHandoff(pending, `per-key item limit ${handoffRetryItemLimit} exceeded`)
+      return false
+    }
+    if (pendingReloadHandoffs.size >= MAX_PENDING_RELOAD_HANDOFF_KEYS) {
+      void reportDiscardedReloadHandoff(pending, `key limit ${MAX_PENDING_RELOAD_HANDOFF_KEYS} reached`)
+      return false
+    }
+    pendingReloadHandoffs.set(keyId, pending)
+    return true
+  }
+
+  const adoptPendingReloadHandoff = (live: LiveSession): void => {
+    const pending = pendingReloadHandoffs.get(live.keyId)
+    if (pending === undefined) return
+    const ageMs = now() - pending.retainedAt
+    if (ageMs >= handoffRetryRetentionMs) {
+      pendingReloadHandoffs.delete(live.keyId)
+      void reportDiscardedReloadHandoff(pending, `retention limit exceeded after ${ageMs}ms`)
+      return
+    }
+    // Delete before enqueueing: once ownership moves to the live queues, a
+    // second ensureLive must not replay the same batch and double-deliver it.
+    pendingReloadHandoffs.delete(live.keyId)
+    live.promptQueue.push(...pending.inbounds)
+    live.contextBuffer.push(...pending.observed)
+    live.pendingSystemReminders.push(...pending.reminders)
+    if ((pending.inbounds.length > 0 || pending.reminders.length > 0) && !live.draining) void drain(live)
+  }
+
   const ensureLive = async (
     key: ChannelKey,
     triggeringMessageId?: string,
@@ -2222,7 +2343,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (existing && !existing.destroyed) {
       // A resume that finds the key already live is a no-op for reopening: the
       // session is up, so just hand it back and let the caller enqueue the wake.
-      if (resumeTarget !== undefined) return existing
+      if (resumeTarget !== undefined) {
+        adoptPendingReloadHandoff(existing)
+        return existing
+      }
       // Rollover decision (soft TTL → cost-aware grace → hard cap) lives in
       // shouldRolloverLive, which also skips draining sessions so a mid-prompt
       // turn is never aborted by a follow-up's idle check (PR #359 incident).
@@ -2252,6 +2376,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           }
         }
       } else {
+        adoptPendingReloadHandoff(existing)
         return existing
       }
     }
@@ -2260,8 +2385,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (inFlight) return inFlight
 
     const generation = liveGeneration
+    const creationToken = (latestCreationTokens.get(keyId) ?? 0) + 1
+    latestCreationTokens.set(keyId, creationToken)
+    const isLatestCreation = (): boolean => latestCreationTokens.get(keyId) === creationToken
 
-    const promise = (async () => {
+    let promise!: Promise<LiveSession>
+    promise = (async () => {
       await ensureLoaded()
       const record = mappings ? findRecord(mappings, key) : undefined
       let resolvedRecord = record
@@ -2389,6 +2518,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         originRef,
       })
       logger.info(`[channels] ${keyId}: ensureLive session-created sessionId=${created.sessionId}`)
+
+      // A watchdog timeout only releases callers; it cannot cancel the factory.
+      // Check the durable per-key token before this late attempt can overwrite
+      // the retry's mapping. The `creating` entry is intentionally insufficient:
+      // both attempts may have removed their transient entries by now.
+      if (!isLatestCreation()) {
+        await created.dispose()
+        throw new Error(`[channels] ${keyId}: superseded live session creation discarded`)
+      }
 
       const transcriptPath = created.getTranscriptPath?.()
       const persistedRecord: ChannelSessionRecord = {
@@ -2588,6 +2726,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (isColdStart) {
         // Install before the slow prefetch so a concurrent teardown/shutdown can
         // see and dispose this session during the network fetch.
+        if (!isLatestCreation()) {
+          await tearDownLive(live)
+          throw new Error(`[channels] ${keyId}: superseded live session creation discarded`)
+        }
         liveSessions.set(keyId, live)
         const adapterConfig = options.configForAdapter(key.adapter)
         // Overlap the disk mapping-write with the network history prefetch —
@@ -2611,6 +2753,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // before installing — a failed persist must fail ensureLive without
         // leaving a warm session behind for later inbounds to reuse.
         await persistPromise
+        if (!isLatestCreation()) {
+          await tearDownLive(live)
+          throw new Error(`[channels] ${keyId}: superseded live session creation discarded`)
+        }
         liveSessions.set(keyId, live)
       }
 
@@ -2623,6 +2769,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.baseContextBytes = measureTranscriptBytes(transcriptPathForBase)
       }
 
+      if (!isLatestCreation()) {
+        await unwindInstalledLive(keyId, live)
+        throw new Error(`[channels] ${keyId}: superseded live session creation discarded`)
+      }
+      adoptPendingReloadHandoff(live)
       logger.info(`[channels] ${keyId}: ensureLive done (${phase})`)
       return live
     })()
@@ -2631,21 +2782,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     try {
       return await raceWithTimeout(promise, ensureLiveTimeoutMs, `[channels] ${keyId} ensureLive`)
     } catch (err) {
-      // The orphaned `promise` may still settle eventually; that's OK because
-      // the only side effect it produces post-timeout is a `liveSessions.set`,
-      // which the next inbound's existence-check short-circuit at the top of
-      // ensureLive will treat as a usable warm session — strictly better than
-      // a permanent silent drop. The caller (route() in this file, ultimately
-      // the adapter's outer catch) sees the timeout error and logs it.
+      // A timed-out creation may still settle, but the durable creation token
+      // discards it if a later creation has claimed ownership of this key.
       logger.error(`[channels] ${keyId}: ensureLive failed: ${describeError(err)}`)
       throw err
     } finally {
-      // Owner-checked delete: only clear the in-flight marker if it still points
-      // at THIS promise. A watchdog timeout can orphan a slow creation whose
-      // `finally` runs while a later inbound has already installed its own
-      // `creating` entry for the same key; an unconditional delete would drop
-      // that newer entry and let a third inbound cold-start a duplicate session
-      // (observed: 3 concurrent sessions approving the same PR).
       if (creating.get(keyId) === promise) creating.delete(keyId)
     }
   }
@@ -3839,9 +3980,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const carriedInbounds = live.promptQueue.splice(0, live.promptQueue.length)
       const carriedObserved = live.contextBuffer.splice(0, live.contextBuffer.length)
       const carriedReminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
+      const hasCarriedWork = carriedInbounds.length > 0 || carriedObserved.length > 0 || carriedReminders.length > 0
+      const retained =
+        hasCarriedWork && retainReloadHandoff(live.key, carriedInbounds, carriedObserved, carriedReminders)
       liveSessions.delete(live.keyId)
       await tearDownLive(live)
-      await handOffToSuccessor(live.key, carriedInbounds, carriedObserved, carriedReminders)
+      if (retained) await handOffToSuccessor(live.key)
     }
   }
 
@@ -3886,33 +4030,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // were enqueued while draining), so they are transplanted straight onto the
   // fresh session's queues rather than re-routed through route() — re-routing
   // would re-run the claim/command/permission gates and re-derive engagement
-  // from a lossy QueuedInbound projection. Best-effort: a recreate failure logs
-  // and drops the batch rather than throwing out of the predecessor's drain.
-  const handOffToSuccessor = async (
-    key: ChannelKey,
-    inbounds: QueuedInbound[],
-    observed: ObservedInbound[],
-    reminders: PendingSystemReminder[],
-  ): Promise<void> => {
-    // Observed context alone is carried too: observe() can buffer post-reload
-    // messages onto contextBuffer with no queued prompt, and dropping them would
-    // lose the successor's "recent context". Only skip when nothing at all was
-    // carried.
-    if (inbounds.length === 0 && reminders.length === 0 && observed.length === 0) return
-    let successor: LiveSession
+  // from a lossy QueuedInbound projection. The batch is retained BEFORE the
+  // recreate attempt so a timeout leaves it available to the next successful
+  // ensureLive rather than dropping the user's messages at the handoff seam.
+  const handOffToSuccessor = async (key: ChannelKey): Promise<void> => {
     try {
-      successor = await ensureLive(key)
+      await ensureLive(key)
     } catch (err) {
-      logger.warn(`[channels] ${channelKeyId(key)}: successor recreate after reload failed: ${describeError(err)}`)
-      return
+      logger.warn(
+        `[channels] ${channelKeyId(key)}: successor recreate after reload failed; queued work retained for the next successful session: ${describeError(err)}`,
+      )
     }
-    if (successor.destroyed) return
-    successor.promptQueue.push(...inbounds)
-    successor.contextBuffer.push(...observed)
-    successor.pendingSystemReminders.push(...reminders)
-    // Observed-only context is NOT a turn trigger — it waits on contextBuffer for
-    // a real inbound. Drain only when there is actual work (a prompt or reminder).
-    if ((inbounds.length > 0 || reminders.length > 0) && !successor.draining) void drain(successor)
   }
 
   const scheduleDebouncedDrain = (live: LiveSession): void => {
@@ -5975,6 +6103,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const runIdleGc = async (): Promise<void> => {
+    await expirePendingReloadHandoffs()
     const t = now()
     const victims: LiveSession[] = []
     for (const live of liveSessions.values()) {
@@ -6009,6 +6138,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (gcTimer) clearInterval(gcTimer)
     gcTimer = null
     liveGeneration++
+    const pendingHandoffs = Array.from(pendingReloadHandoffs.values())
+    pendingReloadHandoffs.clear()
+    for (const pending of pendingHandoffs) {
+      void reportDiscardedReloadHandoff(pending, 'router stopped before replay could complete')
+    }
     const all = Array.from(liveSessions.values())
     liveSessions.clear()
     for (const live of all) {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -64,7 +64,7 @@ import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistr
 import { createPluginLogger } from '@/plugin/context'
 import type { CronHandlerContext } from '@/plugin/types'
 import { createContainerBroker, publishForwardResult, subscribeForwardRequest } from '@/portbroker'
-import { formatChannelReloadSummary, ReloadRegistry, type ReloadAllResult } from '@/reload'
+import { formatChannelReloadSummary, ReloadRegistry, type ReloadAllResult, type ReloadContext } from '@/reload'
 import { createClaimController } from '@/role-claim'
 import {
   exportClaudeCredentialsFileForAgent,
@@ -205,11 +205,11 @@ async function startAgentRuntime(
 ): Promise<StartAgentResult> {
   const reloadRegistry = new ReloadRegistry()
 
-  const reloadAllNonDestructive = async (): Promise<ReloadAllResult> => {
+  const reloadAllNonDestructive = async (context?: ReloadContext): Promise<ReloadAllResult> => {
     const results = []
     for (const item of reloadRegistry.list()) {
       if (item.scope === 'providers') continue
-      results.push(await reloadRegistry.reloadOne(item.scope))
+      results.push(await reloadRegistry.reloadOne(item.scope, context))
     }
     return { results }
   }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -64,7 +64,7 @@ import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistr
 import { createPluginLogger } from '@/plugin/context'
 import type { CronHandlerContext } from '@/plugin/types'
 import { createContainerBroker, publishForwardResult, subscribeForwardRequest } from '@/portbroker'
-import { formatChannelReloadSummary, ReloadRegistry } from '@/reload'
+import { formatChannelReloadSummary, ReloadRegistry, type ReloadAllResult } from '@/reload'
 import { createClaimController } from '@/role-claim'
 import {
   exportClaudeCredentialsFileForAgent,
@@ -204,6 +204,15 @@ async function startAgentRuntime(
   registerBootCleanup: (cleanup: () => void | Promise<void>) => void,
 ): Promise<StartAgentResult> {
   const reloadRegistry = new ReloadRegistry()
+
+  const reloadAllNonDestructive = async (): Promise<ReloadAllResult> => {
+    const results = []
+    for (const item of reloadRegistry.list()) {
+      if (item.scope === 'providers') continue
+      results.push(await reloadRegistry.reloadOne(item.scope))
+    }
+    return { results }
+  }
 
   // Wrap globalThis.fetch BEFORE any plugin/session/manager construction so
   // every LLM provider stream from anywhere in the container is guarded. Logs
@@ -496,7 +505,7 @@ async function startAgentRuntime(
         .filter((child) => child.status === 'running' && child.background === true)
         .map((child) => child.subagentName),
     onReload: async () => {
-      const { results } = await reloadRegistry.reloadAll()
+      const { results } = await reloadAllNonDestructive()
       return formatChannelReloadSummary(results)
     },
     // Always registered so /restart's presence in /help, the Slack manifest,
@@ -1030,7 +1039,7 @@ async function startAgentRuntime(
 
   const serverFactory = createServer({
     port,
-    reloadAll: () => reloadRegistry.reloadAll(),
+    reloadAll: reloadAllNonDestructive,
     reloadRegistry,
     sessionFactory,
     stream,


### PR DESCRIPTION
## Correction (2026-08-31)

**This PR does NOT fix the 2026-08-28 outage.** This PR was opened during the investigation of that outage on the hypothesis that a failed reload handoff silently dropped the 14 queued Discord messages. Host container logs, not available at the time, have since refuted that hypothesis: there is no reload, handoff, `ensureLive failed`, or teardown line anywhere in the incident window.

The proven root cause was a poisoned channel session that stayed registered as live after going structurally dead, with the router repeatedly feeding it messages that produced no assistant output. That's tracked in **#184** ("In-memory poisoned channel session can outlive its restart-only escape hatch," reopened), fix in review at **#1413** ("Gate poisoned-session recovery on fingerprint").

**What still stands on its own:** the same investigation independently found and verified a real, separate bug: `handOffToSuccessor` genuinely discards queued inbounds, observed context, and pending reminders when the successor session's `ensureLive()` throws during a reload. That code path is real, reproducible outside this incident, and this PR closes it on its own merits — it just isn't what caused the 08-28 outage.

---

## Summary

- retain post-reload inbounds, observed context, and reminders when successor session creation fails
- replay retained work in order on the next successful session without double delivery
- bound retry retention by age, key count, per-key item count, and byte size, with operator-visible loss reporting on ultimate discard
- reserve provider invalidation for explicit provider reloads across model, channel, and server entry points

## Why: the loss mechanism this closes

A deferred reload teardown splices the stale session's queued inbounds, observed context, and pending reminders off `promptQueue`/`contextBuffer`/`pendingSystemReminders` before handing off to a freshly-created successor via `ensureLive`. When that recreate attempt failed, `handOffToSuccessor` had nowhere to put the spliced batch — it logged a warning and returned, and the batch was gone. From the user's side this reads as "the agent stopped responding" with no error surfaced anywhere they can see.

## Retention design

- **Key-scoped, ordered, exactly-once.** A failed handoff calls `retainReloadHandoff` to stash the spliced batch under the channel key BEFORE the recreate attempt runs, so a timeout leaves the batch available rather than discarding it. `adoptPendingReloadHandoff` deletes the entry before enqueueing onto the live session's queues, so a second `ensureLive` on the same key can never replay the same batch twice.
- **Timeout-orphan protection.** `ensureLive` now stamps every creation attempt with a monotonic `creationToken` in `latestCreationTokens`. A watchdog timeout only releases the caller — it can't cancel the in-flight factory — so a late-settling orphaned attempt checks `isLatestCreation()` at each install point (post-create, cold-start install, warm-install, and final install) and disposes/tears down itself instead of overwriting a retry's mapping or double-adopting the retained handoff.
- **Bounds.** Retention is capped on four axes so a stalled reload path can't leak memory: TTL (`RELOAD_HANDOFF_RETENTION_MS`, 15 min), key count (`MAX_PENDING_RELOAD_HANDOFF_KEYS`, 100), per-key item count (`MAX_PENDING_RELOAD_HANDOFF_ITEMS_PER_KEY`, 1000), and per-key/global byte size (8 MiB / 64 MiB). TTL, per-key item count, and per-key byte size are test seams on `CreateChannelRouterOptions` so those three bounds are exercisable without manufacturing production-sized batches; key count and the global byte total are fixed production constants.
- **Visible on discard.** Any bound crossed, or the TTL expiring before a successful session shows up, runs `reportDiscardedReloadHandoff`: an operator-facing log line plus a system message sent to the actual channel naming the item count, the reason, and the recovery step (resend, or `reload({ scope: 'providers' })` if credentials changed). Silent trimming was the original bug; this replaces it with a stated loss instead of a smaller silent loss.
- **Engage-reaction cleanup.** A discarded batch also unwinds any `:eyes:` engage reactions still attached to its retained inbounds (`dropPendingReloadHandoffEngageReactions`) so a discarded message doesn't keep a stale "seen" marker with no reply ever coming.

## Reload scoping rationale

Provider credential invalidation tears down and recreates every live channel session — expensive and, worse, itself a source of the handoff race above. `createReloadTool`'s unscoped path (no `scope` arg) now skips `providers` entirely and only runs non-destructive reloadables in registration order; `reload({ scope: 'providers' })` still forces provider invalidation explicitly when credentials actually changed. `startAgentRuntime`'s `reloadAllNonDestructive` applies the identical scope filter for the channel `/reload` command path and the server's `reloadAll`, so routine reload traffic no longer pays the provider-teardown cost or risks the handoff race for no reason. Host credential rotation is untouched: it forwards its `ReloadContext` straight to the channel-scoped reload, so a real credential rotation still reaches the channels that need it.

## What this does NOT do

- Does not change what a reload does to non-channel reloadables (config, plugins, skills, cron) — only the `providers` scope moved behind an explicit call.
- Does not add a new user-facing command; `reload({ scope: 'providers' })` uses the tool's existing scope parameter.
- Does not change engagement/routing decisions for a live inbound — retention only fires on the reload-handoff-failure path.

## Tests

- Failed handoff retains queued inbounds, observed context, and reminders, and replays them in order on the next successful session.
- Successful handoff delivers its queued inbound exactly once (no double delivery from a stale retained copy).
- A timed-out reload successor cannot replace the retry that already replayed the retained work, verified against the creation-token guard.
- Expired retention reports the loss and recovery path to both the channel and the operator log.
- Oversized batches report the whole rejected batch instead of silently trimming it.
- Creation tokens are released after ordinary successful sessions settle (no leak on the happy path).
- Unscoped reload skips forced provider invalidation; explicit `scope: 'providers'` still forces it.

## Verification

- `bun run test` — 13,305 pass, 31 skip
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format` / `bun run format:check` — clean

Related: #1336 (not closed)
</content>
