### PR TITLE
Detect and backfill missed Discord messages

### DIFF
--- a/src/channels/adapters/discord-bot-recovery.test.ts
+++ b/src/channels/adapters/discord-bot-recovery.test.ts
@@ -80,6 +80,23 @@ describe('discord-bot recovery store', () => {
     expect(store.listReplayCursors()).toEqual([])
     expect(store.disconnectedAt()).toBeNull()
   })
+
+  test('merges fresh channel cursors into retained replay anchors on a later disconnect', async () => {
+    const store = await loadDiscordBotRecoveryStore(agentDir)
+    await store.markProcessed({ channelId: 'channel-1', workspace: 'guild-1', messageId: '101', processedAt: 1 })
+    await store.markProcessed({ channelId: 'channel-2', workspace: 'guild-1', messageId: '102', processedAt: 2 })
+    await store.markDisconnected(3)
+    await store.completeReplay('channel-2')
+    await store.markProcessed({ channelId: 'channel-2', workspace: 'guild-1', messageId: '103', processedAt: 4 })
+
+    await store.markDisconnected(5)
+
+    expect(store.listReplayCursors()).toEqual([
+      { channelId: 'channel-1', workspace: 'guild-1', messageId: '101', processedAt: 1 },
+      { channelId: 'channel-2', workspace: 'guild-1', messageId: '103', processedAt: 4 },
+    ])
+    expect(store.disconnectedAt()).toBe(3)
+  })
 })
 
 describe('discord-bot bounded backfill', () => {

--- a/src/channels/adapters/discord-bot-recovery.test.ts
+++ b/src/channels/adapters/discord-bot-recovery.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  DISCORD_BACKFILL_MAX_AGE_MS,
+  DISCORD_BACKFILL_MAX_MESSAGES,
+  fetchDiscordBackfill,
+  loadDiscordBotRecoveryStore,
+} from './discord-bot-recovery'
+
+describe('discord-bot recovery store', () => {
+  let agentDir: string
+
+  beforeEach(async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-discord-recovery-'))
+  })
+
+  afterEach(async () => {
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('persists the newest processed snowflake per channel and disconnect start', async () => {
+    const store = await loadDiscordBotRecoveryStore(agentDir)
+    expect(store.listCursors()).toEqual([])
+    expect(store.disconnectedAt()).toBeNull()
+
+    await store.markProcessed({
+      channelId: 'channel-1',
+      workspace: 'guild-1',
+      messageId: '100000000000000001',
+      processedAt: 1_000,
+    })
+    await store.markProcessed({
+      channelId: 'channel-1',
+      workspace: 'guild-1',
+      messageId: '100000000000000000',
+      processedAt: 900,
+    })
+    await store.markDisconnected(1_500)
+
+    const reloaded = await loadDiscordBotRecoveryStore(agentDir)
+    expect(reloaded.listCursors()).toEqual([
+      {
+        channelId: 'channel-1',
+        workspace: 'guild-1',
+        messageId: '100000000000000001',
+        processedAt: 1_000,
+      },
+    ])
+    expect(reloaded.listReplayCursors()).toEqual(reloaded.listCursors())
+    expect(reloaded.disconnectedAt()).toBe(1_500)
+
+    await reloaded.markProcessed({
+      channelId: 'channel-1',
+      workspace: 'guild-1',
+      messageId: '100000000000000003',
+      processedAt: 2_000,
+    })
+    expect(reloaded.isReplayProcessed('channel-1', '100000000000000002')).toBe(false)
+    expect(reloaded.isReplayProcessed('channel-1', '100000000000000003')).toBe(true)
+    expect(reloaded.listReplayCursors()[0]?.messageId).toBe('100000000000000001')
+
+    await reloaded.completeReplay('channel-1')
+    expect((await loadDiscordBotRecoveryStore(agentDir)).disconnectedAt()).toBeNull()
+  })
+
+  test('clears only completed replay anchors', async () => {
+    const store = await loadDiscordBotRecoveryStore(agentDir)
+    await store.markProcessed({ channelId: 'channel-1', workspace: 'guild-1', messageId: '101', processedAt: 1 })
+    await store.markProcessed({ channelId: 'channel-2', workspace: 'guild-1', messageId: '102', processedAt: 2 })
+    await store.markDisconnected(3)
+
+    await store.completeReplay('channel-2')
+
+    expect(store.listReplayCursors().map((cursor) => cursor.channelId)).toEqual(['channel-1'])
+    expect(store.disconnectedAt()).toBe(3)
+    await store.completeReplay('channel-1')
+    expect(store.listReplayCursors()).toEqual([])
+    expect(store.disconnectedAt()).toBeNull()
+  })
+})
+
+describe('discord-bot bounded backfill', () => {
+  test('returns missed messages exactly once in chronological snowflake order', async () => {
+    const calls: string[] = []
+    const fetchImpl = (async (input: string | URL | Request) => {
+      calls.push(String(input))
+      if (!String(input).includes('/messages?')) return Response.json({ id: 'channel-1', guild_id: 'guild-1' })
+      return Response.json([
+        discordMessage('100000000000000003', 'third', '2026-08-28T10:03:00.000Z'),
+        discordMessage('100000000000000001', 'first', '2026-08-28T10:01:00.000Z'),
+        discordMessage('100000000000000002', 'second', '2026-08-28T10:02:00.000Z'),
+      ])
+    }) as typeof fetch
+
+    const result = await fetchDiscordBackfill({
+      channelId: 'channel-1',
+      workspace: 'guild-1',
+      after: '100000000000000000',
+      token: 'test-token',
+      fetchImpl,
+      now: Date.parse('2026-08-28T10:04:00.000Z'),
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      outcome: 'succeeded',
+      skipped: 0,
+      skippedByAge: 0,
+      skippedByCount: 0,
+    })
+    if (!result.ok) throw new Error('expected backfill success')
+    expect(result.messages.map((message) => message.id)).toEqual([
+      '100000000000000001',
+      '100000000000000002',
+      '100000000000000003',
+    ])
+    const request = new URL(calls.find((call) => call.includes('/messages?'))!)
+    expect(request.searchParams.get('after')).toBe('100000000000000000')
+    expect(request.searchParams.get('limit')).toBe(String(DISCORD_BACKFILL_MAX_MESSAGES + 1))
+  })
+
+  test('caps a long outage to recent messages and reports every observed skip', async () => {
+    const now = Date.parse('2026-08-28T12:00:00.000Z')
+    const raw = Array.from({ length: DISCORD_BACKFILL_MAX_MESSAGES + 1 }, (_, index) => {
+      const id = String(100000000000000001n + BigInt(index))
+      const timestamp = new Date(now - index * 1_000).toISOString()
+      return discordMessage(id, `message-${index}`, timestamp)
+    })
+    raw[raw.length - 1]!.timestamp = new Date(now - DISCORD_BACKFILL_MAX_AGE_MS - 1).toISOString()
+
+    const result = await fetchDiscordBackfill({
+      channelId: 'channel-1',
+      workspace: 'guild-1',
+      after: '100000000000000000',
+      token: 'test-token',
+      fetchImpl: backfillFetch(raw),
+      now,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      outcome: 'capped',
+      skipped: 1,
+      skippedByAge: 1,
+      skippedByCount: 0,
+      moreMayExist: true,
+    })
+    if (!result.ok) throw new Error('expected backfill success')
+    expect(result.messages).toHaveLength(DISCORD_BACKFILL_MAX_MESSAGES)
+  })
+
+  test('reports count overflow separately from age trimming', async () => {
+    const now = Date.parse('2026-08-28T12:00:00.000Z')
+    const raw = Array.from({ length: DISCORD_BACKFILL_MAX_MESSAGES + 1 }, (_, index) =>
+      discordMessage(
+        String(100000000000000001n + BigInt(index)),
+        `message-${index}`,
+        new Date(now - index * 1_000).toISOString(),
+      ),
+    )
+
+    const result = await fetchDiscordBackfill({
+      channelId: 'channel-1',
+      workspace: 'guild-1',
+      after: '100000000000000000',
+      token: 'test-token',
+      fetchImpl: backfillFetch(raw),
+      now,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      outcome: 'capped',
+      skipped: 1,
+      skippedByAge: 0,
+      skippedByCount: 1,
+      moreMayExist: true,
+    })
+  })
+
+  test('reports unavailable history instead of pretending replay succeeded', async () => {
+    const result = await fetchDiscordBackfill({
+      channelId: 'channel-1',
+      workspace: 'guild-1',
+      after: '100000000000000000',
+      token: 'test-token',
+      fetchImpl: backfillFetch([], 403),
+      now: 0,
+    })
+
+    expect(result).toEqual({ ok: false, outcome: 'unavailable', error: 'http 403' })
+  })
+
+  test('rejects a persisted workspace that does not own the channel', async () => {
+    const result = await fetchDiscordBackfill({
+      channelId: 'channel-1',
+      workspace: 'guild-other',
+      after: '100000000000000000',
+      token: 'test-token',
+      fetchImpl: backfillFetch([]),
+      now: 0,
+    })
+
+    expect(result).toEqual({ ok: false, outcome: 'unavailable', error: 'channel workspace mismatch' })
+  })
+})
+
+function discordMessage(id: string, content: string, timestamp: string) {
+  return {
+    id,
+    channel_id: 'channel-1',
+    guild_id: 'guild-1',
+    author: { id: 'user-1', username: 'test-user', bot: false },
+    content,
+    timestamp,
+  }
+}
+
+function backfillFetch(messages: ReturnType<typeof discordMessage>[], historyStatus = 200): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    if (!String(input).includes('/messages?')) return Response.json({ id: 'channel-1', guild_id: 'guild-1' })
+    return historyStatus === 200 ? Response.json(messages) : new Response(null, { status: historyStatus })
+  }) as typeof fetch
+}

--- a/src/channels/adapters/discord-bot-recovery.ts
+++ b/src/channels/adapters/discord-bot-recovery.ts
@@ -176,11 +176,18 @@ function createRecoveryStore(
     },
     markDisconnected: async (at) => {
       await mutate(() => {
-        if (disconnectedAt !== null) return false
-        disconnectedAt = at
-        replayCursors.clear()
-        for (const [channelId, cursor] of cursors) replayCursors.set(channelId, cursor)
-        return true
+        let changed = false
+        if (disconnectedAt === null) {
+          disconnectedAt = at
+          replayCursors.clear()
+          changed = true
+        }
+        for (const [channelId, cursor] of cursors) {
+          if (replayCursors.has(channelId)) continue
+          replayCursors.set(channelId, cursor)
+          changed = true
+        }
+        return changed
       })
     },
     completeReplay: async (channelId) => {

--- a/src/channels/adapters/discord-bot-recovery.ts
+++ b/src/channels/adapters/discord-bot-recovery.ts
@@ -1,0 +1,380 @@
+import { randomUUID } from 'node:crypto'
+import { lstat, mkdir, open, readFile, rename, rm } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+import type {
+  DiscordFile,
+  DiscordGatewayEmbed,
+  DiscordGatewayStickerItem,
+  DiscordUser,
+} from 'agent-messenger/discordbot'
+
+import { describeError } from '../describe-error'
+
+const FILE_VERSION = 1
+export const DISCORD_BACKFILL_MAX_MESSAGES = 50
+export const DISCORD_BACKFILL_MAX_AGE_MS = 30 * 60 * 1_000
+export const DISCORD_BACKFILL_REQUEST_TIMEOUT_MS = 10_000
+const RECENT_MESSAGE_IDS_PER_CHANNEL = DISCORD_BACKFILL_MAX_MESSAGES * 4
+
+export type DiscordBotRecoveryCursor = {
+  channelId: string
+  workspace: string
+  messageId: string
+  processedAt: number
+}
+
+export type DiscordBackfillMessage = {
+  id: string
+  channel_id: string
+  guild_id?: string
+  type?: number
+  author: { id: string; username: string; global_name?: string | null; bot?: boolean }
+  content: string
+  timestamp: string
+  mentions?: DiscordUser[]
+  mention_everyone?: boolean
+  mention_roles?: string[]
+  message_reference?: { message_id?: string; channel_id?: string; guild_id?: string }
+  attachments?: DiscordFile[]
+  embeds?: DiscordGatewayEmbed[]
+  sticker_items?: DiscordGatewayStickerItem[]
+}
+
+type RecoveryFileV1 = {
+  version: 1
+  disconnectedAt: number | null
+  cursors: DiscordBotRecoveryCursor[]
+  replayCursors: DiscordBotRecoveryCursor[]
+  recentMessageIds: Array<{ channelId: string; messageIds: string[] }>
+}
+
+export type DiscordBotRecoveryStore = {
+  listCursors: () => DiscordBotRecoveryCursor[]
+  listReplayCursors: () => DiscordBotRecoveryCursor[]
+  disconnectedAt: () => number | null
+  isProcessed: (channelId: string, messageId: string) => boolean
+  isReplayProcessed: (channelId: string, messageId: string) => boolean
+  markProcessed: (cursor: DiscordBotRecoveryCursor) => Promise<void>
+  markDisconnected: (at: number) => Promise<void>
+  completeReplay: (channelId: string) => Promise<void>
+}
+
+export type DiscordBotRecoveryLogger = {
+  warn: (message: string) => void
+  error: (message: string) => void
+}
+
+const consoleLogger: DiscordBotRecoveryLogger = {
+  warn: (message) => console.warn(message),
+  error: (message) => console.error(message),
+}
+
+export function discordBotRecoveryPath(agentDir: string): string {
+  return join(agentDir, 'channels', 'discord-bot-recovery.json')
+}
+
+export async function loadDiscordBotRecoveryStore(
+  agentDir: string,
+  logger: DiscordBotRecoveryLogger = consoleLogger,
+): Promise<DiscordBotRecoveryStore> {
+  const path = discordBotRecoveryPath(agentDir)
+  const state = await readRecoveryState(path, logger)
+  return createRecoveryStore(state, async (file) => {
+    const directory = dirname(path)
+    await mkdir(directory, { recursive: true })
+    const directoryStat = await lstat(directory)
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+      throw new Error(`Discord recovery directory is not a real directory: ${directory}`)
+    }
+    const temporaryPath = join(directory, `.${basename(path)}.${randomUUID()}.tmp`)
+    const temporary = await open(temporaryPath, 'wx', 0o600)
+    try {
+      await temporary.writeFile(`${JSON.stringify(file, null, 2)}\n`, 'utf8')
+      await temporary.close()
+      await rename(temporaryPath, path)
+    } finally {
+      await temporary.close().catch(() => {})
+      await rm(temporaryPath, { force: true }).catch(() => {})
+    }
+  })
+}
+
+export function createInMemoryDiscordBotRecoveryStore(): DiscordBotRecoveryStore {
+  return createRecoveryStore(
+    { version: FILE_VERSION, disconnectedAt: null, cursors: [], replayCursors: [], recentMessageIds: [] },
+    async () => {},
+  )
+}
+
+function createRecoveryStore(
+  initial: RecoveryFileV1,
+  persist: (state: RecoveryFileV1) => Promise<void>,
+): DiscordBotRecoveryStore {
+  const cursors = new Map(initial.cursors.map((cursor) => [cursor.channelId, cursor]))
+  const replayCursors = new Map(initial.replayCursors.map((cursor) => [cursor.channelId, cursor]))
+  const recentMessageIds = new Map(
+    initial.recentMessageIds.map((entry) => [entry.channelId, new Set(entry.messageIds)]),
+  )
+  let disconnectedAt = initial.disconnectedAt
+  let writeBarrier = Promise.resolve()
+
+  const mutate = async (operation: () => boolean): Promise<void> => {
+    const write = writeBarrier.then(async () => {
+      if (!operation()) return
+      await persist({
+        version: FILE_VERSION,
+        disconnectedAt,
+        cursors: Array.from(cursors.values()),
+        replayCursors: Array.from(replayCursors.values()),
+        recentMessageIds: Array.from(recentMessageIds, ([channelId, messageIds]) => ({
+          channelId,
+          messageIds: Array.from(messageIds),
+        })),
+      })
+    })
+    writeBarrier = write.catch(() => {})
+    await write
+  }
+
+  return {
+    listCursors: () => Array.from(cursors.values()),
+    listReplayCursors: () => Array.from(replayCursors.values()),
+    disconnectedAt: () => disconnectedAt,
+    isProcessed: (channelId, messageId) => {
+      const cursor = cursors.get(channelId)
+      return cursor !== undefined && compareSnowflakes(messageId, cursor.messageId) <= 0
+    },
+    isReplayProcessed: (channelId, messageId) => {
+      const anchor = replayCursors.get(channelId)
+      return (
+        (anchor !== undefined && compareSnowflakes(messageId, anchor.messageId) <= 0) ||
+        recentMessageIds.get(channelId)?.has(messageId) === true
+      )
+    },
+    markProcessed: async (cursor) => {
+      await mutate(() => {
+        const current = cursors.get(cursor.channelId)
+        let changed = false
+        if (current === undefined || compareSnowflakes(cursor.messageId, current.messageId) > 0) {
+          cursors.set(cursor.channelId, cursor)
+          changed = true
+        }
+        const recent = recentMessageIds.get(cursor.channelId) ?? new Set<string>()
+        if (!recent.has(cursor.messageId)) {
+          recent.add(cursor.messageId)
+          while (recent.size > RECENT_MESSAGE_IDS_PER_CHANNEL) {
+            const oldest = recent.values().next().value
+            if (oldest === undefined) break
+            recent.delete(oldest)
+          }
+          recentMessageIds.set(cursor.channelId, recent)
+          changed = true
+        }
+        return changed
+      })
+    },
+    markDisconnected: async (at) => {
+      await mutate(() => {
+        if (disconnectedAt !== null) return false
+        disconnectedAt = at
+        replayCursors.clear()
+        for (const [channelId, cursor] of cursors) replayCursors.set(channelId, cursor)
+        return true
+      })
+    },
+    completeReplay: async (channelId) => {
+      await mutate(() => {
+        if (!replayCursors.delete(channelId)) return false
+        if (replayCursors.size === 0) disconnectedAt = null
+        return true
+      })
+    },
+  }
+}
+
+export type DiscordBackfillResult =
+  | {
+      ok: true
+      outcome: 'succeeded' | 'capped'
+      messages: DiscordBackfillMessage[]
+      skipped: number
+      skippedByAge: number
+      skippedByCount: number
+      moreMayExist: boolean
+    }
+  | { ok: false; outcome: 'unavailable'; error: string }
+
+export async function fetchDiscordBackfill(args: {
+  channelId: string
+  workspace: string
+  after: string
+  token: string
+  fetchImpl: typeof fetch
+  now: number
+}): Promise<DiscordBackfillResult> {
+  const workspace = await fetchDiscordChannelWorkspace(args)
+  if (!workspace.ok) return workspace
+  if (workspace.workspace !== args.workspace) {
+    return { ok: false, outcome: 'unavailable', error: 'channel workspace mismatch' }
+  }
+
+  const limit = DISCORD_BACKFILL_MAX_MESSAGES + 1
+  const params = new URLSearchParams({ after: args.after, limit: String(limit) })
+  let response: Response
+  try {
+    response = await args.fetchImpl(`https://discord.com/api/v10/channels/${args.channelId}/messages?${params}`, {
+      method: 'GET',
+      headers: { Authorization: `Bot ${args.token}` },
+      signal: AbortSignal.timeout(DISCORD_BACKFILL_REQUEST_TIMEOUT_MS),
+    })
+  } catch (error) {
+    return { ok: false, outcome: 'unavailable', error: describeError(error) }
+  }
+  if (!response.ok) return { ok: false, outcome: 'unavailable', error: `http ${response.status}` }
+
+  let raw: DiscordBackfillMessage[]
+  try {
+    const parsed: unknown = await response.json()
+    if (!Array.isArray(parsed) || !parsed.every(isBackfillMessage)) {
+      return { ok: false, outcome: 'unavailable', error: 'invalid message history response' }
+    }
+    if (parsed.some((message) => message.channel_id !== args.channelId)) {
+      return { ok: false, outcome: 'unavailable', error: 'message history channel mismatch' }
+    }
+    raw = parsed
+  } catch (error) {
+    return { ok: false, outcome: 'unavailable', error: `parse failed: ${describeError(error)}` }
+  }
+
+  const cutoff = args.now - DISCORD_BACKFILL_MAX_AGE_MS
+  const recent = raw.filter((message) => {
+    const timestamp = Date.parse(message.timestamp)
+    return Number.isFinite(timestamp) && timestamp >= cutoff
+  })
+  const selected = recent
+    .sort((left, right) => compareSnowflakes(left.id, right.id))
+    .slice(-DISCORD_BACKFILL_MAX_MESSAGES)
+  const skippedByAge = raw.length - recent.length
+  const skippedByCount = recent.length - selected.length
+  const skipped = skippedByAge + skippedByCount
+  const moreMayExist = raw.length === limit
+  const outcome = skipped > 0 || moreMayExist ? 'capped' : 'succeeded'
+  return { ok: true, outcome, messages: selected, skipped, skippedByAge, skippedByCount, moreMayExist }
+}
+
+async function fetchDiscordChannelWorkspace(args: {
+  channelId: string
+  token: string
+  fetchImpl: typeof fetch
+}): Promise<{ ok: true; workspace: string } | { ok: false; outcome: 'unavailable'; error: string }> {
+  let response: Response
+  try {
+    response = await args.fetchImpl(`https://discord.com/api/v10/channels/${args.channelId}`, {
+      method: 'GET',
+      headers: { Authorization: `Bot ${args.token}` },
+      signal: AbortSignal.timeout(DISCORD_BACKFILL_REQUEST_TIMEOUT_MS),
+    })
+  } catch (error) {
+    return { ok: false, outcome: 'unavailable', error: `channel lookup failed: ${describeError(error)}` }
+  }
+  if (!response.ok) return { ok: false, outcome: 'unavailable', error: `channel lookup http ${response.status}` }
+  try {
+    const parsed: unknown = await response.json()
+    if (!isObject(parsed) || typeof parsed.id !== 'string' || parsed.id !== args.channelId) {
+      return { ok: false, outcome: 'unavailable', error: 'invalid channel lookup response' }
+    }
+    if (parsed.guild_id !== undefined && typeof parsed.guild_id !== 'string') {
+      return { ok: false, outcome: 'unavailable', error: 'invalid channel workspace response' }
+    }
+    return { ok: true, workspace: parsed.guild_id ?? '@dm' }
+  } catch (error) {
+    return { ok: false, outcome: 'unavailable', error: `channel lookup parse failed: ${describeError(error)}` }
+  }
+}
+
+function compareSnowflakes(left: string, right: string): number {
+  try {
+    const leftId = BigInt(left)
+    const rightId = BigInt(right)
+    return leftId < rightId ? -1 : leftId > rightId ? 1 : 0
+  } catch {
+    return left.localeCompare(right)
+  }
+}
+
+async function readRecoveryState(path: string, logger: DiscordBotRecoveryLogger): Promise<RecoveryFileV1> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    return emptyRecoveryFile()
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecoveryFile(parsed)) {
+      logger.warn(`[discord-bot] recovery state at ${path} is invalid; starting fresh`)
+      return emptyRecoveryFile()
+    }
+    return parsed
+  } catch (error) {
+    logger.error(`[discord-bot] recovery state at ${path} is corrupted: ${describeError(error)}; starting fresh`)
+    return emptyRecoveryFile()
+  }
+}
+
+function isRecoveryFile(value: unknown): value is RecoveryFileV1 {
+  if (
+    !isObject(value) ||
+    value.version !== FILE_VERSION ||
+    !Array.isArray(value.cursors) ||
+    !Array.isArray(value.replayCursors) ||
+    !Array.isArray(value.recentMessageIds)
+  )
+    return false
+  if (value.disconnectedAt !== null && typeof value.disconnectedAt !== 'number') return false
+  return (
+    value.cursors.every(isCursor) &&
+    value.replayCursors.every(isCursor) &&
+    value.recentMessageIds.every(isRecentMessageIds)
+  )
+}
+
+function emptyRecoveryFile(): RecoveryFileV1 {
+  return { version: FILE_VERSION, disconnectedAt: null, cursors: [], replayCursors: [], recentMessageIds: [] }
+}
+
+function isRecentMessageIds(value: unknown): value is RecoveryFileV1['recentMessageIds'][number] {
+  return (
+    isObject(value) &&
+    typeof value.channelId === 'string' &&
+    Array.isArray(value.messageIds) &&
+    value.messageIds.every((messageId) => typeof messageId === 'string')
+  )
+}
+
+function isCursor(value: unknown): value is DiscordBotRecoveryCursor {
+  return (
+    isObject(value) &&
+    typeof value.channelId === 'string' &&
+    typeof value.workspace === 'string' &&
+    typeof value.messageId === 'string' &&
+    typeof value.processedAt === 'number'
+  )
+}
+
+function isBackfillMessage(value: unknown): value is DiscordBackfillMessage {
+  if (!isObject(value) || !isObject(value.author)) return false
+  return (
+    typeof value.id === 'string' &&
+    typeof value.channel_id === 'string' &&
+    typeof value.author.id === 'string' &&
+    typeof value.author.username === 'string' &&
+    typeof value.content === 'string' &&
+    typeof value.timestamp === 'string'
+  )
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -418,6 +418,49 @@ describe('discord-bot lifecycle', () => {
     expect(recoveryStore.disconnectedAt()).toBeNull()
   })
 
+  test('completes a count-capped replay after reporting and delivering the bounded subset', async () => {
+    const recoveryStore = createInMemoryDiscordBotRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '800000000000000001',
+      workspace: '700000000000000001',
+      messageId: '100000000000000000',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    const historyRequests: URL[] = []
+    const history = Array.from({ length: 51 }, (_, index) =>
+      gatewayMessage(String(100000000000000001n + BigInt(index)), `missed-${index + 1}`),
+    )
+    const warnings: string[] = []
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
+      fetchImpl: discordRecoveryFetch(historyRequests, history),
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+      recoveryStore,
+      now: () => Date.parse('2026-08-28T10:05:00.000Z'),
+    })
+
+    await adapter.start()
+    await Bun.sleep(10)
+    listener.emit('connected', connectedInfo())
+    await adapter.stop()
+
+    expect(router.routed).toHaveLength(50)
+    expect(new Set(router.routed.map((message) => message.externalMessageId))).toHaveLength(50)
+    expect(historyRequests).toHaveLength(1)
+    expect(warnings.some((message) => message.includes('outcome=capped') && message.includes('skipped_count=1'))).toBe(
+      true,
+    )
+    expect(recoveryStore.listReplayCursors()).toEqual([])
+    expect(recoveryStore.disconnectedAt()).toBeNull()
+  })
+
   test('logs the nested reason of a gateway ErrorEvent, never [object ErrorEvent]', async () => {
     // given: a ws 'error' fires with an ErrorEvent, which is not an Error
     const errors: string[] = []

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -197,6 +197,117 @@ describe('discord-bot lifecycle', () => {
     expect(historyRequests).toEqual([])
   })
 
+  test('detects a silent gateway delivery gap and backfills it exactly once after recovery', async () => {
+    const recoveryStore = createInMemoryDiscordBotRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '800000000000000001',
+      workspace: '700000000000000001',
+      messageId: '100000000000000001',
+      processedAt: 1_000,
+    })
+    const missed = gatewayMessage('100000000000000002', '<@bot-1> missed')
+    const historyRequests: URL[] = []
+    const logs: string[] = []
+    let currentTime = 1_000
+    let livenessTick: (() => void) | undefined
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: {
+        info: (message) => logs.push(`info:${message}`),
+        warn: (message) => logs.push(`warn:${message}`),
+        error: (message) => logs.push(`error:${message}`),
+      },
+      fetchImpl: discordRecoveryFetch(historyRequests, [missed]),
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+      recoveryStore,
+      now: () => currentTime,
+      liveness: {
+        staleAfterMs: 100,
+        checkIntervalMs: 10,
+        setInterval: (fn) => {
+          livenessTick = fn
+          return 'liveness-timer'
+        },
+        clearInterval: () => {},
+      },
+    })
+
+    await adapter.start()
+    expect(historyRequests).toEqual([])
+    currentTime = 1_101
+    livenessTick?.()
+    await Bun.sleep(0)
+    await Bun.sleep(0)
+
+    expect(adapter.isConnected()).toBe(false)
+    expect(router.routed).toEqual([])
+    expect(recoveryStore.disconnectedAt()).toBe(1_101)
+    expect(logs.some((message) => message.includes('gateway delivery gap detected'))).toBe(true)
+
+    listener.emit('connected', connectedInfo())
+    listener.emit('message_create', missed)
+    await adapter.stop()
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual(['100000000000000002'])
+    expect(historyRequests).toHaveLength(2)
+    expect(logs.some((message) => message.includes('downtime_ms=0') && message.includes('outcome=succeeded'))).toBe(
+      true,
+    )
+  })
+
+  test('keeps an idle but gap-free gateway healthy', async () => {
+    const recoveryStore = createInMemoryDiscordBotRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '800000000000000001',
+      workspace: '700000000000000001',
+      messageId: '100000000000000010',
+      processedAt: 1_000,
+    })
+    const historyRequests: URL[] = []
+    let currentTime = 1_000
+    let livenessTick: (() => void) | undefined
+    let livenessTimerCleared = false
+    const adapter = createDiscordBotAdapter({
+      router: new FakeDiscordBotRouter().value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl: discordRecoveryFetch(historyRequests, []),
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => new FakeDiscordBotListener().value,
+      recoveryStore,
+      now: () => currentTime,
+      liveness: {
+        staleAfterMs: 100,
+        checkIntervalMs: 10,
+        setInterval: (fn) => {
+          livenessTick = fn
+          return 'liveness-timer'
+        },
+        clearInterval: () => {
+          livenessTimerCleared = true
+        },
+      },
+    })
+
+    await adapter.start()
+    currentTime = 1_101
+    livenessTick?.()
+    await Bun.sleep(0)
+    await Bun.sleep(0)
+
+    expect(adapter.isConnected()).toBe(true)
+    expect(recoveryStore.disconnectedAt()).toBeNull()
+    expect(historyRequests).toHaveLength(1)
+    await adapter.stop()
+    expect(livenessTimerCleared).toBe(true)
+  })
+
   test('does not let a slow live channel block another channel', async () => {
     let releaseSlowRoute: (() => void) | undefined
     const slowRoute = new Promise<void>((resolve) => {

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -31,6 +31,7 @@ import {
   DISCORD_SLASH_COMMAND_NAMES,
 } from './discord-bot'
 import { encodeDiscordReactionRef } from './discord-bot-reactions'
+import { createInMemoryDiscordBotRecoveryStore } from './discord-bot-recovery'
 import { DISCORD_SLASH_COMMAND_TYPE_CHAT_INPUT } from './discord-bot-slash-commands'
 
 const provenanceConfig: ChannelAdapterConfig = {
@@ -93,6 +94,328 @@ describe('discord-bot lifecycle', () => {
     expect(adapter.isConnected()).toBe(false)
     expect(listener.stopped).toBe(true)
     expect(router.unregistered).toEqual(router.registered)
+  })
+
+  test('backfills a reconnect gap once in order before newer live delivery', async () => {
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    const historyRequests: URL[] = []
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl: discordRecoveryFetch(historyRequests, [
+        gatewayMessage('100000000000000003', 'third'),
+        gatewayMessage('100000000000000002', '<@bot-1> second'),
+      ]),
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+      now: () => Date.parse('2026-08-28T10:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('100000000000000001', 'first'))
+    listener.emit('disconnected', 'transport closed')
+    listener.emit('connected', connectedInfo())
+    listener.emit('message_create', gatewayMessage('100000000000000003', 'third'))
+    await adapter.stop()
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual([
+      '100000000000000001',
+      '100000000000000002',
+      '100000000000000003',
+    ])
+    expect(router.routed[1]?.isBotMention).toBe(true)
+    expect(historyRequests).toHaveLength(1)
+    expect(historyRequests[0]?.searchParams.get('after')).toBe('100000000000000001')
+  })
+
+  test('serializes pre-connected gateway delivery with replay for the same message', async () => {
+    let releaseRoute: (() => void) | undefined
+    let targetRouteStarted: (() => void) | undefined
+    const routeStarted = new Promise<void>((resolve) => {
+      targetRouteStarted = resolve
+    })
+    const heldRoute = new Promise<void>((resolve) => {
+      releaseRoute = resolve
+    })
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter(async (message) => {
+      if (message.externalMessageId !== '100000000000000042') return
+      targetRouteStarted?.()
+      await heldRoute
+    })
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl: discordRecoveryFetch([], [gatewayMessage('100000000000000042', 'missed')]),
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('100000000000000041', 'before gap'))
+    await Bun.sleep(0)
+    listener.emit('disconnected', 'transport closed')
+    listener.emit('message_create', gatewayMessage('100000000000000042', 'missed'))
+    listener.emit('connected', connectedInfo())
+    await routeStarted
+    await Bun.sleep(5)
+    releaseRoute?.()
+    await adapter.stop()
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual([
+      '100000000000000041',
+      '100000000000000042',
+    ])
+  })
+
+  test('does not backfill or duplicate delivery during normal operation', async () => {
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    const historyRequests: URL[] = []
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl: discordRecoveryFetch(historyRequests, []),
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+    })
+
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
+    listener.emit('message_create', gatewayMessage('100000000000000010', 'normal'))
+    listener.emit('message_create', gatewayMessage('100000000000000010', 'normal'))
+    await adapter.stop()
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual(['100000000000000010'])
+    expect(historyRequests).toEqual([])
+  })
+
+  test('does not let a slow live channel block another channel', async () => {
+    let releaseSlowRoute: (() => void) | undefined
+    const slowRoute = new Promise<void>((resolve) => {
+      releaseSlowRoute = resolve
+    })
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter(async (message) => {
+      if (message.chat === '800000000000000001') await slowRoute
+    })
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl: discordRecoveryFetch([], []),
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('100000000000000020', 'slow'))
+    listener.emit('message_create', {
+      ...gatewayMessage('100000000000000021', 'independent'),
+      channel_id: '800000000000000002',
+    })
+    await Bun.sleep(5)
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual(['100000000000000021'])
+    releaseSlowRoute?.()
+    await adapter.stop()
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual([
+      '100000000000000021',
+      '100000000000000020',
+    ])
+  })
+
+  test('retains a failed replay anchor when newer live messages advance the cursor', async () => {
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    let historyAttempt = 0
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      if (url.pathname === '/api/v10/channels/800000000000000001') {
+        return Response.json({ id: '800000000000000001', guild_id: '700000000000000001' })
+      }
+      if (url.pathname.endsWith('/messages') && url.searchParams.has('after')) {
+        historyAttempt++
+        if (historyAttempt === 1) return new Response(null, { status: 503 })
+        return Response.json([
+          withoutDispatchType(gatewayMessage('100000000000000003', 'newer live')),
+          withoutDispatchType(gatewayMessage('100000000000000002', 'missed')),
+        ])
+      }
+      return Response.json({})
+    }) as typeof fetch
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl,
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+      now: () => Date.parse('2026-08-28T10:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('100000000000000001', 'first'))
+    listener.emit('disconnected', 'transport closed')
+    listener.emit('connected', connectedInfo())
+    listener.emit('message_create', gatewayMessage('100000000000000003', 'newer live'))
+    listener.emit('disconnected', 'transport closed')
+    listener.emit('connected', connectedInfo())
+    await adapter.stop()
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual([
+      '100000000000000001',
+      '100000000000000003',
+      '100000000000000002',
+    ])
+    expect(new Set(router.routed.map((message) => message.externalMessageId)).size).toBe(3)
+    expect(historyAttempt).toBe(2)
+  })
+
+  test('releases live delivery when reconnect recovery reaches its duration cap', async () => {
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    const warnings: string[] = []
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      if (init?.signal !== undefined && String(input).endsWith('/channels/800000000000000001')) {
+        return await new Promise<Response>(() => {})
+      }
+      const url = new URL(String(input))
+      if (url.pathname.startsWith('/api/v10/channels/')) {
+        return Response.json({ id: url.pathname.split('/').at(-1), guild_id: '700000000000000001' })
+      }
+      return Response.json({})
+    }) as typeof fetch
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
+      fetchImpl,
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+      recoveryMaxDurationMs: 5,
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('100000000000000030', 'before gap'))
+    listener.emit('disconnected', 'transport closed')
+    listener.emit('connected', connectedInfo())
+    listener.emit('message_create', gatewayMessage('100000000000000031', 'after timeout'))
+    await Bun.sleep(20)
+    await adapter.stop()
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual([
+      '100000000000000030',
+      '100000000000000031',
+    ])
+    expect(warnings.some((message) => message.includes('outcome=capped reason=duration'))).toBe(true)
+  })
+
+  test('retries a duration-capped replay anchor on the next connection', async () => {
+    const recoveryStore = createInMemoryDiscordBotRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '800000000000000001',
+      workspace: '700000000000000001',
+      messageId: '100000000000000050',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    let channelLookupAttempt = 0
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      if (url.pathname === '/api/v10/channels/800000000000000001') {
+        channelLookupAttempt++
+        if (channelLookupAttempt === 1) return await new Promise<Response>(() => {})
+        return Response.json({ id: '800000000000000001', guild_id: '700000000000000001' })
+      }
+      if (url.pathname.endsWith('/messages')) {
+        return Response.json([withoutDispatchType(gatewayMessage('100000000000000051', 'missed'))])
+      }
+      return Response.json({})
+    }) as typeof fetch
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl,
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+      recoveryStore,
+      recoveryMaxDurationMs: 5,
+      now: () => Date.parse('2026-08-28T10:05:00.000Z'),
+    })
+
+    await adapter.start()
+    await Bun.sleep(15)
+    expect(recoveryStore.listReplayCursors()).toHaveLength(1)
+    listener.emit('connected', connectedInfo())
+    await adapter.stop()
+
+    expect(router.routed.map((message) => message.externalMessageId)).toEqual(['100000000000000051'])
+    expect(channelLookupAttempt).toBeGreaterThanOrEqual(2)
+    expect(recoveryStore.listReplayCursors()).toEqual([])
+    expect(recoveryStore.disconnectedAt()).toBeNull()
+  })
+
+  test('retains channels beyond the replay pass limit for the next connection', async () => {
+    const recoveryStore = createInMemoryDiscordBotRecoveryStore()
+    for (let index = 1; index <= 21; index++) {
+      await recoveryStore.markProcessed({
+        channelId: String(800000000000000000n + BigInt(index)),
+        workspace: '700000000000000001',
+        messageId: String(100000000000000000n + BigInt(index)),
+        processedAt: index,
+      })
+    }
+    await recoveryStore.markDisconnected(22)
+    const historyChannels: string[] = []
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      const channelId = url.pathname.endsWith('/messages')
+        ? url.pathname.split('/').at(-2)
+        : url.pathname.split('/').at(-1)
+      if (url.pathname.endsWith('/messages')) {
+        historyChannels.push(channelId ?? '')
+        return Response.json([])
+      }
+      return Response.json({ id: channelId, guild_id: '700000000000000001' })
+    }) as typeof fetch
+    const listener = new FakeDiscordBotListener()
+    const adapter = createDiscordBotAdapter({
+      router: new FakeDiscordBotRouter().value,
+      configRef: () => lifecycleConfig(),
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl,
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+      recoveryStore,
+    })
+
+    await adapter.start()
+    await Bun.sleep(10)
+    expect(historyChannels).toHaveLength(20)
+    expect(recoveryStore.listReplayCursors()).toHaveLength(1)
+    listener.emit('connected', connectedInfo())
+    await adapter.stop()
+
+    expect(historyChannels).toHaveLength(21)
+    expect(new Set(historyChannels)).toHaveLength(21)
+    expect(recoveryStore.listReplayCursors()).toEqual([])
+    expect(recoveryStore.disconnectedAt()).toBeNull()
   })
 
   test('logs the nested reason of a gateway ErrorEvent, never [object ErrorEvent]', async () => {
@@ -2212,9 +2535,15 @@ class FakeDiscordBotListener {
 class FakeDiscordBotRouter {
   readonly registered: string[] = []
   readonly unregistered: string[] = []
+  readonly routed: InboundMessage[] = []
   selfIdentity: ((workspace: string) => { id: string; username?: string } | null) | null = null
+  constructor(private readonly routeHook?: (message: InboundMessage) => Promise<void>) {}
+
   readonly value = {
-    route: async () => {},
+    route: async (message: InboundMessage) => {
+      await this.routeHook?.(message)
+      this.routed.push(message)
+    },
     registerOutbound: () => this.registered.push('outbound'),
     unregisterOutbound: () => this.unregistered.push('outbound'),
     registerReaction: () => this.registered.push('reaction'),
@@ -2248,7 +2577,40 @@ class FakeDiscordBotRouter {
 }
 
 function connectedInfo() {
-  return { user: { id: 'bot-1', username: 'Typeey' }, sessionId: 'session-1' }
+  return { user: { id: 'bot-1', username: 'test-bot' }, sessionId: 'test-session' }
+}
+
+function gatewayMessage(id: string, content: string): DiscordGatewayMessageCreateEvent {
+  return {
+    type: 'MESSAGE_CREATE',
+    id,
+    channel_id: '800000000000000001',
+    guild_id: '700000000000000001',
+    author: { id: '600000000000000001', username: 'test-user', bot: false },
+    content,
+    timestamp: '2026-08-28T10:00:00.000Z',
+  }
+}
+
+function discordRecoveryFetch(historyRequests: URL[], history: DiscordGatewayMessageCreateEvent[]): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = new URL(String(input))
+    if (url.pathname.endsWith('/messages') && url.searchParams.has('after')) {
+      historyRequests.push(url)
+      return Response.json(history.map(({ type: _type, ...message }) => message))
+    }
+    if (url.pathname === '/api/v10/channels/800000000000000001') {
+      return Response.json({ id: '800000000000000001', guild_id: '700000000000000001' })
+    }
+    return Response.json({})
+  }) as typeof fetch
+}
+
+function withoutDispatchType(
+  message: DiscordGatewayMessageCreateEvent,
+): Omit<DiscordGatewayMessageCreateEvent, 'type'> {
+  const { type: _type, ...rest } = message
+  return rest
 }
 
 function lifecycleConfig(): ChannelAdapterConfig {

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -1327,7 +1327,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         continue
       }
 
-      let cursorCompleted = result.outcome === 'succeeded'
+      let cursorCompleted = true
       if (result.outcome === 'capped') {
         cappedChannels++
         skipped += result.skipped

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -65,6 +65,13 @@ import {
   createDiscordRemoveReactionCallback,
   encodeDiscordReactionRef,
 } from './discord-bot-reactions'
+import {
+  createInMemoryDiscordBotRecoveryStore,
+  fetchDiscordBackfill,
+  loadDiscordBotRecoveryStore,
+  type DiscordBackfillMessage,
+  type DiscordBotRecoveryStore,
+} from './discord-bot-recovery'
 import { enrichDiscordMessageReferences } from './discord-bot-reference'
 import {
   ackInteraction,
@@ -93,6 +100,10 @@ const STOP_REPLY_FAILED = 'Could not stop the current turn (internal error).'
 const STOP_REPLY_PERMISSION_DENIED = 'You do not have permission to stop the current turn in this channel.'
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10'
+const DISCORD_BACKFILL_MAX_CHANNELS = 20
+const DISCORD_BACKFILL_MAX_TOTAL_MESSAGES = 100
+const DISCORD_BACKFILL_MAX_DURATION_MS = 20_000
+const DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS = 5_000
 
 function formatLabel(name: string | undefined, id: string, prefix = ''): string {
   if (name === undefined || name === '' || name === id) return id
@@ -139,6 +150,9 @@ export type DiscordBotAdapterOptions = {
   createClient?: () => DiscordBotClient
   createListener?: (client: DiscordBotClient, options: DiscordBotListenerOptions) => DiscordBotListener
   enrichHistoricalProvenance?: typeof enrichHistoricalProvenance
+  recoveryStore?: DiscordBotRecoveryStore
+  now?: () => number
+  recoveryMaxDurationMs?: number
 }
 
 export type DiscordBotAdapter = {
@@ -1051,7 +1065,13 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
   let connected = false
   let started = false
   let inflightInbounds = 0
+  const inflightOperations = new Set<Promise<void>>()
   let stopWaiters: Array<() => void> = []
+  let recoveryStore = options.recoveryStore ?? null
+  let recoveryBarrier = Promise.resolve()
+  const channelBarriers = new Map<string, Promise<void>>()
+  const now = options.now ?? Date.now
+  const recoveryMaxDurationMs = options.recoveryMaxDurationMs ?? DISCORD_BACKFILL_MAX_DURATION_MS
 
   const channelResolver = createDiscordChannelResolver({ token: options.token, fetchImpl })
   const threadRoomResolver = createDiscordThreadRoomResolver({ token: options.token, fetchImpl })
@@ -1130,76 +1150,263 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
     }
   }
 
-  const handleMessageCreate = async (event: DiscordGatewayMessageCreateEvent): Promise<void> => {
-    inflightInbounds++
-    try {
-      // One log line per gateway event is non-negotiable: it's the only way to
-      // tell from logs whether the gateway is delivering at all. content_len=0
-      // is the smoking gun for a missing MessageContent privileged intent.
-      const inboundWorkspace = event.guild_id ?? '@dm'
-      const inboundTag = await formatChannelTag(inboundWorkspace, event.channel_id)
-      logger.info(
-        `[discord-bot] inbound id=${event.id} author=${formatLabel(event.author.username, event.author.id)} ${inboundTag} content_len=${event.content.length}`,
-      )
+  const processMessageCreate = async (event: DiscordGatewayMessageCreateEvent): Promise<void> => {
+    // One log line per gateway event is non-negotiable: it's the only way to
+    // tell from logs whether the gateway is delivering at all. content_len=0
+    // is the smoking gun for a missing MessageContent privileged intent.
+    const inboundWorkspace = event.guild_id ?? '@dm'
+    const inboundTag = await formatChannelTag(inboundWorkspace, event.channel_id)
+    logger.info(
+      `[discord-bot] inbound id=${event.id} author=${formatLabel(event.author.username, event.author.id)} ${inboundTag} content_len=${event.content.length}`,
+    )
 
-      const verdict = classifyInbound(event, options.configRef(), botUserId)
-      if (verdict.kind === 'drop') {
-        logger.info(`[discord-bot] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+    const verdict = classifyInbound(event, options.configRef(), botUserId)
+    if (verdict.kind === 'drop') {
+      logger.info(`[discord-bot] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+      return
+    }
+
+    const hintedText = addDiscordMentionHints(verdict.payload.text, mentionUserMap(event.mentions), { botUserId })
+    const replyMessageId = event.message_reference?.message_id
+    const referenceResult = await enrichDiscordMessageReferences({
+      text: hintedText,
+      ...(replyMessageId !== undefined
+        ? { reply: { channelId: event.message_reference?.channel_id ?? event.channel_id, messageId: replyMessageId } }
+        : {}),
+      fetchMessage: async (channelId, messageId) => {
+        const message: { author: { id: string; username: string; global_name?: string | null }; content: string } =
+          await client.getMessage(channelId, messageId)
+        return {
+          authorId: message.author.id,
+          authorName: message.author.global_name ?? message.author.username,
+          text: message.content,
+        }
+      },
+    })
+    // Discord threads are their own channels (`chat = thread id`, `thread`
+    // stays null), so the engagement gate cannot see "this is a thread" from
+    // the payload alone. Resolve the channel's type/parent and stamp the
+    // structural `room` signal for guild inbounds; DMs are never thread rooms.
+    let room = event.guild_id !== undefined ? await threadRoomResolver(event.channel_id) : undefined
+    if (room?.parentChat !== undefined && event.guild_id !== undefined) {
+      const parentNames = await channelResolver({
+        adapter: 'discord-bot',
+        workspace: event.guild_id,
+        chat: room.parentChat,
+        thread: null,
+      })
+      if (parentNames.chatName !== undefined) room = { ...room, parentChatName: parentNames.chatName }
+    }
+    const basePayload =
+      referenceResult.referenceContext === undefined
+        ? { ...verdict.payload, text: hintedText }
+        : { ...verdict.payload, text: hintedText, referenceContext: referenceResult.referenceContext }
+    const payload = room !== undefined ? { ...basePayload, room } : basePayload
+
+    const routedTag = await formatChannelTag(payload.workspace, payload.chat)
+    logger.info(
+      `[discord-bot] routed id=${event.id} ${routedTag} mention=${payload.isBotMention} reply=${payload.replyToBotMessageId !== null}`,
+    )
+    await options.router.route(payload)
+  }
+
+  const trackInbound = (operation: Promise<void>): Promise<void> => {
+    inflightInbounds++
+    inflightOperations.add(operation)
+    return operation.finally(() => {
+      inflightOperations.delete(operation)
+      inflightInbounds--
+      if (inflightInbounds !== 0 || stopWaiters.length === 0) return
+      const waiters = stopWaiters
+      stopWaiters = []
+      for (const waiter of waiters) waiter()
+    })
+  }
+
+  const enqueueChannelOperation = <T>(channelId: string, operation: () => Promise<T>): Promise<T> => {
+    const previous = channelBarriers.get(channelId) ?? Promise.resolve()
+    const queued = previous.then(operation)
+    const barrier = queued.then(
+      () => undefined,
+      () => undefined,
+    )
+    channelBarriers.set(channelId, barrier)
+    void barrier.finally(() => {
+      if (channelBarriers.get(channelId) === barrier) channelBarriers.delete(channelId)
+    })
+    return queued
+  }
+
+  const enqueueChannelInbound = (channelId: string, operation: () => Promise<void>): Promise<void> => {
+    const recoveryGate = recoveryBarrier
+    return trackInbound(recoveryGate.then(() => enqueueChannelOperation(channelId, operation)))
+  }
+
+  const enqueueRecovery = (operation: () => Promise<void>): Promise<void> => {
+    const queued = recoveryBarrier.then(operation)
+    recoveryBarrier = queued.catch(() => {})
+    return trackInbound(queued)
+  }
+
+  const handleMessageCreate = (event: DiscordGatewayMessageCreateEvent): Promise<void> =>
+    enqueueChannelInbound(event.channel_id, async () => {
+      if (recoveryStore?.isProcessed(event.channel_id, event.id) === true) {
+        logger.info(`[discord-bot] deduplicated id=${event.id} channel=${event.channel_id}`)
         return
       }
-
-      const hintedText = addDiscordMentionHints(verdict.payload.text, mentionUserMap(event.mentions), { botUserId })
-      const replyMessageId = event.message_reference?.message_id
-      const referenceResult = await enrichDiscordMessageReferences({
-        text: hintedText,
-        ...(replyMessageId !== undefined
-          ? { reply: { channelId: event.message_reference?.channel_id ?? event.channel_id, messageId: replyMessageId } }
-          : {}),
-        fetchMessage: async (channelId, messageId) => {
-          const message: { author: { id: string; username: string; global_name?: string | null }; content: string } =
-            await client.getMessage(channelId, messageId)
-          return {
-            authorId: message.author.id,
-            authorName: message.author.global_name ?? message.author.username,
-            text: message.content,
-          }
-        },
-      })
-      // Discord threads are their own channels (`chat = thread id`, `thread`
-      // stays null), so the engagement gate cannot see "this is a thread" from
-      // the payload alone. Resolve the channel's type/parent and stamp the
-      // structural `room` signal for guild inbounds; DMs are never thread rooms.
-      let room = event.guild_id !== undefined ? await threadRoomResolver(event.channel_id) : undefined
-      if (room?.parentChat !== undefined && event.guild_id !== undefined) {
-        const parentNames = await channelResolver({
-          adapter: 'discord-bot',
-          workspace: event.guild_id,
-          chat: room.parentChat,
-          thread: null,
+      try {
+        await processMessageCreate(event)
+        await recoveryStore?.markProcessed({
+          channelId: event.channel_id,
+          workspace: event.guild_id ?? '@dm',
+          messageId: event.id,
+          processedAt: now(),
         })
-        if (parentNames.chatName !== undefined) room = { ...room, parentChatName: parentNames.chatName }
+      } catch (err) {
+        logger.error(`[discord-bot] handleInbound failed: ${describeError(err)}`)
       }
-      const basePayload =
-        referenceResult.referenceContext === undefined
-          ? { ...verdict.payload, text: hintedText }
-          : { ...verdict.payload, text: hintedText, referenceContext: referenceResult.referenceContext }
-      const payload = room !== undefined ? { ...basePayload, room } : basePayload
+    })
 
-      const routedTag = await formatChannelTag(payload.workspace, payload.chat)
-      logger.info(
-        `[discord-bot] routed id=${event.id} ${routedTag} mention=${payload.isBotMention} reply=${payload.replyToBotMessageId !== null}`,
-      )
-      await options.router.route(payload)
-    } catch (err) {
-      logger.error(`[discord-bot] handleInbound failed: ${describeError(err)}`)
-    } finally {
-      inflightInbounds--
-      if (inflightInbounds === 0 && stopWaiters.length > 0) {
-        const waiters = stopWaiters
-        stopWaiters = []
-        for (const w of waiters) w()
+  const replayAfterReconnect = async (): Promise<void> => {
+    if (recoveryStore === null) return
+    const store = recoveryStore
+    const disconnectedAt = store.disconnectedAt()
+    if (disconnectedAt === null) return
+
+    const downtimeMs = Math.max(0, now() - disconnectedAt)
+    let replayed = 0
+    let skipped = 0
+    let cappedChannels = 0
+    let unavailableChannels = 0
+    const replayDeadline = performance.now() + recoveryMaxDurationMs
+    const replayCursors = store.listReplayCursors().sort((left, right) => right.processedAt - left.processedAt)
+    const selectedCursors = replayCursors.slice(0, DISCORD_BACKFILL_MAX_CHANNELS)
+    let skippedChannels = replayCursors.length - selectedCursors.length
+    let remainingMessages = DISCORD_BACKFILL_MAX_TOTAL_MESSAGES
+    let deadlineReached = false
+    cursorLoop: for (const [cursorIndex, cursor] of selectedCursors.entries()) {
+      const fetchBudgetMs = replayDeadline - performance.now()
+      if (remainingMessages === 0) {
+        skippedChannels++
+        continue
       }
+      if (fetchBudgetMs <= 0) {
+        deadlineReached = true
+        skippedChannels += selectedCursors.length - cursorIndex
+        break
+      }
+      const fetched = await settleWithin(
+        fetchDiscordBackfill({
+          channelId: cursor.channelId,
+          workspace: cursor.workspace,
+          after: cursor.messageId,
+          token: options.token,
+          fetchImpl,
+          now: now(),
+        }),
+        fetchBudgetMs,
+      )
+      if (fetched.kind === 'timed-out') {
+        deadlineReached = true
+        skippedChannels += selectedCursors.length - cursorIndex
+        break
+      }
+      if (fetched.kind === 'failed') {
+        unavailableChannels++
+        logger.warn(
+          `[discord-bot] replay downtime_ms=${downtimeMs} outcome=unavailable channel=${cursor.channelId} error=${describeError(fetched.error)}`,
+        )
+        continue
+      }
+      const result = fetched.value
+      if (!result.ok) {
+        unavailableChannels++
+        logger.warn(
+          `[discord-bot] replay downtime_ms=${downtimeMs} outcome=unavailable channel=${cursor.channelId} error=${result.error}`,
+        )
+        continue
+      }
+
+      let cursorCompleted = result.outcome === 'succeeded'
+      if (result.outcome === 'capped') {
+        cappedChannels++
+        skipped += result.skipped
+        logger.warn(
+          `[discord-bot] replay downtime_ms=${downtimeMs} outcome=capped channel=${cursor.channelId} skipped_age=${result.skippedByAge} skipped_count=${result.skippedByCount} more_may_exist=${String(result.moreMayExist)}`,
+        )
+      }
+      const aggregateOverflow = Math.max(0, result.messages.length - remainingMessages)
+      if (aggregateOverflow > 0) {
+        cursorCompleted = false
+        cappedChannels++
+        skipped += aggregateOverflow
+        logger.warn(
+          `[discord-bot] replay downtime_ms=${downtimeMs} outcome=capped channel=${cursor.channelId} skipped_aggregate=${aggregateOverflow}`,
+        )
+      }
+      const messages = result.messages.slice(-remainingMessages)
+      remainingMessages -= messages.length
+      for (const [messageIndex, message] of messages.entries()) {
+        if (performance.now() >= replayDeadline) {
+          cursorCompleted = false
+          deadlineReached = true
+          skipped += messages.length - messageIndex
+          skippedChannels += selectedCursors.length - cursorIndex - 1
+          break cursorLoop
+        }
+        const delivery = await enqueueChannelOperation(message.channel_id, async () => {
+          if (store.isReplayProcessed(message.channel_id, message.id)) return 'deduplicated' as const
+          if (performance.now() >= replayDeadline) return 'timed-out' as const
+          try {
+            await processMessageCreate(toGatewayMessage(message, cursor.workspace))
+            await store.markProcessed({
+              channelId: message.channel_id,
+              workspace: cursor.workspace,
+              messageId: message.id,
+              processedAt: now(),
+            })
+            return 'replayed' as const
+          } catch (err) {
+            logger.error(
+              `[discord-bot] replay downtime_ms=${downtimeMs} outcome=route_failed channel=${cursor.channelId} id=${message.id} error=${describeError(err)}`,
+            )
+            return 'failed' as const
+          }
+        })
+        if (delivery === 'replayed') {
+          replayed++
+        } else if (delivery === 'timed-out') {
+          cursorCompleted = false
+          deadlineReached = true
+          skipped += messages.length - messageIndex
+          skippedChannels += selectedCursors.length - cursorIndex - 1
+          break cursorLoop
+        } else if (delivery === 'failed') {
+          cursorCompleted = false
+          unavailableChannels++
+          break
+        }
+      }
+      if (cursorCompleted) await store.completeReplay(cursor.channelId)
     }
+
+    if (deadlineReached) {
+      cappedChannels++
+      logger.warn(
+        `[discord-bot] replay downtime_ms=${downtimeMs} outcome=capped reason=duration duration_limit_ms=${recoveryMaxDurationMs}`,
+      )
+    }
+    if (skippedChannels > 0) {
+      cappedChannels += skippedChannels
+      logger.warn(
+        `[discord-bot] replay downtime_ms=${downtimeMs} outcome=capped skipped_channels=${skippedChannels} channel_limit=${DISCORD_BACKFILL_MAX_CHANNELS} message_limit=${DISCORD_BACKFILL_MAX_TOTAL_MESSAGES} duration_limit_ms=${recoveryMaxDurationMs}`,
+      )
+    }
+    const outcome = unavailableChannels > 0 ? 'partial' : cappedChannels > 0 ? 'capped' : 'succeeded'
+    const log = unavailableChannels > 0 || cappedChannels > 0 ? logger.warn : logger.info
+    log(
+      `[discord-bot] replay downtime_ms=${downtimeMs} outcome=${outcome} replayed=${replayed} skipped_observed=${skipped} capped_channels=${cappedChannels} unavailable_channels=${unavailableChannels}`,
+    )
   }
 
   return {
@@ -1214,11 +1421,19 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         throw err
       }
 
+      recoveryStore ??=
+        options.agentDir === undefined
+          ? createInMemoryDiscordBotRecoveryStore()
+          : await loadDiscordBotRecoveryStore(options.agentDir, logger)
+
       listener = createListener(client, { intents: DISCORD_BOT_INTENTS })
       listener.on('connected', (info) => {
         connected = true
         botUserId = info.user.id
         logger.info(`[discord-bot] connected as ${info.user.username} (${info.user.id})`)
+        void enqueueRecovery(replayAfterReconnect).catch((err) => {
+          logger.error(`[discord-bot] replay failed: ${describeError(err)}`)
+        })
         // For bots, the gateway's user.id IS the application id — the same
         // value is required for both /me lookups and /applications/{id}/
         // commands. Fire-and-forget registration so a slow Discord API
@@ -1249,6 +1464,23 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       })
       listener.on('disconnected', () => {
         connected = false
+        if (started) {
+          const pendingChannels = Array.from(inflightOperations)
+          void enqueueRecovery(async () => {
+            const drain = await settleWithin(
+              Promise.all(pendingChannels).then(() => undefined),
+              DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS,
+            )
+            if (drain.kind === 'timed-out') {
+              logger.warn(
+                `[discord-bot] disconnect drain timed out after ${DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS}ms; snapshotting completed cursors`,
+              )
+            }
+            await recoveryStore?.markDisconnected(now())
+          }).catch((err) => {
+            logger.error(`[discord-bot] failed to persist disconnect: ${describeError(err)}`)
+          })
+        }
         logger.warn('[discord-bot] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
@@ -1256,7 +1488,26 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         // when a terminal Gateway close stops the listener. Match that
         // distinct SDK error contract without treating transient transport
         // errors as disconnects.
-        if (isTerminalGatewayClose(err)) connected = false
+        if (isTerminalGatewayClose(err)) {
+          connected = false
+          if (started) {
+            const pendingChannels = Array.from(inflightOperations)
+            void enqueueRecovery(async () => {
+              const drain = await settleWithin(
+                Promise.all(pendingChannels).then(() => undefined),
+                DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS,
+              )
+              if (drain.kind === 'timed-out') {
+                logger.warn(
+                  `[discord-bot] disconnect drain timed out after ${DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS}ms; snapshotting completed cursors`,
+                )
+              }
+              await recoveryStore?.markDisconnected(now())
+            }).catch((persistErr) => {
+              logger.error(`[discord-bot] failed to persist disconnect: ${describeError(persistErr)}`)
+            })
+          }
+        }
         logger.error(`[discord-bot] gateway error: ${describeError(err)}`)
       })
       listener.on('message_create', (event) => {
@@ -1353,6 +1604,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
     async stop(): Promise<void> {
       if (!started) return
       started = false
+      listener?.stop()
       options.router.unregisterOutbound('discord-bot', outboundCallback)
       options.router.unregisterReaction('discord-bot', reactionCallback)
       options.router.unregisterRemoveReaction('discord-bot', removeReactionCallback)
@@ -1371,7 +1623,6 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
           stopWaiters.push(resolve)
         })
       }
-      listener?.stop()
       listener = null
       connected = false
     },
@@ -1386,6 +1637,32 @@ const TERMINAL_GATEWAY_CLOSE_PATTERN = /^Discord gateway closed with non-recover
 
 function isTerminalGatewayClose(err: unknown): boolean {
   return err instanceof Error && TERMINAL_GATEWAY_CLOSE_PATTERN.test(err.message)
+}
+
+function toGatewayMessage(message: DiscordBackfillMessage, workspace: string): DiscordGatewayMessageCreateEvent {
+  return {
+    ...message,
+    guild_id: workspace === '@dm' ? undefined : workspace,
+    type: 'MESSAGE_CREATE',
+  }
+}
+
+type TimedSettlement<T> = { kind: 'completed'; value: T } | { kind: 'failed'; error: unknown } | { kind: 'timed-out' }
+
+function settleWithin<T>(operation: Promise<T>, timeoutMs: number): Promise<TimedSettlement<T>> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve({ kind: 'timed-out' }), Math.max(0, timeoutMs))
+    void operation.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve({ kind: 'completed', value })
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        resolve({ kind: 'failed', error })
+      },
+    )
+  })
 }
 
 // Operator hints appended to drop logs. Kept short — full guidance lives in

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -104,6 +104,8 @@ const DISCORD_BACKFILL_MAX_CHANNELS = 20
 const DISCORD_BACKFILL_MAX_TOTAL_MESSAGES = 100
 const DISCORD_BACKFILL_MAX_DURATION_MS = 20_000
 const DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS = 5_000
+const DISCORD_GATEWAY_STALE_AFTER_MS = 90_000
+const DISCORD_GATEWAY_LIVENESS_CHECK_INTERVAL_MS = 30_000
 
 function formatLabel(name: string | undefined, id: string, prefix = ''): string {
   if (name === undefined || name === '' || name === id) return id
@@ -153,6 +155,12 @@ export type DiscordBotAdapterOptions = {
   recoveryStore?: DiscordBotRecoveryStore
   now?: () => number
   recoveryMaxDurationMs?: number
+  liveness?: {
+    staleAfterMs?: number
+    checkIntervalMs?: number
+    setInterval?: (fn: () => void, ms: number) => unknown
+    clearInterval?: (handle: unknown) => void
+  }
 }
 
 export type DiscordBotAdapter = {
@@ -1072,6 +1080,15 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
   const channelBarriers = new Map<string, Promise<void>>()
   const now = options.now ?? Date.now
   const recoveryMaxDurationMs = options.recoveryMaxDurationMs ?? DISCORD_BACKFILL_MAX_DURATION_MS
+  const staleAfterMs = options.liveness?.staleAfterMs ?? DISCORD_GATEWAY_STALE_AFTER_MS
+  const livenessCheckIntervalMs = options.liveness?.checkIntervalMs ?? DISCORD_GATEWAY_LIVENESS_CHECK_INTERVAL_MS
+  const setLivenessInterval = options.liveness?.setInterval ?? ((fn: () => void, ms: number) => setInterval(fn, ms))
+  const clearLivenessInterval =
+    options.liveness?.clearInterval ?? ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>))
+  let lastGatewayEventAt = 0
+  let livenessTimer: unknown = null
+  let livenessProbeRunning = false
+  let livenessCursorIndex = 0
 
   const channelResolver = createDiscordChannelResolver({ token: options.token, fetchImpl })
   const threadRoomResolver = createDiscordThreadRoomResolver({ token: options.token, fetchImpl })
@@ -1409,6 +1426,71 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
     )
   }
 
+  // The SDK already closes on a missing heartbeat ACK, but heartbeat state is
+  // private and cannot detect the production failure where the socket remains
+  // nominally alive while MESSAGE_CREATE dispatch stops. Inactivity alone is
+  // not evidence of failure (a guild may be quiet for hours), so a stale
+  // timestamp only permits this REST comparison. A newer channel message in
+  // REST than the newest gateway-processed snowflake is positive proof that
+  // delivery has a gap; only then do we report unhealthy to manager recovery.
+  const checkGatewayLiveness = async (): Promise<void> => {
+    if (!started || !connected || livenessProbeRunning) return
+    const checkedAt = now()
+    if (checkedAt - lastGatewayEventAt < staleAfterMs) return
+    const gatewayEventAtStart = lastGatewayEventAt
+    const store = recoveryStore
+    if (store === null) return
+    const cursors = store.listCursors().sort((left, right) => right.processedAt - left.processedAt)
+    if (cursors.length === 0) return
+    const cursor = cursors[livenessCursorIndex % cursors.length]
+    if (cursor === undefined) return
+    livenessCursorIndex = (livenessCursorIndex + 1) % cursors.length
+
+    livenessProbeRunning = true
+    try {
+      const result = await fetchDiscordBackfill({
+        channelId: cursor.channelId,
+        workspace: cursor.workspace,
+        after: cursor.messageId,
+        token: options.token,
+        fetchImpl,
+        now: checkedAt,
+      })
+      if (!result.ok) {
+        logger.warn(`[discord-bot] liveness probe unavailable: ${result.error}; gateway health unchanged`)
+        return
+      }
+      if (result.messages.length === 0 && result.skipped === 0 && !result.moreMayExist) return
+      // A dispatch that landed while REST was in flight proves the Gateway is
+      // delivering again; its per-channel operation may not have advanced the
+      // durable cursor yet, so the timestamp is the race-free authority here.
+      if (!started || !connected || lastGatewayEventAt !== gatewayEventAtStart) return
+
+      connected = false
+      await store.markDisconnected(checkedAt)
+      logger.warn(
+        `[discord-bot] gateway delivery gap detected channel=${cursor.channelId} stale_ms=${checkedAt - lastGatewayEventAt}; reporting unhealthy for recovery restart`,
+      )
+    } finally {
+      livenessProbeRunning = false
+    }
+  }
+
+  const startLivenessTimer = (): void => {
+    if (livenessTimer !== null) return
+    livenessTimer = setLivenessInterval(() => {
+      void checkGatewayLiveness().catch((err) => {
+        logger.error(`[discord-bot] liveness check failed: ${describeError(err)}`)
+      })
+    }, livenessCheckIntervalMs)
+  }
+
+  const stopLivenessTimer = (): void => {
+    if (livenessTimer === null) return
+    clearLivenessInterval(livenessTimer)
+    livenessTimer = null
+  }
+
   return {
     async start(): Promise<void> {
       if (started) return
@@ -1429,6 +1511,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       listener = createListener(client, { intents: DISCORD_BOT_INTENTS })
       listener.on('connected', (info) => {
         connected = true
+        lastGatewayEventAt = now()
         botUserId = info.user.id
         logger.info(`[discord-bot] connected as ${info.user.username} (${info.user.id})`)
         void enqueueRecovery(replayAfterReconnect).catch((err) => {
@@ -1465,6 +1548,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       listener.on('disconnected', () => {
         connected = false
         if (started) {
+          const disconnectedAt = now()
           const pendingChannels = Array.from(inflightOperations)
           void enqueueRecovery(async () => {
             const drain = await settleWithin(
@@ -1476,7 +1560,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
                 `[discord-bot] disconnect drain timed out after ${DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS}ms; snapshotting completed cursors`,
               )
             }
-            await recoveryStore?.markDisconnected(now())
+            await recoveryStore?.markDisconnected(disconnectedAt)
           }).catch((err) => {
             logger.error(`[discord-bot] failed to persist disconnect: ${describeError(err)}`)
           })
@@ -1491,6 +1575,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         if (isTerminalGatewayClose(err)) {
           connected = false
           if (started) {
+            const disconnectedAt = now()
             const pendingChannels = Array.from(inflightOperations)
             void enqueueRecovery(async () => {
               const drain = await settleWithin(
@@ -1502,7 +1587,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
                   `[discord-bot] disconnect drain timed out after ${DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS}ms; snapshotting completed cursors`,
                 )
               }
-              await recoveryStore?.markDisconnected(now())
+              await recoveryStore?.markDisconnected(disconnectedAt)
             }).catch((persistErr) => {
               logger.error(`[discord-bot] failed to persist disconnect: ${describeError(persistErr)}`)
             })
@@ -1511,9 +1596,17 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         logger.error(`[discord-bot] gateway error: ${describeError(err)}`)
       })
       listener.on('message_create', (event) => {
+        lastGatewayEventAt = now()
+        if (!connected && recoveryStore !== null && recoveryStore.disconnectedAt() !== null) {
+          connected = true
+          void enqueueRecovery(replayAfterReconnect).catch((err) => {
+            logger.error(`[discord-bot] replay failed after gateway delivery resumed: ${describeError(err)}`)
+          })
+        }
         void handleMessageCreate(event)
       })
       listener.on('interaction_create', (event) => {
+        lastGatewayEventAt = now()
         void handleInteractionCreate(event)
       })
 
@@ -1533,6 +1626,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
 
       try {
         await listener.start()
+        startLivenessTimer()
       } catch (err) {
         // Listener failed after registration — roll back every callback so a
         // failed start leaves no router state behind (stop() returns early on
@@ -1554,6 +1648,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         listener = null
         botUserId = null
         connected = false
+        lastGatewayEventAt = 0
         started = false
         logger.error(`[discord-bot] listener start failed: ${describeError(err)}`)
         throw err
@@ -1604,6 +1699,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
     async stop(): Promise<void> {
       if (!started) return
       started = false
+      stopLivenessTimer()
       listener?.stop()
       options.router.unregisterOutbound('discord-bot', outboundCallback)
       options.router.unregisterReaction('discord-bot', reactionCallback)
@@ -1625,6 +1721,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       }
       listener = null
       connected = false
+      lastGatewayEventAt = 0
     },
 
     isConnected(): boolean {


### PR DESCRIPTION
## Correction (2026-08-31)

**This PR does NOT fix the 2026-08-28 outage.** The gateway-gap hypothesis below, which motivated this PR, has been refuted by host container logs that weren't available when this PR was opened. The only Discord Gateway disconnect in the incident window lasted 1.4 seconds and happened at 10:40, *after* all 14 messages had already been consumed by the router. There was no silent gap for this PR's detection logic to have caught.

The proven root cause was a poisoned channel session that stayed registered as live after going structurally dead, with the router repeatedly feeding it messages that produced no assistant output. That's tracked in **#184** ("In-memory poisoned channel session can outlive its restart-only escape hatch," reopened), fix in review at **#1413** ("Gate poisoned-session recovery on fingerprint").

**What still stands on its own:** the investigation into this incident independently found that 10 of 12 channel adapters lose messages across a reconnect gap with no backfill (see #1406-#1412). The Discord Gateway genuinely can drop dispatches during a reconnect without ever surfacing an SDK `disconnected` event, and when that happens today, the messages sent during the gap are gone. This PR closes that real gap for the `discord-bot` adapter. It just isn't what caused the 08-28 outage.

The "Incident fingerprint" and "recovers the 14-message/22-minute incident" framing below is left as originally written for the historical record of what motivated this PR, but should be read with the above correction: the fingerprint was real, the diagnosis of its cause was wrong.

---

## Background

**Incident fingerprint (see correction above — cause was misdiagnosed).** A Discord bot replied normally, then received 14 messages over six minutes—10 direct mentions—with no output. Roughly 22 minutes later, a new bare mention received a reply in five seconds, and that reply addressed only the newest message. The router atomically drains its entire prompt queue, so a newest-only reply proves the earlier 14 messages never reached the router. (Proven cause, per host logs: a poisoned session, not a Gateway gap — see #184.)

**Why health lied.** #1195 fixed the narrower case where an explicit SDK `disconnected` event or terminal close left `isConnected()` true. It deliberately made message replay a non-goal. A half-dead socket can still stop delivering dispatches without either signal, leaving `started && connected` true and preventing the manager's existing recovery watchdog from arming.

Upstream `agent-messenger` does support in-memory Gateway `RESUME`, including sequence tracking and Discord's buffered event replay. It also privately monitors heartbeat ACKs. Neither state nor an ACK hook is exposed durably: an invalidated session, fresh `IDENTIFY`, or process restart still needs history recovery, and TypeClaw cannot use private ACK state as its health signal.

## What changed

### Idle-safe liveness detection

The adapter records the last Gateway event time. Staleness alone never marks the adapter unhealthy: an idle guild can legitimately receive no events for hours. After 90 seconds without an observed event, a 30-second monitor probes one known channel at a time, round-robin, by comparing its durable processed snowflake with Discord REST history.

Only positive proof—a newer REST message that the Gateway did not deliver—sets `connected = false`, records the gap start, and lets `src/channels/manager.ts`'s existing disconnected-grace watchdog restart the adapter. If a Gateway event arrives while the REST request is in flight, the probe aborts rather than reporting a false failure.

### Durable reconnect replay

- Persist the newest processed snowflake per channel in `channels/discord-bot-recovery.json` using atomic temp-file replacement.
- Snapshot replay anchors when an explicit disconnect, terminal close, or positive liveness probe detects a gap.
- Start replay only after `connected` has synchronously established `botUserId`, preventing backfilled messages from racing into the classifier's `pre_connect` drop.
- Serialize replay and live delivery per channel, route missed messages in ascending snowflake order, and retain bounded recent IDs so replay/live overlap is delivered exactly once.
- Keep unavailable anchors for a later reconnect instead of silently abandoning them.

## Storm-safety policy

Replay is bounded to:

- 50 messages per channel
- messages no older than 30 minutes
- 20 channels per pass
- 100 messages across a pass
- 20 seconds per pass
- 10 seconds per REST request

This is scaled to comfortably cover a gap the size of the 14-message/22-minute incident window *if* that incident had been a Gateway gap (it wasn't — see correction above) — without dumping an unbounded outage into one turn. Overflow is never silent: logs include `downtime_ms`, `outcome` (`succeeded`, `capped`, `unavailable`, or `partial`), and the observed age/count/aggregate/channel skips so the operator can inspect older history manually.

## Relationship to prior work and scope

- Preserves #1195's explicit-disconnect health fix and adds a second, positive-proof liveness path.
- Completes #1195's explicit replay non-goal in the same change as the new detection guard, so detection does not discard authorized work.
- Does not change engagement, suppressors, `NO_REPLY`, cron, or router reload/handoff behavior.
- Scope is `discord-bot`. The separate user-token `discord` adapter remains a documented gap because it uses a different SDK/client surface.
- #1336 remains open; this PR does not add a visible turn-progress signal.

## Tests

Failure direction:

- a silent Gateway gap is positively detected as unhealthy;
- reconnect backfills missed messages once, in order, before overlapping live delivery;
- replay waits for bot identity;
- unavailable/capped passes retain or terminate anchors as designed and log the outcome.

Normal direction:

- an idle but gap-free Gateway stays healthy after the liveness probe;
- clean operation performs no backfill and produces no duplicates;
- the monitor timer is stopped during adapter teardown.

## Verification

- `bun run typecheck`
- `bun run lint` — 0 errors
- `bun run format:check`
- `bun run test` — 13,351 pass / 31 skip / 0 fail
</content>
