### PR TITLE
Gate poisoned-session recovery on fingerprint

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -66,6 +66,7 @@ import {
   TYPING_HEARTBEAT_MS,
   MAX_WILLINGNESS_NUDGES,
   OUTBOUND_FLOOD_ERROR,
+  POISONED_SESSION_RESET_TEXT,
   SEND_RATE_WARN_THRESHOLD,
   SEND_RATE_WINDOW_MS,
   SEND_WILLINGNESS_NUDGE,
@@ -7765,6 +7766,58 @@ describe('ChannelRouter channel-turn protocol', () => {
     )
     expect(sent).toContain('recovered')
     expect(logs.some((m) => m.includes('poisoned-session-rollover'))).toBe(true)
+  })
+
+  test('stop during a held poison notice keeps the cleared pointer and review round', async () => {
+    const dir = await tempDir()
+    const reviewRound = {
+      kind: 'push' as const,
+      roundId: 'test-round',
+      workspace: 'acme/widgets',
+      prNumber: 7,
+      headSha: 'sha-round',
+      carrierThread: '101',
+    }
+    const noticeStarted = Promise.withResolvers<void>()
+    const releaseNotice = Promise.withResolvers<void>()
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (message) => {
+      if (message.text === POISONED_SESSION_RESET_TEXT) {
+        noticeStarted.resolve()
+        await releaseNotice.promise
+      }
+      return { ok: true }
+    })
+
+    await router.route(
+      inbound({ text: 'start the work', externalMessageId: 'trigger', githubReviewRound: reviewRound }),
+    )
+    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'shutdown-race')
+    await router.__testing!.flushDebounce(KEY)
+    for (let i = 1; i < 3; i++) {
+      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    await router.route(inbound({ text: 'missed-3', externalMessageId: 'm3' }))
+    const draining = router.__testing!.flushDebounce(KEY)
+    await noticeStarted.promise
+    await router.stop()
+
+    const persistedFile = (await Bun.file(channelsSessionsPath(dir)).json()) as { sessions: ChannelSessionRecord[] }
+    const [persisted] = persistedFile.sessions
+    expect(persisted?.sessionId).toBeUndefined()
+    expect(persisted?.sessionFile).toBeUndefined()
+    expect(persisted?.githubReviewRound).toMatchObject({
+      kind: reviewRound.kind,
+      roundId: reviewRound.roundId,
+      workspace: reviewRound.workspace,
+      prNumber: reviewRound.prNumber,
+      headSha: reviewRound.headSha,
+    })
+
+    releaseNotice.resolve()
+    await draining
   })
 
   test('/stop sees a suspected poisoned session and resets the escape hatch', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7884,9 +7884,9 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(sessions).toHaveLength(2)
-    expect(sessions[1]!.prompts.join('\n')).toContain('retained-1')
-    expect(sessions[1]!.prompts.join('\n')).toContain('retained-2')
-    expect(sessions[1]!.prompts.join('\n')).toContain('retained-3')
+    for (let i = 1; i <= 3; i++) {
+      expect(sessions[1]!.prompts.filter((prompt) => prompt.includes(`retained-${i}`))).toHaveLength(1)
+    }
     expect(sent).toContain('recovered later')
   })
 
@@ -7936,6 +7936,48 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     expect(snapshots.some((records) => records[0]?.sessionId === undefined)).toBe(true)
     expect(stopSettled).toBe(true)
+  })
+
+  test('shutdown retires a tripped poison before the drain registers retirement', async () => {
+    const dir = await tempDir()
+    let releaseNotice: (() => void) | undefined
+    let noticeStarted: (() => void) | undefined
+    const noticeStartedPromise = new Promise<void>((resolve) => {
+      noticeStarted = resolve
+    })
+    const snapshots: ChannelSessionRecord[][] = []
+    const { router, sessions } = makeRouter(dir, {
+      saveChannelSessions: async (_agentDir, records) => {
+        snapshots.push(records.map((record) => ({ ...record })))
+      },
+    })
+    router.registerOutbound('discord-bot', async (message) => {
+      if (message.text?.includes('conversation session stopped responding')) {
+        noticeStarted?.()
+        await new Promise<void>((resolve) => {
+          releaseNotice = resolve
+        })
+      }
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'prime', externalMessageId: 'prime' }))
+    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'shutdown-before-retire')
+    await router.__testing!.flushDebounce(KEY)
+    for (let i = 1; i <= 2; i++) {
+      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    await router.route(inbound({ text: 'missed-3', externalMessageId: 'm3' }))
+    const rollover = router.__testing!.flushDebounce(KEY)
+    await noticeStartedPromise
+    const stopping = router.stop()
+    releaseNotice?.()
+    await Promise.all([rollover, stopping])
+
+    expect(snapshots.some((records) => records[0]?.sessionId === undefined)).toBe(true)
+    expect(sessions[0]!.disposed).toBe(1)
   })
 
   test('reroutes an inbound that was awaiting membership while its poisoned live retires', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -296,6 +296,28 @@ function strandOnUnansweredToolUse(session: FakeSession, id: string = 'strand'):
   session.leafEntry = toolResultEntry
 }
 
+function installPoisonWatchTrigger(router: ChannelRouter, session: FakeSession, key: ChannelKey, id: string): void {
+  let promptCount = 0
+  session.onPrompt = async () => {
+    promptCount++
+    if (promptCount === 1) {
+      await router.send({ ...key, text: 'working' })
+      strandOnUnansweredToolUse(session, id)
+      return
+    }
+    const priorLeaf = session.leafEntry
+    const userEntry: SessionEntry = {
+      type: 'message',
+      id: `${id}-retry-user-${promptCount}`,
+      parentId: priorLeaf?.id ?? null,
+      timestamp: '2026-08-28T00:00:00.000Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'retry' }], timestamp: 1000 },
+    }
+    session.entriesById.set(userEntry.id, userEntry)
+    session.leafEntry = userEntry
+  }
+}
+
 // A bare-empty `stop` leaf whose parentId chain runs back through a web_search
 // tool call to a bounding user entry — the production shape recoverableAssistantText
 // recovers as { text: '', source: 'leaf' } while attemptMadeToolCall still finds
@@ -7684,6 +7706,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
+    let historyFetches = 0
     const { router, sessions } = makeRouter(dir, {
       logs,
       onSessionCreated: (session) => {
@@ -7719,6 +7742,10 @@ describe('ChannelRouter channel-turn protocol', () => {
       sent.push(msg.text ?? '')
       return { ok: true }
     })
+    router.registerHistory('discord-bot', async () => {
+      historyFetches++
+      return { ok: true, messages: [historyMessage({ externalMessageId: 'm1', text: 'missed-1' })] }
+    })
 
     await router.route(inbound({ text: 'start the work', externalMessageId: 'trigger' }))
     await router.__testing!.flushDebounce(KEY)
@@ -7737,6 +7764,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sessions[1]!.prompts[0]).toContain('missed-3')
     expect(sent).toContain('⚠️ I reset a stuck conversation session and retried the messages that received no reply.')
     expect(sent).toContain('recovered')
+    expect(historyFetches).toBe(1)
     expect(logs.some((m) => m.includes('poisoned-session-rollover'))).toBe(true)
   })
 
@@ -7785,11 +7813,80 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sessions).toHaveLength(2)
   })
 
+  test('keeps affected inbounds queued when successor creation fails and retries them on the next message', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    let failedSuccessorOnce = false
+    const { router, sessions } = makeRouter(dir, {
+      onSessionCreated: (session) => {
+        if (sessions.length === 0) {
+          let promptCount = 0
+          session.onPrompt = async () => {
+            promptCount++
+            if (promptCount === 1) {
+              await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'working' })
+              strandOnUnansweredToolUse(session, 'recreate-failure-trigger')
+              return
+            }
+            const priorLeaf = session.leafEntry
+            const userEntry: SessionEntry = {
+              type: 'message',
+              id: `recreate-failure-user-${promptCount}`,
+              parentId: priorLeaf?.id ?? null,
+              timestamp: '2026-08-28T00:00:00.000Z',
+              message: { role: 'user', content: [{ type: 'text', text: 'unanswered' }], timestamp: 1000 },
+            }
+            session.entriesById.set(userEntry.id, userEntry)
+            session.leafEntry = userEntry
+          }
+          return
+        }
+        if (!failedSuccessorOnce) {
+          failedSuccessorOnce = true
+          throw new Error('synthetic successor failure')
+        }
+        session.onPrompt = async () => {
+          await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovered later' })
+          session.setAssistantText('recovered later')
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async (message) => {
+      sent.push(message.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'start work', externalMessageId: 'm-start' }))
+    await router.__testing!.flushDebounce(KEY)
+    for (let i = 1; i <= 3; i++) {
+      await router.route(inbound({ text: `retained-${i}`, externalMessageId: `m${i}` }))
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    expect(sessions).toHaveLength(1)
+    expect(sent).toContain(
+      '⚠️ The stuck session was reset, but the replacement could not start. Your unanswered messages remain queued and will retry with the next message.',
+    )
+
+    await router.route(inbound({ text: 'retry now', externalMessageId: 'm-retry' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[1]!.prompts.join('\n')).toContain('retained-1')
+    expect(sessions[1]!.prompts.join('\n')).toContain('retained-2')
+    expect(sessions[1]!.prompts.join('\n')).toContain('retained-3')
+    expect(sent).toContain('recovered later')
+  })
+
   test('does not roll over slow or tool-heavy turns that produce assistant progress', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1000 }
     const { router, sessions } = makeRouter(dir, { nowRef })
     router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: 'start deep work', externalMessageId: 'm-start' }))
+    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'slow-safe')
+    await router.__testing!.flushDebounce(KEY)
 
     for (let i = 1; i <= 4; i++) {
       await router.route(inbound({ text: `deep-work-${i}`, externalMessageId: `m${i}` }))
@@ -7832,15 +7929,27 @@ describe('ChannelRouter channel-turn protocol', () => {
 
   test('does not count deliberate NO_REPLY, skip_response, or background-child waits as poison', async () => {
     const dir = await tempDir()
+    let backgroundChildRunning = false
     const { router, sessions } = makeRouter(dir, {
-      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_3' ? 1000 : null),
+      newestRunningChildSubagentStartedAt: (sessionId) =>
+        backgroundChildRunning && sessionId === 'ses_fake_3' ? 1000 : null,
     })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: 'prime no reply', externalMessageId: 'prime-nr' }))
+    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'no-reply-safe')
+    await router.__testing!.flushDebounce(KEY)
 
     for (let i = 1; i <= 4; i++) {
       await router.route(inbound({ text: `silent-${i}`, externalMessageId: `m-nr-${i}` }))
       sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
       await router.__testing!.flushDebounce(KEY)
     }
+
+    const skipKey = { ...KEY, chat: 'c2' }
+    await router.route(inbound({ text: 'prime skip', chat: 'c2', externalMessageId: 'prime-skip' }))
+    installPoisonWatchTrigger(router, sessions[1]!, skipKey, 'skip-safe')
+    await router.__testing!.flushDebounce(skipKey)
 
     for (let i = 1; i <= 4; i++) {
       await router.route(inbound({ text: `skip-${i}`, chat: 'c2', externalMessageId: `m-skip-${i}` }))
@@ -7849,6 +7958,12 @@ describe('ChannelRouter channel-turn protocol', () => {
       }
       await router.__testing!.flushDebounce({ ...KEY, chat: 'c2' })
     }
+
+    const backgroundKey = { ...KEY, chat: 'c3' }
+    await router.route(inbound({ text: 'prime background wait', chat: 'c3', externalMessageId: 'prime-bg' }))
+    installPoisonWatchTrigger(router, sessions[2]!, backgroundKey, 'background-safe')
+    await router.__testing!.flushDebounce(backgroundKey)
+    backgroundChildRunning = true
 
     for (let i = 1; i <= 4; i++) {
       await router.route(inbound({ text: `waiting-${i}`, chat: 'c3', externalMessageId: `m-bg-${i}` }))

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -308,10 +308,10 @@ function installPoisonWatchTrigger(router: ChannelRouter, session: FakeSession, 
     const priorLeaf = session.leafEntry
     const userEntry: SessionEntry = {
       type: 'message',
-      id: `${id}-retry-user-${promptCount}`,
+      id: `${id}-dead-user-${promptCount}`,
       parentId: priorLeaf?.id ?? null,
       timestamp: '2026-08-28T00:00:00.000Z',
-      message: { role: 'user', content: [{ type: 'text', text: 'retry' }], timestamp: 1000 },
+      message: { role: 'user', content: [{ type: 'text', text: 'unanswered' }], timestamp: 1000 },
     }
     session.entriesById.set(userEntry.id, userEntry)
     session.leafEntry = userEntry
@@ -7702,16 +7702,12 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('no recoverable assistant text in branch'))).toBe(true)
   })
 
-  test('rolls over after consecutive fast turns append no assistant entry and replays every affected inbound', async () => {
+  test('rolls over after consecutive fast turns append no assistant entry so a later message is answered', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
-    const originRefs: SessionOriginRef[] = []
-    const replayAuthors: Array<string | undefined> = []
-    let historyFetches = 0
     const { router, sessions } = makeRouter(dir, {
       logs,
-      originRefs,
       onSessionCreated: (session) => {
         if (sessions.length === 0) {
           let deadTurn = 0
@@ -7735,10 +7731,6 @@ describe('ChannelRouter channel-turn protocol', () => {
           }
         } else if (sessions.length === 1) {
           session.onPrompt = async () => {
-            const origin = originRefs[1]?.current
-            replayAuthors.push(
-              origin !== undefined && origin.kind === 'channel' ? origin.lastInboundAuthorId : undefined,
-            )
             await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovered' })
             session.setAssistantText('recovered')
           }
@@ -7749,67 +7741,42 @@ describe('ChannelRouter channel-turn protocol', () => {
       sent.push(msg.text ?? '')
       return { ok: true }
     })
-    router.registerHistory('discord-bot', async () => {
-      historyFetches++
-      return { ok: true, messages: [historyMessage({ externalMessageId: 'm1', text: 'missed-1' })] }
-    })
 
     await router.route(inbound({ text: 'start the work', externalMessageId: 'trigger' }))
     await router.__testing!.flushDebounce(KEY)
 
     for (let i = 1; i <= 3; i++) {
-      await router.route(
-        inbound({ text: `missed-${i}`, externalMessageId: `m${i}`, authorId: i === 2 ? 'owner' : 'guest' }),
-      )
+      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
       await router.__testing!.flushDebounce(KEY)
       if (i < 3) expect(sessions).toHaveLength(1)
     }
 
-    expect(sessions).toHaveLength(2)
+    expect(sessions).toHaveLength(1)
     expect(sessions[0]!.disposed).toBe(1)
-    expect(sessions[1]!.prompts).toHaveLength(3)
-    expect(sessions[1]!.prompts[0]).toContain('missed-1')
-    expect(sessions[1]!.prompts[1]).toContain('missed-2')
-    expect(sessions[1]!.prompts[2]).toContain('missed-3')
-    expect(replayAuthors).toEqual(['guest', 'owner', 'guest'])
+
+    await router.route(inbound({ text: 'after reset', externalMessageId: 'm4' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[1]!.prompts).toHaveLength(1)
+    expect(sessions[1]!.prompts[0]).toContain('after reset')
     expect(sent).toContain(
-      '⚠️ This conversation session stopped responding. I’m resetting it and will retry the unanswered messages.',
+      '⚠️ This conversation session stopped responding, so I reset it. Please resend any unanswered request.',
     )
     expect(sent).toContain('recovered')
-    expect(historyFetches).toBe(1)
     expect(logs.some((m) => m.includes('poisoned-session-rollover'))).toBe(true)
   })
 
   test('/stop sees a suspected poisoned session and resets the escape hatch', async () => {
     const dir = await tempDir()
-    let promptCount = 0
     const logs: string[] = []
     const { router, sessions } = makeRouter(dir, {
       logs,
-      onSessionCreated: (session) => {
-        session.onPrompt = async () => {
-          promptCount++
-          if (promptCount === 1) {
-            await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'working' })
-            strandOnUnansweredToolUse(session, 'stop-trigger')
-          } else {
-            const priorLeaf = session.leafEntry
-            const userEntry: SessionEntry = {
-              type: 'message',
-              id: `stop-dead-user-${promptCount}`,
-              parentId: priorLeaf?.id ?? null,
-              timestamp: '2026-08-28T00:00:00.000Z',
-              message: { role: 'user', content: [{ type: 'text', text: 'unanswered' }], timestamp: 1000 },
-            }
-            session.entriesById.set(userEntry.id, userEntry)
-            session.leafEntry = userEntry
-          }
-        }
-      },
     })
     router.registerOutbound('discord-bot', async () => ({ ok: true }))
 
     await router.route(inbound({ text: 'start the work', externalMessageId: 'trigger' }))
+    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'stop-trigger')
     await router.__testing!.flushDebounce(KEY)
 
     await router.route(inbound({ text: 'first miss' }))
@@ -7823,224 +7790,6 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.route(inbound({ text: 'fresh turn', externalMessageId: 'm2' }))
     await router.__testing!.flushDebounce(KEY)
     expect(sessions).toHaveLength(2)
-  })
-
-  test('keeps affected inbounds queued when successor creation fails and retries them on the next message', async () => {
-    const dir = await tempDir()
-    const sent: string[] = []
-    let failedSuccessorOnce = false
-    const { router, sessions } = makeRouter(dir, {
-      onSessionCreated: (session) => {
-        if (sessions.length === 0) {
-          let promptCount = 0
-          session.onPrompt = async () => {
-            promptCount++
-            if (promptCount === 1) {
-              await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'working' })
-              strandOnUnansweredToolUse(session, 'recreate-failure-trigger')
-              return
-            }
-            const priorLeaf = session.leafEntry
-            const userEntry: SessionEntry = {
-              type: 'message',
-              id: `recreate-failure-user-${promptCount}`,
-              parentId: priorLeaf?.id ?? null,
-              timestamp: '2026-08-28T00:00:00.000Z',
-              message: { role: 'user', content: [{ type: 'text', text: 'unanswered' }], timestamp: 1000 },
-            }
-            session.entriesById.set(userEntry.id, userEntry)
-            session.leafEntry = userEntry
-          }
-          return
-        }
-        if (!failedSuccessorOnce) {
-          failedSuccessorOnce = true
-          throw new Error('synthetic successor failure')
-        }
-        session.onPrompt = async () => {
-          await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovered later' })
-          session.setAssistantText('recovered later')
-        }
-      },
-    })
-    router.registerOutbound('discord-bot', async (message) => {
-      sent.push(message.text ?? '')
-      return { ok: true }
-    })
-
-    await router.route(inbound({ text: 'start work', externalMessageId: 'm-start' }))
-    await router.__testing!.flushDebounce(KEY)
-    for (let i = 1; i <= 3; i++) {
-      await router.route(inbound({ text: `retained-${i}`, externalMessageId: `m${i}` }))
-      await router.__testing!.flushDebounce(KEY)
-    }
-
-    expect(sessions).toHaveLength(1)
-    expect(sent).toContain(
-      '⚠️ The stuck session was reset, but the replacement could not start. Your unanswered messages remain queued and will retry with the next message.',
-    )
-
-    await router.route(inbound({ text: 'retry now', externalMessageId: 'm-retry' }))
-    await router.__testing!.flushDebounce(KEY)
-
-    expect(sessions).toHaveLength(2)
-    for (let i = 1; i <= 3; i++) {
-      expect(sessions[1]!.prompts.filter((prompt) => prompt.includes(`retained-${i}`))).toHaveLength(1)
-    }
-    expect(sent).toContain('recovered later')
-  })
-
-  test('shutdown waits for poisoned-session pointer clearing to persist', async () => {
-    const dir = await tempDir()
-    let holdPointerClear = false
-    let releasePointerClear: (() => void) | undefined
-    let pointerClearStarted: (() => void) | undefined
-    const pointerClearStartedPromise = new Promise<void>((resolve) => {
-      pointerClearStarted = resolve
-    })
-    const snapshots: ChannelSessionRecord[][] = []
-    const { router, sessions } = makeRouter(dir, {
-      saveChannelSessions: async (_agentDir, records) => {
-        snapshots.push(records.map((record) => ({ ...record })))
-        if (holdPointerClear && records[0]?.sessionId === undefined) {
-          pointerClearStarted?.()
-          await new Promise<void>((resolve) => {
-            releasePointerClear = resolve
-          })
-        }
-      },
-    })
-    router.registerOutbound('discord-bot', async () => ({ ok: true }))
-
-    await router.route(inbound({ text: 'prime', externalMessageId: 'prime' }))
-    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'shutdown-race')
-    await router.__testing!.flushDebounce(KEY)
-    for (let i = 1; i <= 2; i++) {
-      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
-      await router.__testing!.flushDebounce(KEY)
-    }
-
-    holdPointerClear = true
-    await router.route(inbound({ text: 'missed-3', externalMessageId: 'm3' }))
-    const rollover = router.__testing!.flushDebounce(KEY)
-    await pointerClearStartedPromise
-    let stopSettled = false
-    const stopping = router.stop().then(() => {
-      stopSettled = true
-    })
-    await Promise.resolve()
-    expect(stopSettled).toBe(false)
-
-    releasePointerClear?.()
-    await Promise.all([rollover, stopping])
-
-    expect(snapshots.some((records) => records[0]?.sessionId === undefined)).toBe(true)
-    expect(stopSettled).toBe(true)
-  })
-
-  test('shutdown retires a tripped poison before the drain registers retirement', async () => {
-    const dir = await tempDir()
-    let releaseNotice: (() => void) | undefined
-    let noticeStarted: (() => void) | undefined
-    const noticeStartedPromise = new Promise<void>((resolve) => {
-      noticeStarted = resolve
-    })
-    const snapshots: ChannelSessionRecord[][] = []
-    const { router, sessions } = makeRouter(dir, {
-      saveChannelSessions: async (_agentDir, records) => {
-        snapshots.push(records.map((record) => ({ ...record })))
-      },
-    })
-    router.registerOutbound('discord-bot', async (message) => {
-      if (message.text?.includes('conversation session stopped responding')) {
-        noticeStarted?.()
-        await new Promise<void>((resolve) => {
-          releaseNotice = resolve
-        })
-      }
-      return { ok: true }
-    })
-
-    await router.route(inbound({ text: 'prime', externalMessageId: 'prime' }))
-    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'shutdown-before-retire')
-    await router.__testing!.flushDebounce(KEY)
-    for (let i = 1; i <= 2; i++) {
-      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
-      await router.__testing!.flushDebounce(KEY)
-    }
-
-    await router.route(inbound({ text: 'missed-3', externalMessageId: 'm3' }))
-    const rollover = router.__testing!.flushDebounce(KEY)
-    await noticeStartedPromise
-    const stopping = router.stop()
-    releaseNotice?.()
-    await Promise.all([rollover, stopping])
-
-    expect(snapshots.some((records) => records[0]?.sessionId === undefined)).toBe(true)
-    expect(sessions[0]!.disposed).toBe(1)
-  })
-
-  test('reroutes an inbound that was awaiting membership while its poisoned live retires', async () => {
-    const dir = await tempDir()
-    let holdMembership = false
-    let releaseMembership: (() => void) | undefined
-    let membershipStarted: (() => void) | undefined
-    const membershipStartedPromise = new Promise<void>((resolve) => {
-      membershipStarted = resolve
-    })
-    const { router, sessions } = makeRouter(dir, {
-      onSessionCreated: (session) => {
-        if (sessions.length === 1) session.onPrompt = () => session.setAssistantText('recovered')
-      },
-    })
-    router.registerOutbound('discord-bot', async () => ({ ok: true }))
-    router.registerMembership('discord-bot', async () => {
-      if (holdMembership) {
-        membershipStarted?.()
-        await new Promise<void>((resolve) => {
-          releaseMembership = resolve
-        })
-      }
-      return { humans: 2, bots: 0, fetchedAt: Date.now(), truncated: false }
-    })
-
-    await router.route(inbound({ text: 'prime', externalMessageId: 'prime' }))
-    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'route-race')
-    await router.__testing!.flushDebounce(KEY)
-    for (let i = 1; i <= 2; i++) {
-      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
-      await router.__testing!.flushDebounce(KEY)
-    }
-
-    let racedRoute: Promise<void> | undefined
-    sessions[0]!.onPrompt = async () => {
-      const priorLeaf = sessions[0]!.leafEntry
-      const userEntry: SessionEntry = {
-        type: 'message',
-        id: 'route-race-third-user',
-        parentId: priorLeaf?.id ?? null,
-        timestamp: '2026-08-28T00:00:00.000Z',
-        message: { role: 'user', content: [{ type: 'text', text: 'missed-3' }], timestamp: 1000 },
-      }
-      sessions[0]!.entriesById.set(userEntry.id, userEntry)
-      sessions[0]!.leafEntry = userEntry
-      holdMembership = true
-      racedRoute = router.route(
-        inbound({ text: 'raced inbound', authorId: 'bob', authorName: 'bob', externalMessageId: 'raced' }),
-      )
-      await membershipStartedPromise
-    }
-    await router.route(inbound({ text: 'missed-3', externalMessageId: 'm3' }))
-    const rollover = router.__testing!.flushDebounce(KEY)
-    await waitFor(() => sessions[0]!.disposed === 1)
-    holdMembership = false
-    releaseMembership?.()
-    await rollover
-    await racedRoute
-    await router.__testing!.flushDebounce(KEY)
-
-    expect(sessions).toHaveLength(2)
-    expect(sessions[1]!.prompts.some((prompt) => prompt.includes('raced inbound'))).toBe(true)
   })
 
   test('does not roll over slow or tool-heavy turns that produce assistant progress', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7706,9 +7706,12 @@ describe('ChannelRouter channel-turn protocol', () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
+    const originRefs: SessionOriginRef[] = []
+    const replayAuthors: Array<string | undefined> = []
     let historyFetches = 0
     const { router, sessions } = makeRouter(dir, {
       logs,
+      originRefs,
       onSessionCreated: (session) => {
         if (sessions.length === 0) {
           let deadTurn = 0
@@ -7732,6 +7735,10 @@ describe('ChannelRouter channel-turn protocol', () => {
           }
         } else if (sessions.length === 1) {
           session.onPrompt = async () => {
+            const origin = originRefs[1]?.current
+            replayAuthors.push(
+              origin !== undefined && origin.kind === 'channel' ? origin.lastInboundAuthorId : undefined,
+            )
             await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovered' })
             session.setAssistantText('recovered')
           }
@@ -7751,18 +7758,23 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
 
     for (let i = 1; i <= 3; i++) {
-      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
+      await router.route(
+        inbound({ text: `missed-${i}`, externalMessageId: `m${i}`, authorId: i === 2 ? 'owner' : 'guest' }),
+      )
       await router.__testing!.flushDebounce(KEY)
       if (i < 3) expect(sessions).toHaveLength(1)
     }
 
     expect(sessions).toHaveLength(2)
     expect(sessions[0]!.disposed).toBe(1)
-    expect(sessions[1]!.prompts).toHaveLength(1)
+    expect(sessions[1]!.prompts).toHaveLength(3)
     expect(sessions[1]!.prompts[0]).toContain('missed-1')
-    expect(sessions[1]!.prompts[0]).toContain('missed-2')
-    expect(sessions[1]!.prompts[0]).toContain('missed-3')
-    expect(sent).toContain('⚠️ I reset a stuck conversation session and retried the messages that received no reply.')
+    expect(sessions[1]!.prompts[1]).toContain('missed-2')
+    expect(sessions[1]!.prompts[2]).toContain('missed-3')
+    expect(replayAuthors).toEqual(['guest', 'owner', 'guest'])
+    expect(sent).toContain(
+      '⚠️ This conversation session stopped responding. I’m resetting it and will retry the unanswered messages.',
+    )
     expect(sent).toContain('recovered')
     expect(historyFetches).toBe(1)
     expect(logs.some((m) => m.includes('poisoned-session-rollover'))).toBe(true)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7890,6 +7890,117 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent).toContain('recovered later')
   })
 
+  test('shutdown waits for poisoned-session pointer clearing to persist', async () => {
+    const dir = await tempDir()
+    let holdPointerClear = false
+    let releasePointerClear: (() => void) | undefined
+    let pointerClearStarted: (() => void) | undefined
+    const pointerClearStartedPromise = new Promise<void>((resolve) => {
+      pointerClearStarted = resolve
+    })
+    const snapshots: ChannelSessionRecord[][] = []
+    const { router, sessions } = makeRouter(dir, {
+      saveChannelSessions: async (_agentDir, records) => {
+        snapshots.push(records.map((record) => ({ ...record })))
+        if (holdPointerClear && records[0]?.sessionId === undefined) {
+          pointerClearStarted?.()
+          await new Promise<void>((resolve) => {
+            releasePointerClear = resolve
+          })
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: 'prime', externalMessageId: 'prime' }))
+    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'shutdown-race')
+    await router.__testing!.flushDebounce(KEY)
+    for (let i = 1; i <= 2; i++) {
+      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    holdPointerClear = true
+    await router.route(inbound({ text: 'missed-3', externalMessageId: 'm3' }))
+    const rollover = router.__testing!.flushDebounce(KEY)
+    await pointerClearStartedPromise
+    let stopSettled = false
+    const stopping = router.stop().then(() => {
+      stopSettled = true
+    })
+    await Promise.resolve()
+    expect(stopSettled).toBe(false)
+
+    releasePointerClear?.()
+    await Promise.all([rollover, stopping])
+
+    expect(snapshots.some((records) => records[0]?.sessionId === undefined)).toBe(true)
+    expect(stopSettled).toBe(true)
+  })
+
+  test('reroutes an inbound that was awaiting membership while its poisoned live retires', async () => {
+    const dir = await tempDir()
+    let holdMembership = false
+    let releaseMembership: (() => void) | undefined
+    let membershipStarted: (() => void) | undefined
+    const membershipStartedPromise = new Promise<void>((resolve) => {
+      membershipStarted = resolve
+    })
+    const { router, sessions } = makeRouter(dir, {
+      onSessionCreated: (session) => {
+        if (sessions.length === 1) session.onPrompt = () => session.setAssistantText('recovered')
+      },
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    router.registerMembership('discord-bot', async () => {
+      if (holdMembership) {
+        membershipStarted?.()
+        await new Promise<void>((resolve) => {
+          releaseMembership = resolve
+        })
+      }
+      return { humans: 2, bots: 0, fetchedAt: Date.now(), truncated: false }
+    })
+
+    await router.route(inbound({ text: 'prime', externalMessageId: 'prime' }))
+    installPoisonWatchTrigger(router, sessions[0]!, KEY, 'route-race')
+    await router.__testing!.flushDebounce(KEY)
+    for (let i = 1; i <= 2; i++) {
+      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    let racedRoute: Promise<void> | undefined
+    sessions[0]!.onPrompt = async () => {
+      const priorLeaf = sessions[0]!.leafEntry
+      const userEntry: SessionEntry = {
+        type: 'message',
+        id: 'route-race-third-user',
+        parentId: priorLeaf?.id ?? null,
+        timestamp: '2026-08-28T00:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'missed-3' }], timestamp: 1000 },
+      }
+      sessions[0]!.entriesById.set(userEntry.id, userEntry)
+      sessions[0]!.leafEntry = userEntry
+      holdMembership = true
+      racedRoute = router.route(
+        inbound({ text: 'raced inbound', authorId: 'bob', authorName: 'bob', externalMessageId: 'raced' }),
+      )
+      await membershipStartedPromise
+    }
+    await router.route(inbound({ text: 'missed-3', externalMessageId: 'm3' }))
+    const rollover = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.disposed === 1)
+    holdMembership = false
+    releaseMembership?.()
+    await rollover
+    await racedRoute
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[1]!.prompts.some((prompt) => prompt.includes('raced inbound'))).toBe(true)
+  })
+
   test('does not roll over slow or tool-heavy turns that produce assistant progress', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1000 }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7679,6 +7679,185 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     expect(logs.some((m) => m.includes('no recoverable assistant text in branch'))).toBe(true)
   })
+
+  test('rolls over after consecutive fast turns append no assistant entry and replays every affected inbound', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      onSessionCreated: (session) => {
+        if (sessions.length === 0) {
+          let deadTurn = 0
+          session.onPrompt = async () => {
+            deadTurn++
+            if (deadTurn === 1) {
+              await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'working' })
+              strandOnUnansweredToolUse(session, 'poison-trigger')
+              return
+            }
+            const priorLeaf = session.leafEntry
+            const userEntry: SessionEntry = {
+              type: 'message',
+              id: `dead-user-${deadTurn}`,
+              parentId: priorLeaf?.id ?? null,
+              timestamp: '2026-08-28T00:00:00.000Z',
+              message: { role: 'user', content: [{ type: 'text', text: `missed-${deadTurn}` }], timestamp: 1000 },
+            }
+            session.entriesById.set(userEntry.id, userEntry)
+            session.leafEntry = userEntry
+          }
+        } else if (sessions.length === 1) {
+          session.onPrompt = async () => {
+            await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovered' })
+            session.setAssistantText('recovered')
+          }
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'start the work', externalMessageId: 'trigger' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    for (let i = 1; i <= 3; i++) {
+      await router.route(inbound({ text: `missed-${i}`, externalMessageId: `m${i}` }))
+      await router.__testing!.flushDebounce(KEY)
+      if (i < 3) expect(sessions).toHaveLength(1)
+    }
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0]!.disposed).toBe(1)
+    expect(sessions[1]!.prompts).toHaveLength(1)
+    expect(sessions[1]!.prompts[0]).toContain('missed-1')
+    expect(sessions[1]!.prompts[0]).toContain('missed-2')
+    expect(sessions[1]!.prompts[0]).toContain('missed-3')
+    expect(sent).toContain('⚠️ I reset a stuck conversation session and retried the messages that received no reply.')
+    expect(sent).toContain('recovered')
+    expect(logs.some((m) => m.includes('poisoned-session-rollover'))).toBe(true)
+  })
+
+  test('/stop sees a suspected poisoned session and resets the escape hatch', async () => {
+    const dir = await tempDir()
+    let promptCount = 0
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      onSessionCreated: (session) => {
+        session.onPrompt = async () => {
+          promptCount++
+          if (promptCount === 1) {
+            await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'working' })
+            strandOnUnansweredToolUse(session, 'stop-trigger')
+          } else {
+            const priorLeaf = session.leafEntry
+            const userEntry: SessionEntry = {
+              type: 'message',
+              id: `stop-dead-user-${promptCount}`,
+              parentId: priorLeaf?.id ?? null,
+              timestamp: '2026-08-28T00:00:00.000Z',
+              message: { role: 'user', content: [{ type: 'text', text: 'unanswered' }], timestamp: 1000 },
+            }
+            session.entriesById.set(userEntry.id, userEntry)
+            session.leafEntry = userEntry
+          }
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: 'start the work', externalMessageId: 'trigger' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    await router.route(inbound({ text: 'first miss' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const stopped = await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
+    expect(stopped).toEqual({ kind: 'handled', name: 'stop', reply: 'Reset the stuck conversation session.' })
+    expect(sessions[0]!.aborted).toBeGreaterThanOrEqual(1)
+    expect(sessions[0]!.disposed).toBe(1)
+
+    await router.route(inbound({ text: 'fresh turn', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(2)
+  })
+
+  test('does not roll over slow or tool-heavy turns that produce assistant progress', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    for (let i = 1; i <= 4; i++) {
+      await router.route(inbound({ text: `deep-work-${i}`, externalMessageId: `m${i}` }))
+      sessions[0]!.onPrompt = () => {
+        const assistantToolCall = messageEntry({
+          ...assistantMessage(''),
+          content: [{ type: 'toolCall', id: `tool-${i}`, name: 'web_search', arguments: { query: 'topic' } }],
+          stopReason: 'toolUse',
+        })
+        assistantToolCall.id = `assistant-tool-${i}`
+        const toolResult: SessionEntry = {
+          type: 'message',
+          id: `tool-result-${i}`,
+          parentId: assistantToolCall.id,
+          timestamp: '2026-08-28T00:00:00.000Z',
+          message: {
+            role: 'toolResult',
+            toolCallId: `tool-${i}`,
+            toolName: 'web_search',
+            content: [{ type: 'text', text: 'result' }],
+            isError: false,
+            timestamp: 1000,
+          },
+        }
+        const answer = messageEntry(assistantMessage(`answer-${i}`))
+        answer.id = `assistant-answer-${i}`
+        answer.parentId = toolResult.id
+        sessions[0]!.entriesById.set(assistantToolCall.id, assistantToolCall)
+        sessions[0]!.entriesById.set(toolResult.id, toolResult)
+        sessions[0]!.entriesById.set(answer.id, answer)
+        sessions[0]!.leafEntry = answer
+        nowRef.value += 5_000
+      }
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.disposed).toBe(0)
+  })
+
+  test('does not count deliberate NO_REPLY, skip_response, or background-child waits as poison', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir, {
+      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_3' ? 1000 : null),
+    })
+
+    for (let i = 1; i <= 4; i++) {
+      await router.route(inbound({ text: `silent-${i}`, externalMessageId: `m-nr-${i}` }))
+      sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+      await router.__testing!.flushDebounce(KEY)
+    }
+
+    for (let i = 1; i <= 4; i++) {
+      await router.route(inbound({ text: `skip-${i}`, chat: 'c2', externalMessageId: `m-skip-${i}` }))
+      sessions[1]!.onPrompt = () => {
+        router.markTurnSkipped({ parentSessionId: 'ses_fake_2', reason: 'deliberate silence' })
+      }
+      await router.__testing!.flushDebounce({ ...KEY, chat: 'c2' })
+    }
+
+    for (let i = 1; i <= 4; i++) {
+      await router.route(inbound({ text: `waiting-${i}`, chat: 'c3', externalMessageId: `m-bg-${i}` }))
+      await router.__testing!.flushDebounce({ ...KEY, chat: 'c3' })
+    }
+
+    expect(sessions).toHaveLength(3)
+    expect(sessions.every((session) => session.disposed === 0)).toBe(true)
+  })
 })
 
 describe('ChannelRouter consecutive-send accounting', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4354,6 +4354,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
 
     const membership = await membershipForEngagement(live)
+    // A poisoned-session retirement can begin while this route awaits a slow
+    // membership lookup. Never enqueue onto the now-destroyed predecessor: run
+    // the full admission path again so ensureLive waits for the retirement
+    // barrier and targets the successor.
+    if (live.destroyed || liveSessions.get(live.keyId) !== live) {
+      logger.info(`[channels] ${live.keyId}: route retry after live-session replacement`)
+      return await route(event)
+    }
 
     const effectiveHumans = countEffectiveHumans(live.participants, membership, now())
     live.multiHumanGroup = isMultiHumanGroup(event.isDm, effectiveHumans)
@@ -6265,6 +6273,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   gcTimer.unref?.()
 
   const stop = async (): Promise<void> => {
+    // Pointer clearing during poison retirement must reach disk before closing
+    // seals persist(). Otherwise shutdown can preserve the poisoned sessionId
+    // and rehydrate it on the next boot.
+    while (retiring.size > 0) await Promise.all(retiring.values())
     closing = true
     if (gcTimer) clearInterval(gcTimer)
     gcTimer = null

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -337,6 +337,19 @@ export const CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS = 16384
 // straight to the fallback. See validateChannelTurn's candidate===null branch.
 export const MAX_EMPTY_TURN_RETRIES = 2
 
+// A structurally dead in-memory branch returns almost immediately without
+// appending an assistant entry, then repeats that exact shape for every new
+// inbound. Three consecutive fingerprints are required before rollover: one
+// empty completion can be a benign SDK edge, while the 2026-08-28 production
+// incident produced the same ~55ms/no-assistant result for fourteen messages.
+// The time ceiling excludes slow providers and long tool loops; the branch-entry
+// check excludes real assistant/tool progress even when validation finds no
+// postable text. Deliberate silence exits validation earlier and never counts.
+export const POISONED_SESSION_CONSECUTIVE_TURNS = 3
+export const POISONED_SESSION_FAST_TURN_MS = 1_000
+export const POISONED_SESSION_RESET_TEXT =
+  '⚠️ I reset a stuck conversation session and retried the messages that received no reply.'
+
 // Separate, tiny budget for the tool-call-leak self-correction retry. Kept
 // apart from MAX_EMPTY_TURN_RETRIES so a persistently-leaking model cannot
 // consume the empty-turn budget (or vice versa) and so it can't livelock: one
@@ -1098,6 +1111,19 @@ type LiveSession = {
   // increments it before injecting EMPTY_TURN_RETRY_NUDGE and reads it to decide
   // retry-vs-fallback. See the candidate===null branch.
   emptyTurnRetries: number
+  // Consecutive 2026-08-28 poison fingerprints. The matching inbounds are
+  // retained so rollover replays the work instead of merely replacing one
+  // silent drop with another. NO_REPLY, skip_response, awaiting-background-child,
+  // slow provider calls, and tool-heavy turns all fail at least one discriminator
+  // and clear this state.
+  rapidUnchangedEmptyTurns: number
+  rapidUnchangedEmptyInbounds: QueuedInbound[]
+  rapidUnchangedEmptyObserved: ObservedInbound[]
+  poisonedRolloverPending: boolean
+  // Armed only by the stranded-toolUse-after-send recovery path that preceded
+  // the 2026-08-28 collapse. Healthy empty turns outside that fingerprint can
+  // never accumulate toward rollover; any later assistant progress disarms it.
+  poisonWatchArmed: boolean
   // Count of tool-call-leak self-correction re-prompts spent this logical turn,
   // bounded by MAX_TOOL_LEAK_RETRIES. Separate from emptyTurnRetries so the two
   // failure modes can't drain each other's budget. Reset with the rest on a
@@ -1894,7 +1920,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       handler: async ({ live }) => {
         // requiresLiveSession:true guarantees the dispatch layer resolved a
         // session before running this handler, so `live` is non-null here.
-        await stopCurrentChannelTurn(live!)
+        const target = live!
+        const resetPoisonedSession = target.rapidUnchangedEmptyTurns > 0
+        await stopCurrentChannelTurn(target)
+        if (resetPoisonedSession) {
+          await retireLiveSession(target)
+          return { reply: 'Reset the stuck conversation session.' }
+        }
         return { reply: 'Stopped the current turn.' }
       },
     },
@@ -1979,6 +2011,34 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     })
     persistChain = next.catch(() => {})
     await next
+  }
+
+  const clearPersistedSessionPointer = async (live: LiveSession): Promise<void> => {
+    if (mappings === null) return
+    const idx = mappings.findIndex(
+      (record) =>
+        record.adapter === live.key.adapter &&
+        record.workspace === live.key.workspace &&
+        record.chat === live.key.chat &&
+        (record.thread ?? null) === (live.key.thread ?? null),
+    )
+    if (idx < 0) return
+    const previous = mappings[idx]!
+    mappings[idx] = {
+      adapter: previous.adapter,
+      workspace: previous.workspace,
+      chat: previous.chat,
+      thread: previous.thread,
+      participants: previous.participants,
+      lastInboundAt: 0,
+    }
+    await persist()
+  }
+
+  const retireLiveSession = async (live: LiveSession): Promise<void> => {
+    liveSessions.delete(live.keyId)
+    await tearDownLive(live)
+    await clearPersistedSessionPointer(live)
   }
 
   const persistGithubReviewRound = (live: LiveSession, round: GithubReviewFollowupRound | null): void => {
@@ -2500,6 +2560,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
         emptyTurnRetries: 0,
+        rapidUnchangedEmptyTurns: 0,
+        rapidUnchangedEmptyInbounds: [],
+        rapidUnchangedEmptyObserved: [],
+        poisonedRolloverPending: false,
+        poisonWatchArmed: false,
         toolLeakRetries: 0,
         emptyStopAfterToolWorkArmed: false,
         willingnessNudges: 0,
@@ -3351,7 +3416,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // session and posts "stopped" in a multi-agent channel. Mirrors exactly what
   // stopCurrentChannelTurn cancels: in-flight drain, queued prompts, reminders.
   const hasStoppableWork = (live: LiveSession): boolean =>
-    live.draining || live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0
+    live.draining ||
+    live.promptQueue.length > 0 ||
+    live.pendingSystemReminders.length > 0 ||
+    live.rapidUnchangedEmptyTurns > 0
 
   const hasPendingContinueReply = (live: LiveSession): boolean => {
     const progressReply = live.continueReplyTurn
@@ -3483,7 +3551,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       while (
         (live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) &&
         !live.destroyed &&
-        !live.pendingTeardown
+        !live.pendingTeardown &&
+        !live.poisonedRolloverPending
       ) {
         live.typingTimedOut = false
         // Each turn starts with no held reactions; the model re-requests them
@@ -3654,6 +3723,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         applyTurnThinkingLevel(live.session, retrievalQuery, live.turnThinkingDefault, live.lastQuestionSignal)
         live.promptInFlight = true
         try {
+          const leafEntryBeforePromptId = live.session.sessionManager.getLeafEntry()?.id ?? null
+          const assistantEntryBeforePrompt = latestAssistantEntryId(live.session)
           const result = await promptPersistentTurnWithFallback({
             refs: resolveFallbackChain(getConfig().models, undefined),
             currentModelRef: live.activeModelRef,
@@ -3680,7 +3751,27 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             },
           })
           if (result.success) live.activeModelRef = result.refUsed
-          await validateChannelTurn(live, successfulSendsBeforePrompt)
+          const rapidUnchangedEmptyTurnsBeforePrompt = live.rapidUnchangedEmptyTurns
+          const poisonWatchArmedBeforePrompt = live.poisonWatchArmed
+          await validateChannelTurn(live, successfulSendsBeforePrompt, {
+            batch,
+            observed,
+            elapsedMs: now() - promptStart,
+            leafEntryBeforePromptId,
+            assistantEntryBeforePrompt,
+          })
+          if (!live.poisonedRolloverPending && live.rapidUnchangedEmptyTurns === rapidUnchangedEmptyTurnsBeforePrompt) {
+            live.rapidUnchangedEmptyTurns = 0
+            live.rapidUnchangedEmptyInbounds = []
+            live.rapidUnchangedEmptyObserved = []
+            if (
+              live.poisonWatchArmed === poisonWatchArmedBeforePrompt &&
+              (live.successfulChannelSends > successfulSendsBeforePrompt ||
+                latestAssistantEntryId(live.session) !== assistantEntryBeforePrompt)
+            ) {
+              live.poisonWatchArmed = false
+            }
+          }
           live.consecutiveAborts = 0
           // Resolve the pending logical-turn signal on a binary rule: ONLY a
           // usable assistant reply (real model prose the user saw) seeds the next
@@ -3823,6 +3914,34 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // to clear a flat-DM status; clearing it first would strand the indicator.
       await stopTypingHeartbeat(live)
       live.currentTurnTypingThread = null
+    }
+    if (live.poisonedRolloverPending && !live.destroyed) {
+      const carriedInbounds = [
+        ...live.rapidUnchangedEmptyInbounds,
+        ...live.promptQueue.splice(0, live.promptQueue.length),
+      ]
+      const carriedObserved = [
+        ...live.rapidUnchangedEmptyObserved,
+        ...live.contextBuffer.splice(0, live.contextBuffer.length),
+      ]
+      const carriedReminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
+      logger.warn(
+        `[channels] ${live.keyId}: poisoned-session-rollover replaying=${carriedInbounds.length} session=${live.sessionId}`,
+      )
+      const trigger = carriedInbounds.at(-1)
+      await retireLiveSession(live)
+      let successor: LiveSession
+      try {
+        successor = await ensureLive(live.key, trigger?.externalMessageId, trigger?.authorId, undefined, live.room)
+      } catch (err) {
+        logger.error(`[channels] ${live.keyId}: poisoned-session recreate failed: ${describeError(err)}`)
+        return
+      }
+      successor.promptQueue.push(...carriedInbounds)
+      successor.contextBuffer.push(...carriedObserved)
+      successor.pendingSystemReminders.push(...carriedReminders)
+      await drain(successor)
+      return
     }
     // A reload deferred this session's teardown so its in-flight reply could
     // land; now that the turn drained (and the loop stopped BEFORE draining any
@@ -5296,7 +5415,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return false
   }
 
-  const validateChannelTurn = async (live: LiveSession, successfulSendsBeforePrompt: number): Promise<void> => {
+  const validateChannelTurn = async (
+    live: LiveSession,
+    successfulSendsBeforePrompt: number,
+    prompt: {
+      batch: QueuedInbound[]
+      observed: ObservedInbound[]
+      elapsedMs: number
+      leafEntryBeforePromptId: string | null
+      assistantEntryBeforePrompt: string | null
+    },
+  ): Promise<void> => {
     // `skip_response` short-circuit. Honoring it bypasses recovery entirely.
     // Stale-flag protection: only honor when stamped on the just-completed
     // turn. A flag set by a previous turn that crashed before validation
@@ -5353,6 +5482,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
 
     const retryStrandedToolUse = async (cause: string, exhaustedCause: string): Promise<void> => {
+      if (cause === 'stranded_toolUse_after_send') live.poisonWatchArmed = true
       if (live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
         live.emptyTurnRetries++
         const routerAbortReason =
@@ -5601,6 +5731,42 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // assistant message at all) keeps the historical silent bail —
       // re-prompting it would manufacture replies to nothing.
       if (live.currentTurnAuthorId === null || leafStopReason === undefined) {
+        const rapidUnchangedRealUserTurn =
+          live.poisonWatchArmed &&
+          prompt.batch.length > 0 &&
+          prompt.elapsedMs <= POISONED_SESSION_FAST_TURN_MS &&
+          prompt.leafEntryBeforePromptId !== (live.session.sessionManager.getLeafEntry()?.id ?? null) &&
+          prompt.assistantEntryBeforePrompt === latestAssistantEntryId(live.session) &&
+          live.successfulChannelSends === successfulSendsBeforePrompt
+        if (rapidUnchangedRealUserTurn) {
+          live.rapidUnchangedEmptyTurns++
+          live.rapidUnchangedEmptyInbounds.push(...prompt.batch)
+          live.rapidUnchangedEmptyObserved.push(...prompt.observed)
+          logger.warn(
+            `[channels] ${live.keyId}: rapid unchanged empty turn ` +
+              `count=${live.rapidUnchangedEmptyTurns}/${POISONED_SESSION_CONSECUTIVE_TURNS} elapsed_ms=${prompt.elapsedMs}`,
+          )
+          if (live.rapidUnchangedEmptyTurns >= POISONED_SESSION_CONSECUTIVE_TURNS) {
+            // 2026-08-28 Discord fingerprint: after stranded_toolUse_after_send,
+            // prompt() returned in 53-56ms for 14 real-user turns, appended no
+            // assistant entry, and kept swallowing messages until idle rollover.
+            live.poisonedRolloverPending = true
+            live.emptyTurnFallbackTurn = live.turnSeq
+            const notice = await send(
+              {
+                adapter: live.key.adapter,
+                workspace: live.key.workspace,
+                chat: live.key.chat,
+                thread: live.key.thread,
+                text: POISONED_SESSION_RESET_TEXT,
+              },
+              { source: 'system', outputKind: 'meta' },
+            )
+            if (!notice.ok) {
+              logger.warn(`[channels] ${live.keyId}: poisoned-session notice send failed: ${notice.error}`)
+            }
+          }
+        }
         logger.info(`[channels] ${live.keyId}: no recoverable assistant text in branch`)
         return
       }
@@ -7773,6 +7939,21 @@ async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): 
   } finally {
     if (timer !== null) clearTimeout(timer)
   }
+}
+
+// Returns the newest assistant entry reachable from the current branch leaf.
+// A poisoned prompt still appends its USER entry, so comparing leaf ids would
+// mistake that bookkeeping for model progress. Walking to the nearest assistant
+// is the transcript-level discriminator the 2026-08-28 incident lacked: a real
+// reply or tool call changes this id; a dead branch that only accepts users does
+// not. The depth bound matches the other defensive branch walks below.
+function latestAssistantEntryId(session: AgentSession): string | null {
+  let cursor: SessionEntry | undefined = session.sessionManager.getLeafEntry()
+  for (let depth = 0; depth < 32 && cursor; depth++) {
+    if (cursor.type === 'message' && cursor.message.role === 'assistant') return cursor.id
+    cursor = cursor.parentId ? session.sessionManager.getEntry(cursor.parentId) : undefined
+  }
+  return null
 }
 
 // Walks the session branch backward from the leaf to find a recoverable

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -348,7 +348,9 @@ export const MAX_EMPTY_TURN_RETRIES = 2
 export const POISONED_SESSION_CONSECUTIVE_TURNS = 3
 export const POISONED_SESSION_FAST_TURN_MS = 1_000
 export const POISONED_SESSION_RESET_TEXT =
-  '⚠️ I reset a stuck conversation session and retried the messages that received no reply.'
+  '⚠️ This conversation session stopped responding. I’m resetting it and will retry the unanswered messages.'
+const POISONED_SESSION_RECREATE_FAILED_TEXT =
+  '⚠️ The stuck session was reset, but the replacement could not start. Your unanswered messages remain queued and will retry with the next message.'
 
 // Separate, tiny budget for the tool-call-leak self-correction retry. Kept
 // apart from MAX_EMPTY_TURN_RETRIES so a persistently-leaking model cannot
@@ -1117,8 +1119,7 @@ type LiveSession = {
   // slow provider calls, and tool-heavy turns all fail at least one discriminator
   // and clear this state.
   rapidUnchangedEmptyTurns: number
-  rapidUnchangedEmptyInbounds: QueuedInbound[]
-  rapidUnchangedEmptyObserved: ObservedInbound[]
+  rapidUnchangedEmptyBatches: Array<{ inbounds: QueuedInbound[]; observed: ObservedInbound[] }>
   poisonedRolloverPending: boolean
   // Armed only by the stranded-toolUse-after-send recovery path that preceded
   // the 2026-08-28 collapse. Healthy empty turns outside that fingerprint can
@@ -1865,6 +1866,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const newestRunningChildSubagentStartedAt = options.newestRunningChildSubagentStartedAt ?? (() => null)
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
+  // Serializes pointer clearing + teardown against a racing ensureLive. Without
+  // this per-key barrier, an inbound can rehydrate the poisoned sessionId in the
+  // await gap and undo the reset.
+  const retiring = new Map<string, Promise<void>>()
+  const pendingPoisonReplays = new Map<
+    string,
+    {
+      turns: Array<{ inbounds: QueuedInbound[]; observed: ObservedInbound[] }>
+      reminders: PendingSystemReminder[]
+    }
+  >()
+  const activePoisonReplays = new Map<string, Promise<void>>()
   // Restart-resume reservations, keyed by channelKeyId. Installed by
   // reserveRestartHandoff BEFORE channel adapters start receiving, so an
   // inbound that races the boot resume coalesces onto the reservation (via the
@@ -2036,9 +2049,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const retireLiveSession = async (live: LiveSession): Promise<void> => {
-    liveSessions.delete(live.keyId)
-    await tearDownLive(live)
-    await clearPersistedSessionPointer(live)
+    const existing = retiring.get(live.keyId)
+    if (existing !== undefined) return existing
+    const retirement = (async () => {
+      liveSessions.delete(live.keyId)
+      try {
+        await clearPersistedSessionPointer(live)
+      } catch (err) {
+        logger.error(`[channels] ${live.keyId}: session pointer clear failed during reset: ${describeError(err)}`)
+      }
+      await tearDownLive(live)
+    })()
+    retiring.set(live.keyId, retirement)
+    try {
+      await retirement
+    } finally {
+      if (retiring.get(live.keyId) === retirement) retiring.delete(live.keyId)
+    }
   }
 
   const persistGithubReviewRound = (live: LiveSession, round: GithubReviewFollowupRound | null): void => {
@@ -2276,8 +2303,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // parent-scoped from the first fetch (Discord threads resolve `chat` to the
     // thread id, so an unscoped warm would prime the cache against the thread).
     room?: InboundMessage['room'],
+    // Poison rollover replays all retained messages itself. Prefetch can exclude
+    // only one triggering id and would duplicate every earlier affected inbound.
+    skipColdStartPrefetch = false,
   ): Promise<LiveSession> => {
     const keyId = channelKeyId(key)
+    const retirement = retiring.get(keyId)
+    if (retirement !== undefined) {
+      await retirement
+      return ensureLive(key, triggeringMessageId, triggeringAuthorId, resumeTarget, room, skipColdStartPrefetch)
+    }
+    skipColdStartPrefetch ||= pendingPoisonReplays.has(keyId)
     const existing = liveSessions.get(keyId)
     if (existing && !existing.destroyed) {
       // A resume that finds the key already live is a no-op for reopening: the
@@ -2561,8 +2597,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         policyDeniedToolSendsThisTurn: new Map(),
         emptyTurnRetries: 0,
         rapidUnchangedEmptyTurns: 0,
-        rapidUnchangedEmptyInbounds: [],
-        rapidUnchangedEmptyObserved: [],
+        rapidUnchangedEmptyBatches: [],
         poisonedRolloverPending: false,
         poisonWatchArmed: false,
         toolLeakRetries: 0,
@@ -2658,9 +2693,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // Overlap the disk mapping-write with the network history prefetch —
         // they are independent. allSettled lets a persist failure take priority
         // (and unwind the install) even if prefetch also rejects.
-        const prefetchPromise = adapterConfig
-          ? prefetchChannelContext(live, adapterConfig, triggeringMessageId)
-          : Promise.resolve()
+        const prefetchPromise =
+          adapterConfig && !skipColdStartPrefetch
+            ? prefetchChannelContext(live, adapterConfig, triggeringMessageId)
+            : Promise.resolve()
         const [persistResult, prefetchResult] = await Promise.allSettled([persistPromise, prefetchPromise])
         if (persistResult.status === 'rejected') {
           await unwindInstalledLive(keyId, live)
@@ -2670,7 +2706,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           await unwindInstalledLive(keyId, live)
           throw prefetchResult.reason
         }
-        if (adapterConfig) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
+        if (adapterConfig && !skipColdStartPrefetch) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
       } else {
         // Rehydrate has no prefetch to overlap, so settle the mapping write
         // before installing — a failed persist must fail ensureLive without
@@ -3762,8 +3798,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           })
           if (!live.poisonedRolloverPending && live.rapidUnchangedEmptyTurns === rapidUnchangedEmptyTurnsBeforePrompt) {
             live.rapidUnchangedEmptyTurns = 0
-            live.rapidUnchangedEmptyInbounds = []
-            live.rapidUnchangedEmptyObserved = []
+            live.rapidUnchangedEmptyBatches = []
             if (
               live.poisonWatchArmed === poisonWatchArmedBeforePrompt &&
               (live.successfulChannelSends > successfulSendsBeforePrompt ||
@@ -3916,31 +3951,49 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.currentTurnTypingThread = null
     }
     if (live.poisonedRolloverPending && !live.destroyed) {
-      const carriedInbounds = [
-        ...live.rapidUnchangedEmptyInbounds,
-        ...live.promptQueue.splice(0, live.promptQueue.length),
-      ]
-      const carriedObserved = [
-        ...live.rapidUnchangedEmptyObserved,
-        ...live.contextBuffer.splice(0, live.contextBuffer.length),
-      ]
+      const turns = [...live.rapidUnchangedEmptyBatches]
+      const queuedInbounds = live.promptQueue.splice(0, live.promptQueue.length)
+      const queuedObserved = live.contextBuffer.splice(0, live.contextBuffer.length)
+      if (queuedInbounds.length > 0) turns.push({ inbounds: queuedInbounds, observed: queuedObserved })
+      else if (queuedObserved.length > 0 && turns.length > 0) turns.at(-1)!.observed.push(...queuedObserved)
       const carriedReminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
+      const replayCount = turns.reduce((count, turn) => count + turn.inbounds.length, 0)
       logger.warn(
-        `[channels] ${live.keyId}: poisoned-session-rollover replaying=${carriedInbounds.length} session=${live.sessionId}`,
+        `[channels] ${live.keyId}: poisoned-session-rollover replaying=${replayCount} session=${live.sessionId}`,
       )
-      const trigger = carriedInbounds.at(-1)
+      const trigger = turns.at(-1)?.inbounds.at(-1)
+      pendingPoisonReplays.set(live.keyId, { turns, reminders: carriedReminders })
       await retireLiveSession(live)
       let successor: LiveSession
       try {
-        successor = await ensureLive(live.key, trigger?.externalMessageId, trigger?.authorId, undefined, live.room)
+        successor = await ensureLive(
+          live.key,
+          trigger?.externalMessageId,
+          trigger?.authorId,
+          undefined,
+          live.room,
+          true,
+        )
       } catch (err) {
         logger.error(`[channels] ${live.keyId}: poisoned-session recreate failed: ${describeError(err)}`)
+        const failureNotice = await send(
+          {
+            adapter: live.key.adapter,
+            workspace: live.key.workspace,
+            chat: live.key.chat,
+            thread: live.key.thread,
+            text: POISONED_SESSION_RECREATE_FAILED_TEXT,
+          },
+          { source: 'system', outputKind: 'meta' },
+        )
+        if (!failureNotice.ok) {
+          logger.warn(
+            `[channels] ${live.keyId}: poisoned-session recreate-failure notice failed: ${failureNotice.error}`,
+          )
+        }
         return
       }
-      successor.promptQueue.push(...carriedInbounds)
-      successor.contextBuffer.push(...carriedObserved)
-      successor.pendingSystemReminders.push(...carriedReminders)
-      await drain(successor)
+      await replayPendingPoisonTurns(successor)
       return
     }
     // A reload deferred this session's teardown so its in-flight reply could
@@ -4237,6 +4290,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     const live = await ensureLive(key, event.externalMessageId, event.authorId, undefined, event.room)
     live.room = event.room
+    const pendingPoisonReplay = pendingPoisonReplays.get(live.keyId)
+    if (pendingPoisonReplay !== undefined) {
+      pendingPoisonReplays.delete(live.keyId)
+      live.promptQueue.push(...pendingPoisonReplay.inbounds)
+      live.contextBuffer.push(...pendingPoisonReplay.observed)
+      live.pendingSystemReminders.push(...pendingPoisonReplay.reminders)
+      logger.warn(
+        `[channels] ${live.keyId}: poisoned-session replay resumed count=${pendingPoisonReplay.inbounds.length}`,
+      )
+      void drain(live)
+    }
 
     const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
     live.participants = updateParticipants(
@@ -5731,17 +5795,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // assistant message at all) keeps the historical silent bail —
       // re-prompting it would manufacture replies to nothing.
       if (live.currentTurnAuthorId === null || leafStopReason === undefined) {
+        const branchLeaf = live.session.sessionManager.getLeafEntry()
+        const trigger = prompt.batch.at(-1)
         const rapidUnchangedRealUserTurn =
           live.poisonWatchArmed &&
           prompt.batch.length > 0 &&
+          trigger?.authorIsBot === false &&
           prompt.elapsedMs <= POISONED_SESSION_FAST_TURN_MS &&
-          prompt.leafEntryBeforePromptId !== (live.session.sessionManager.getLeafEntry()?.id ?? null) &&
+          branchLeaf?.type === 'message' &&
+          branchLeaf.message.role === 'user' &&
+          prompt.leafEntryBeforePromptId !== branchLeaf.id &&
           prompt.assistantEntryBeforePrompt === latestAssistantEntryId(live.session) &&
+          !isPinnedByRunningChild(live.sessionId, live.keyId, 'poisoned-session-rollover') &&
           live.successfulChannelSends === successfulSendsBeforePrompt
         if (rapidUnchangedRealUserTurn) {
           live.rapidUnchangedEmptyTurns++
-          live.rapidUnchangedEmptyInbounds.push(...prompt.batch)
-          live.rapidUnchangedEmptyObserved.push(...prompt.observed)
+          live.rapidUnchangedEmptyBatches.push({ inbounds: [...prompt.batch], observed: [...prompt.observed] })
           logger.warn(
             `[channels] ${live.keyId}: rapid unchanged empty turn ` +
               `count=${live.rapidUnchangedEmptyTurns}/${POISONED_SESSION_CONSECUTIVE_TURNS} elapsed_ms=${prompt.elapsedMs}`,

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -6276,6 +6276,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // Pointer clearing during poison retirement must reach disk before closing
     // seals persist(). Otherwise shutdown can preserve the poisoned sessionId
     // and rehydrate it on the next boot.
+    const trippedPoisoned = Array.from(liveSessions.values()).filter(
+      (live) => live.poisonedRolloverPending && !live.destroyed,
+    )
+    for (const live of trippedPoisoned) await retireLiveSession(live)
     while (retiring.size > 0) await Promise.all(retiring.values())
     closing = true
     if (gcTimer) clearInterval(gcTimer)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2052,13 +2052,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const existing = retiring.get(live.keyId)
     if (existing !== undefined) return existing
     const retirement = Promise.resolve().then(async () => {
+      let pointerClearError: unknown = null
       try {
         await clearPersistedSessionPointer(live)
       } catch (err) {
         logger.error(`[channels] ${live.keyId}: session pointer clear failed during reset: ${describeError(err)}`)
+        pointerClearError = err
       }
       liveSessions.delete(live.keyId)
       await tearDownLive(live)
+      if (pointerClearError !== null) throw pointerClearError
     })
     retiring.set(live.keyId, retirement)
     try {
@@ -3963,9 +3966,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       )
       const trigger = turns.at(-1)?.inbounds.at(-1)
       pendingPoisonReplays.set(live.keyId, { turns, reminders: carriedReminders })
-      await retireLiveSession(live)
       let successor: LiveSession
       try {
+        await retireLiveSession(live)
         successor = await ensureLive(
           live.key,
           trigger?.externalMessageId,
@@ -6276,11 +6279,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // Pointer clearing during poison retirement must reach disk before closing
     // seals persist(). Otherwise shutdown can preserve the poisoned sessionId
     // and rehydrate it on the next boot.
-    const trippedPoisoned = Array.from(liveSessions.values()).filter(
-      (live) => live.poisonedRolloverPending && !live.destroyed,
-    )
-    for (const live of trippedPoisoned) await retireLiveSession(live)
-    while (retiring.size > 0) await Promise.all(retiring.values())
+    while (true) {
+      const trippedPoisoned = Array.from(liveSessions.values()).filter(
+        (live) => live.poisonedRolloverPending && !live.destroyed,
+      )
+      if (trippedPoisoned.length === 0 && retiring.size === 0) break
+      await Promise.all([...trippedPoisoned.map((live) => retireLiveSession(live)), ...retiring.values()])
+    }
     closing = true
     if (gcTimer) clearInterval(gcTimer)
     gcTimer = null

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1935,11 +1935,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // session before running this handler, so `live` is non-null here.
         const target = live!
         const resetPoisonedSession = target.rapidUnchangedEmptyTurns > 0
-        await stopCurrentChannelTurn(target)
         if (resetPoisonedSession) {
           await retireLiveSession(target)
           return { reply: 'Reset the stuck conversation session.' }
         }
+        await stopCurrentChannelTurn(target)
         return { reply: 'Stopped the current turn.' }
       },
     },
@@ -2051,15 +2051,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const retireLiveSession = async (live: LiveSession): Promise<void> => {
     const existing = retiring.get(live.keyId)
     if (existing !== undefined) return existing
-    const retirement = (async () => {
-      liveSessions.delete(live.keyId)
+    const retirement = Promise.resolve().then(async () => {
       try {
         await clearPersistedSessionPointer(live)
       } catch (err) {
         logger.error(`[channels] ${live.keyId}: session pointer clear failed during reset: ${describeError(err)}`)
       }
+      liveSessions.delete(live.keyId)
       await tearDownLive(live)
-    })()
+    })
     retiring.set(live.keyId, retirement)
     try {
       await retirement
@@ -4043,6 +4043,35 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return running
   }
 
+  // Replay each swallowed real-user turn separately. Collapsing them into one
+  // batch would authorize every earlier speaker as the final speaker, allowing a
+  // low-privilege request to inherit a later owner's tool permissions.
+  const replayPendingPoisonTurns = async (live: LiveSession): Promise<void> => {
+    const active = activePoisonReplays.get(live.keyId)
+    if (active !== undefined) return await active
+    const replay = (async () => {
+      const pending = pendingPoisonReplays.get(live.keyId)
+      if (pending === undefined) return
+      while (pending.turns.length > 0) {
+        const turn = pending.turns[0]!
+        live.contextBuffer.push(...turn.observed)
+        live.promptQueue.push(...turn.inbounds)
+        await drain(live)
+        pending.turns.shift()
+      }
+      live.pendingSystemReminders.push(...pending.reminders)
+      pending.reminders.length = 0
+      pendingPoisonReplays.delete(live.keyId)
+      if (live.pendingSystemReminders.length > 0) await drain(live)
+    })()
+    activePoisonReplays.set(live.keyId, replay)
+    try {
+      await replay
+    } finally {
+      if (activePoisonReplays.get(live.keyId) === replay) activePoisonReplays.delete(live.keyId)
+    }
+  }
+
   // Resolves once no drain is running. Loops because a drain's post-`draining`
   // tail can start a rival, and because work queued during one turn opens the
   // next; a snapshot `Promise.all` would return with that successor in flight.
@@ -4292,14 +4321,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.room = event.room
     const pendingPoisonReplay = pendingPoisonReplays.get(live.keyId)
     if (pendingPoisonReplay !== undefined) {
-      pendingPoisonReplays.delete(live.keyId)
-      live.promptQueue.push(...pendingPoisonReplay.inbounds)
-      live.contextBuffer.push(...pendingPoisonReplay.observed)
-      live.pendingSystemReminders.push(...pendingPoisonReplay.reminders)
-      logger.warn(
-        `[channels] ${live.keyId}: poisoned-session replay resumed count=${pendingPoisonReplay.inbounds.length}`,
-      )
-      void drain(live)
+      const replayCount = pendingPoisonReplay.turns.reduce((count, turn) => count + turn.inbounds.length, 0)
+      logger.warn(`[channels] ${live.keyId}: poisoned-session replay resumed count=${replayCount}`)
+      await replayPendingPoisonTurns(live)
     }
 
     const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
@@ -5798,6 +5822,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const branchLeaf = live.session.sessionManager.getLeafEntry()
         const trigger = prompt.batch.at(-1)
         const rapidUnchangedRealUserTurn =
+          live.key.adapter === 'discord-bot' &&
           live.poisonWatchArmed &&
           prompt.batch.length > 0 &&
           trigger?.authorIsBot === false &&

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -348,9 +348,7 @@ export const MAX_EMPTY_TURN_RETRIES = 2
 export const POISONED_SESSION_CONSECUTIVE_TURNS = 3
 export const POISONED_SESSION_FAST_TURN_MS = 1_000
 export const POISONED_SESSION_RESET_TEXT =
-  '⚠️ This conversation session stopped responding. I’m resetting it and will retry the unanswered messages.'
-const POISONED_SESSION_RECREATE_FAILED_TEXT =
-  '⚠️ The stuck session was reset, but the replacement could not start. Your unanswered messages remain queued and will retry with the next message.'
+  '⚠️ This conversation session stopped responding, so I reset it. Please resend any unanswered request.'
 
 // Separate, tiny budget for the tool-call-leak self-correction retry. Kept
 // apart from MAX_EMPTY_TURN_RETRIES so a persistently-leaking model cannot
@@ -1113,14 +1111,9 @@ type LiveSession = {
   // increments it before injecting EMPTY_TURN_RETRY_NUDGE and reads it to decide
   // retry-vs-fallback. See the candidate===null branch.
   emptyTurnRetries: number
-  // Consecutive 2026-08-28 poison fingerprints. The matching inbounds are
-  // retained so rollover replays the work instead of merely replacing one
-  // silent drop with another. NO_REPLY, skip_response, awaiting-background-child,
-  // slow provider calls, and tool-heavy turns all fail at least one discriminator
-  // and clear this state.
+  // Consecutive 2026-08-28 poison fingerprints. Deliberate silence, slow
+  // providers, and tool-heavy turns all fail at least one discriminator.
   rapidUnchangedEmptyTurns: number
-  rapidUnchangedEmptyBatches: Array<{ inbounds: QueuedInbound[]; observed: ObservedInbound[] }>
-  poisonedRolloverPending: boolean
   // Armed only by the stranded-toolUse-after-send recovery path that preceded
   // the 2026-08-28 collapse. Healthy empty turns outside that fingerprint can
   // never accumulate toward rollover; any later assistant progress disarms it.
@@ -1866,18 +1859,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const newestRunningChildSubagentStartedAt = options.newestRunningChildSubagentStartedAt ?? (() => null)
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
-  // Serializes pointer clearing + teardown against a racing ensureLive. Without
-  // this per-key barrier, an inbound can rehydrate the poisoned sessionId in the
-  // await gap and undo the reset.
-  const retiring = new Map<string, Promise<void>>()
-  const pendingPoisonReplays = new Map<
-    string,
-    {
-      turns: Array<{ inbounds: QueuedInbound[]; observed: ObservedInbound[] }>
-      reminders: PendingSystemReminder[]
-    }
-  >()
-  const activePoisonReplays = new Map<string, Promise<void>>()
   // Restart-resume reservations, keyed by channelKeyId. Installed by
   // reserveRestartHandoff BEFORE channel adapters start receiving, so an
   // inbound that races the boot resume coalesces onto the reservation (via the
@@ -1935,11 +1916,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // session before running this handler, so `live` is non-null here.
         const target = live!
         const resetPoisonedSession = target.rapidUnchangedEmptyTurns > 0
+        await stopCurrentChannelTurn(target)
         if (resetPoisonedSession) {
-          await retireLiveSession(target)
+          await retirePoisonedSession(target)
           return { reply: 'Reset the stuck conversation session.' }
         }
-        await stopCurrentChannelTurn(target)
         return { reply: 'Stopped the current turn.' }
       },
     },
@@ -2026,49 +2007,30 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     await next
   }
 
-  const clearPersistedSessionPointer = async (live: LiveSession): Promise<void> => {
-    if (mappings === null) return
-    const idx = mappings.findIndex(
-      (record) =>
-        record.adapter === live.key.adapter &&
-        record.workspace === live.key.workspace &&
-        record.chat === live.key.chat &&
-        (record.thread ?? null) === (live.key.thread ?? null),
-    )
-    if (idx < 0) return
-    const previous = mappings[idx]!
-    mappings[idx] = {
-      adapter: previous.adapter,
-      workspace: previous.workspace,
-      chat: previous.chat,
-      thread: previous.thread,
-      participants: previous.participants,
-      lastInboundAt: 0,
-    }
-    await persist()
-  }
-
-  const retireLiveSession = async (live: LiveSession): Promise<void> => {
-    const existing = retiring.get(live.keyId)
-    if (existing !== undefined) return existing
-    const retirement = Promise.resolve().then(async () => {
-      let pointerClearError: unknown = null
-      try {
-        await clearPersistedSessionPointer(live)
-      } catch (err) {
-        logger.error(`[channels] ${live.keyId}: session pointer clear failed during reset: ${describeError(err)}`)
-        pointerClearError = err
+  const retirePoisonedSession = async (live: LiveSession): Promise<void> => {
+    if (mappings !== null) {
+      const idx = mappings.findIndex(
+        (record) =>
+          record.adapter === live.key.adapter &&
+          record.workspace === live.key.workspace &&
+          record.chat === live.key.chat &&
+          (record.thread ?? null) === (live.key.thread ?? null),
+      )
+      if (idx >= 0) {
+        const previous = mappings[idx]!
+        mappings[idx] = {
+          adapter: previous.adapter,
+          workspace: previous.workspace,
+          chat: previous.chat,
+          thread: previous.thread,
+          participants: previous.participants,
+          githubReviewRound: previous.githubReviewRound,
+          lastInboundAt: 0,
+        }
       }
-      liveSessions.delete(live.keyId)
-      await tearDownLive(live)
-      if (pointerClearError !== null) throw pointerClearError
-    })
-    retiring.set(live.keyId, retirement)
-    try {
-      await retirement
-    } finally {
-      if (retiring.get(live.keyId) === retirement) retiring.delete(live.keyId)
     }
+    liveSessions.delete(live.keyId)
+    await Promise.all([tearDownLive(live), persist()])
   }
 
   const persistGithubReviewRound = (live: LiveSession, round: GithubReviewFollowupRound | null): void => {
@@ -2306,17 +2268,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // parent-scoped from the first fetch (Discord threads resolve `chat` to the
     // thread id, so an unscoped warm would prime the cache against the thread).
     room?: InboundMessage['room'],
-    // Poison rollover replays all retained messages itself. Prefetch can exclude
-    // only one triggering id and would duplicate every earlier affected inbound.
-    skipColdStartPrefetch = false,
   ): Promise<LiveSession> => {
     const keyId = channelKeyId(key)
-    const retirement = retiring.get(keyId)
-    if (retirement !== undefined) {
-      await retirement
-      return ensureLive(key, triggeringMessageId, triggeringAuthorId, resumeTarget, room, skipColdStartPrefetch)
-    }
-    skipColdStartPrefetch ||= pendingPoisonReplays.has(keyId)
     const existing = liveSessions.get(keyId)
     if (existing && !existing.destroyed) {
       // A resume that finds the key already live is a no-op for reopening: the
@@ -2600,8 +2553,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         policyDeniedToolSendsThisTurn: new Map(),
         emptyTurnRetries: 0,
         rapidUnchangedEmptyTurns: 0,
-        rapidUnchangedEmptyBatches: [],
-        poisonedRolloverPending: false,
         poisonWatchArmed: false,
         toolLeakRetries: 0,
         emptyStopAfterToolWorkArmed: false,
@@ -2696,10 +2647,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // Overlap the disk mapping-write with the network history prefetch —
         // they are independent. allSettled lets a persist failure take priority
         // (and unwind the install) even if prefetch also rejects.
-        const prefetchPromise =
-          adapterConfig && !skipColdStartPrefetch
-            ? prefetchChannelContext(live, adapterConfig, triggeringMessageId)
-            : Promise.resolve()
+        const prefetchPromise = adapterConfig
+          ? prefetchChannelContext(live, adapterConfig, triggeringMessageId)
+          : Promise.resolve()
         const [persistResult, prefetchResult] = await Promise.allSettled([persistPromise, prefetchPromise])
         if (persistResult.status === 'rejected') {
           await unwindInstalledLive(keyId, live)
@@ -2709,7 +2659,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           await unwindInstalledLive(keyId, live)
           throw prefetchResult.reason
         }
-        if (adapterConfig && !skipColdStartPrefetch) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
+        if (adapterConfig) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
       } else {
         // Rehydrate has no prefetch to overlap, so settle the mapping write
         // before installing — a failed persist must fail ensureLive without
@@ -3591,7 +3541,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         (live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) &&
         !live.destroyed &&
         !live.pendingTeardown &&
-        !live.poisonedRolloverPending
+        live.rapidUnchangedEmptyTurns < POISONED_SESSION_CONSECUTIVE_TURNS
       ) {
         live.typingTimedOut = false
         // Each turn starts with no held reactions; the model re-requests them
@@ -3762,7 +3712,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         applyTurnThinkingLevel(live.session, retrievalQuery, live.turnThinkingDefault, live.lastQuestionSignal)
         live.promptInFlight = true
         try {
-          const leafEntryBeforePromptId = live.session.sessionManager.getLeafEntry()?.id ?? null
           const assistantEntryBeforePrompt = latestAssistantEntryId(live.session)
           const result = await promptPersistentTurnWithFallback({
             refs: resolveFallbackChain(getConfig().models, undefined),
@@ -3794,14 +3743,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           const poisonWatchArmedBeforePrompt = live.poisonWatchArmed
           await validateChannelTurn(live, successfulSendsBeforePrompt, {
             batch,
-            observed,
             elapsedMs: now() - promptStart,
-            leafEntryBeforePromptId,
             assistantEntryBeforePrompt,
           })
-          if (!live.poisonedRolloverPending && live.rapidUnchangedEmptyTurns === rapidUnchangedEmptyTurnsBeforePrompt) {
+          if (live.rapidUnchangedEmptyTurns === rapidUnchangedEmptyTurnsBeforePrompt) {
             live.rapidUnchangedEmptyTurns = 0
-            live.rapidUnchangedEmptyBatches = []
             if (
               live.poisonWatchArmed === poisonWatchArmedBeforePrompt &&
               (live.successfulChannelSends > successfulSendsBeforePrompt ||
@@ -3953,50 +3899,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       await stopTypingHeartbeat(live)
       live.currentTurnTypingThread = null
     }
-    if (live.poisonedRolloverPending && !live.destroyed) {
-      const turns = [...live.rapidUnchangedEmptyBatches]
-      const queuedInbounds = live.promptQueue.splice(0, live.promptQueue.length)
-      const queuedObserved = live.contextBuffer.splice(0, live.contextBuffer.length)
-      if (queuedInbounds.length > 0) turns.push({ inbounds: queuedInbounds, observed: queuedObserved })
-      else if (queuedObserved.length > 0 && turns.length > 0) turns.at(-1)!.observed.push(...queuedObserved)
-      const carriedReminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
-      const replayCount = turns.reduce((count, turn) => count + turn.inbounds.length, 0)
-      logger.warn(
-        `[channels] ${live.keyId}: poisoned-session-rollover replaying=${replayCount} session=${live.sessionId}`,
-      )
-      const trigger = turns.at(-1)?.inbounds.at(-1)
-      pendingPoisonReplays.set(live.keyId, { turns, reminders: carriedReminders })
-      let successor: LiveSession
-      try {
-        await retireLiveSession(live)
-        successor = await ensureLive(
-          live.key,
-          trigger?.externalMessageId,
-          trigger?.authorId,
-          undefined,
-          live.room,
-          true,
-        )
-      } catch (err) {
-        logger.error(`[channels] ${live.keyId}: poisoned-session recreate failed: ${describeError(err)}`)
-        const failureNotice = await send(
-          {
-            adapter: live.key.adapter,
-            workspace: live.key.workspace,
-            chat: live.key.chat,
-            thread: live.key.thread,
-            text: POISONED_SESSION_RECREATE_FAILED_TEXT,
-          },
-          { source: 'system', outputKind: 'meta' },
-        )
-        if (!failureNotice.ok) {
-          logger.warn(
-            `[channels] ${live.keyId}: poisoned-session recreate-failure notice failed: ${failureNotice.error}`,
-          )
-        }
-        return
-      }
-      await replayPendingPoisonTurns(successor)
+    if (live.rapidUnchangedEmptyTurns >= POISONED_SESSION_CONSECUTIVE_TURNS && !live.destroyed) {
+      logger.warn(`[channels] ${live.keyId}: poisoned-session-rollover session=${live.sessionId}`)
+      await retirePoisonedSession(live)
       return
     }
     // A reload deferred this session's teardown so its in-flight reply could
@@ -4044,35 +3949,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.activeDrains.add(settled)
     void settled.then(() => live.activeDrains.delete(settled))
     return running
-  }
-
-  // Replay each swallowed real-user turn separately. Collapsing them into one
-  // batch would authorize every earlier speaker as the final speaker, allowing a
-  // low-privilege request to inherit a later owner's tool permissions.
-  const replayPendingPoisonTurns = async (live: LiveSession): Promise<void> => {
-    const active = activePoisonReplays.get(live.keyId)
-    if (active !== undefined) return await active
-    const replay = (async () => {
-      const pending = pendingPoisonReplays.get(live.keyId)
-      if (pending === undefined) return
-      while (pending.turns.length > 0) {
-        const turn = pending.turns[0]!
-        live.contextBuffer.push(...turn.observed)
-        live.promptQueue.push(...turn.inbounds)
-        await drain(live)
-        pending.turns.shift()
-      }
-      live.pendingSystemReminders.push(...pending.reminders)
-      pending.reminders.length = 0
-      pendingPoisonReplays.delete(live.keyId)
-      if (live.pendingSystemReminders.length > 0) await drain(live)
-    })()
-    activePoisonReplays.set(live.keyId, replay)
-    try {
-      await replay
-    } finally {
-      if (activePoisonReplays.get(live.keyId) === replay) activePoisonReplays.delete(live.keyId)
-    }
   }
 
   // Resolves once no drain is running. Loops because a drain's post-`draining`
@@ -4322,12 +4198,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     const live = await ensureLive(key, event.externalMessageId, event.authorId, undefined, event.room)
     live.room = event.room
-    const pendingPoisonReplay = pendingPoisonReplays.get(live.keyId)
-    if (pendingPoisonReplay !== undefined) {
-      const replayCount = pendingPoisonReplay.turns.reduce((count, turn) => count + turn.inbounds.length, 0)
-      logger.warn(`[channels] ${live.keyId}: poisoned-session replay resumed count=${replayCount}`)
-      await replayPendingPoisonTurns(live)
-    }
 
     const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
     live.participants = updateParticipants(
@@ -4357,14 +4227,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
 
     const membership = await membershipForEngagement(live)
-    // A poisoned-session retirement can begin while this route awaits a slow
-    // membership lookup. Never enqueue onto the now-destroyed predecessor: run
-    // the full admission path again so ensureLive waits for the retirement
-    // barrier and targets the successor.
-    if (live.destroyed || liveSessions.get(live.keyId) !== live) {
-      logger.info(`[channels] ${live.keyId}: route retry after live-session replacement`)
-      return await route(event)
-    }
 
     const effectiveHumans = countEffectiveHumans(live.participants, membership, now())
     live.multiHumanGroup = isMultiHumanGroup(event.isDm, effectiveHumans)
@@ -5519,9 +5381,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     successfulSendsBeforePrompt: number,
     prompt: {
       batch: QueuedInbound[]
-      observed: ObservedInbound[]
       elapsedMs: number
-      leafEntryBeforePromptId: string | null
       assistantEntryBeforePrompt: string | null
     },
   ): Promise<void> => {
@@ -5840,13 +5700,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           prompt.elapsedMs <= POISONED_SESSION_FAST_TURN_MS &&
           branchLeaf?.type === 'message' &&
           branchLeaf.message.role === 'user' &&
-          prompt.leafEntryBeforePromptId !== branchLeaf.id &&
           prompt.assistantEntryBeforePrompt === latestAssistantEntryId(live.session) &&
           !isPinnedByRunningChild(live.sessionId, live.keyId, 'poisoned-session-rollover') &&
           live.successfulChannelSends === successfulSendsBeforePrompt
         if (rapidUnchangedRealUserTurn) {
           live.rapidUnchangedEmptyTurns++
-          live.rapidUnchangedEmptyBatches.push({ inbounds: [...prompt.batch], observed: [...prompt.observed] })
           logger.warn(
             `[channels] ${live.keyId}: rapid unchanged empty turn ` +
               `count=${live.rapidUnchangedEmptyTurns}/${POISONED_SESSION_CONSECUTIVE_TURNS} elapsed_ms=${prompt.elapsedMs}`,
@@ -5855,7 +5713,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             // 2026-08-28 Discord fingerprint: after stranded_toolUse_after_send,
             // prompt() returned in 53-56ms for 14 real-user turns, appended no
             // assistant entry, and kept swallowing messages until idle rollover.
-            live.poisonedRolloverPending = true
             live.emptyTurnFallbackTurn = live.turnSeq
             const notice = await send(
               {
@@ -6276,16 +6133,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   gcTimer.unref?.()
 
   const stop = async (): Promise<void> => {
-    // Pointer clearing during poison retirement must reach disk before closing
-    // seals persist(). Otherwise shutdown can preserve the poisoned sessionId
-    // and rehydrate it on the next boot.
-    while (true) {
-      const trippedPoisoned = Array.from(liveSessions.values()).filter(
-        (live) => live.poisonedRolloverPending && !live.destroyed,
-      )
-      if (trippedPoisoned.length === 0 && retiring.size === 0) break
-      await Promise.all([...trippedPoisoned.map((live) => retireLiveSession(live)), ...retiring.values()])
-    }
     closing = true
     if (gcTimer) clearInterval(gcTimer)
     gcTimer = null

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2007,7 +2007,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     await next
   }
 
-  const retirePoisonedSession = async (live: LiveSession): Promise<void> => {
+  const clearPoisonedSessionPointer = async (live: LiveSession): Promise<void> => {
     if (mappings !== null) {
       const idx = mappings.findIndex(
         (record) =>
@@ -2018,6 +2018,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       )
       if (idx >= 0) {
         const previous = mappings[idx]!
+        if (previous.sessionId === undefined && previous.sessionFile === undefined) return
         mappings[idx] = {
           adapter: previous.adapter,
           workspace: previous.workspace,
@@ -2027,10 +2028,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           githubReviewRound: previous.githubReviewRound,
           lastInboundAt: 0,
         }
+        await persist()
       }
     }
+  }
+
+  const retirePoisonedSession = async (live: LiveSession): Promise<void> => {
+    await clearPoisonedSessionPointer(live)
     liveSessions.delete(live.keyId)
-    await Promise.all([tearDownLive(live), persist()])
+    await tearDownLive(live)
   }
 
   const persistGithubReviewRound = (live: LiveSession, round: GithubReviewFollowupRound | null): void => {
@@ -5714,6 +5720,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             // prompt() returned in 53-56ms for 14 real-user turns, appended no
             // assistant entry, and kept swallowing messages until idle rollover.
             live.emptyTurnFallbackTurn = live.turnSeq
+            await clearPoisonedSessionPointer(live)
             const notice = await send(
               {
                 adapter: live.key.adapter,


### PR DESCRIPTION
## Background

A production Discord session got stuck after the `stranded_toolUse_after_send` recovery path fired once: every subsequent `prompt()` call returned in ~50ms with no assistant entry appended to the transcript. The transcript kept growing (the user's own message still landed on the branch), but nothing the model did was ever visible. Fourteen real user messages landed on that dead branch and were silently swallowed with no error and no reply.

Idle GC (`SESSION_IDLE_MS`) is not a recovery path for this shape — a poisoned session keeps refreshing `lastInboundAt` on every message it swallows, so as long as the user keeps trying, the idle window never starts.

Related to #184.

## Summary

Adds a fingerprint-gated rollover: once a session has been armed by the `stranded_toolUse_after_send` path, three consecutive turns matching the exact production fingerprint trigger a reset.

A turn counts toward the threshold only when every one of these holds on that same turn (`rapidUnchangedRealUserTurn` in `validateChannelTurn`):

- `discord-bot` adapter only — the incident's adapter, not every channel type.
- `poisonWatchArmed` — only set by `stranded_toolUse_after_send`; a session that never hit that path can never accumulate rollover state.
- A real inbound triggered the turn, from a human author (not a bot).
- Fast — elapsed time under `POISONED_SESSION_FAST_TURN_MS` (1s). A turn that did real work (slow provider, long tool loop) never counts.
- The branch leaf is a user message, and the nearest assistant entry id is unchanged since before the prompt — comparing leaf ids alone would mistake the branch's own bookkeeping (it still appends the user message) for progress.
- Not pinned by a running background child.
- No successful channel send this turn.

Any turn that clears validation the normal way (real assistant progress, a successful send, `NO_REPLY`, `skip_response`, or an awaited background child) disarms `poisonWatchArmed`, so armed state doesn't outlive the incident it was armed for.

On the third consecutive match, the session posts a visible reset notice (`POISONED_SESSION_RESET_TEXT`) asking the user to resend any unanswered request, then tears down. The persisted session pointer is cleared **before** the notice send and teardown, so a crash mid-reset can't leave the poisoned session id rehydrated on restart; the mapping record's `githubReviewRound` is preserved across that clear. A later inbound on the same key routes to a fresh session the normal way — there is no explicit recreation or replay path.

`/stop` now also recognizes a session with `rapidUnchangedEmptyTurns > 0` as stoppable work (it has no current turn to cancel, but it is stuck), tears it down the same way rollover would, and replies with a distinct message.

## What this does NOT do

- No message replay of anything swallowed during the poisoned window — the reset notice is the recovery signal, not an automatic resend.
- Doesn't change `stranded_toolUse_after_send` recovery itself, only observes its outcome.
- Doesn't touch the `NO_REPLY` / `skip_response` / background-child-await validation paths; all three exit before the poison check runs and never count toward the threshold.
- Doesn't close #184; this narrows a related but distinct failure shape.

## Review notes

The load-bearing invariant is the AND of all the gates above — dropping the arm-gate or the `discord-bot` adapter check turns this from "recover from one specific incident class" into "restart any session that goes quiet three times fast."

Tests in `router.test.ts` cover: the full rollover-to-reset path where a later message is answered on the fresh session, `/stop` on a suspected poisoned session, the pointer-clear-preserves-`githubReviewRound` case during a held notice, and on the negative side, that slow/tool-heavy turns with real assistant progress never roll over and that deliberate `NO_REPLY` / `skip_response` / background-child-wait turns never count even when repeated.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format` — clean
- `bun test --parallel src/channels/` — 3175 pass, 0 fail
- `bun run test` (full suite) — 13337 pass, 31 skip, 0 fail