### PR TITLE
Route Slack user attachment events

### DIFF
--- a/src/channels/adapters/slack-classify.test.ts
+++ b/src/channels/adapters/slack-classify.test.ts
@@ -1,22 +1,36 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { SlackRTMMessageEvent } from 'agent-messenger/slack'
+import type { SlackFile } from 'agent-messenger/slack'
 
 import { channelsSchema } from '@/channels/schema'
 import { isDmChannelOrigin } from '@/permissions'
 
-import { classifyInbound } from './slack-classify'
+import { classifyInbound, type SlackInboundMessageEvent } from './slack-classify'
 
 const config = channelsSchema.parse({ slack: {} }).slack!
 const context = { teamId: 'T0123456789', selfUserId: 'USELF', selfAliases: ['typeclaw'] }
 
-function event(overrides: Partial<SlackRTMMessageEvent> = {}): SlackRTMMessageEvent {
+function event(overrides: Partial<SlackInboundMessageEvent> = {}): SlackInboundMessageEvent {
   return {
     type: 'message',
     channel: 'C0123456789',
     user: 'UUSER',
     text: 'hello',
     ts: '1770000000.000100',
+    ...overrides,
+  }
+}
+
+function file(overrides: Partial<SlackFile> = {}): SlackFile {
+  return {
+    id: 'F0001',
+    name: 'image.png',
+    title: 'image.png',
+    mimetype: 'image/png',
+    size: 1024,
+    url_private: 'https://files.slack.com/files-pri/T1-F0001/image.png',
+    created: 1,
+    user: 'UUSER',
     ...overrides,
   }
 }
@@ -44,6 +58,38 @@ describe('classifyInbound (slack user)', () => {
     expect(verdict.payload.workspace).toBe('@dm')
     expect(verdict.payload.isDm).toBe(true)
     expect(verdict.payload.thread).toBeNull()
+  })
+
+  test('routes captionless subtype-less RTM file messages with addressable attachment descriptors', () => {
+    const verdict = classifyInbound(event({ text: '', files: [file()] }), config, context)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.text).toBe('[Slack attachment #1: file image/png name=image.png]')
+    expect(verdict.payload.attachments).toEqual([
+      { id: 1, kind: 'file', ref: 'F0001', filename: 'image.png', mimetype: 'image/png' },
+    ])
+  })
+
+  test('appends every attachment descriptor after text in upload order', () => {
+    const verdict = classifyInbound(
+      event({
+        text: 'two files',
+        files: [file(), file({ id: 'F0002', name: 'notes.txt', mimetype: 'text/plain' })],
+      }),
+      config,
+      context,
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.text).toBe(
+      'two files\n[Slack attachment #1: file image/png name=image.png]\n[Slack attachment #2: file text/plain name=notes.txt]',
+    )
+    expect(verdict.payload.attachments).toEqual([
+      { id: 1, kind: 'file', ref: 'F0001', filename: 'image.png', mimetype: 'image/png' },
+      { id: 2, kind: 'file', ref: 'F0002', filename: 'notes.txt', mimetype: 'text/plain' },
+    ])
   })
 
   test('fails closed to the team workspace for a G-prefixed conversation without metadata', () => {

--- a/src/channels/adapters/slack-classify.ts
+++ b/src/channels/adapters/slack-classify.ts
@@ -9,6 +9,8 @@ import { encodeSlackReactionRef } from './slack-reactions'
 
 export type SlackInboundMessageEvent = SlackRTMMessageEvent & {
   channel_type?: string
+  // Modern RTM file messages are subtype-less but retain the `files` array.
+  files?: SlackFile[]
   is_mpim?: boolean
 }
 
@@ -35,10 +37,11 @@ export function classifyInbound(
   if (context.selfUserId !== null && event.user === context.selfUserId) return { kind: 'drop', reason: 'self_author' }
   if (event.user === undefined || event.user === '') return { kind: 'drop', reason: 'no_user' }
   if (!isRouteableSlackMessageSubtype(event.subtype)) return { kind: 'drop', reason: 'slack_system_message' }
-  if ((event.text ?? '') === '') return { kind: 'drop', reason: 'empty_text' }
+  const rawText = event.text ?? ''
+  const { text, attachments } = splitSlackFiles(rawText, event.files)
+  if (text === '') return { kind: 'drop', reason: 'empty_text' }
   if (context.selfUserId === null) return { kind: 'drop', reason: 'pre_connect' }
 
-  const rawText = event.text ?? ''
   const conversationType = classifyConversation(event, context.conversationType)
   const isDm = conversationType === 'im'
   const workspace = isDm ? '@dm' : context.teamId
@@ -57,7 +60,8 @@ export function classifyInbound(
       chat: event.channel,
       thread,
       ...(thread !== null ? { room: { kind: 'thread' as const } } : {}),
-      text: rawText,
+      text,
+      ...(attachments.length > 0 ? { attachments } : {}),
       externalMessageId: event.ts,
       reactionRef: encodeSlackReactionRef({ channel: event.channel, ts: event.ts }),
       authorId: event.user,
@@ -91,12 +95,11 @@ export function isRouteableSlackMessageSubtype(subtype: string | undefined): boo
   return subtype === undefined || subtype === 'me_message'
 }
 
-// The REST history fetch bypasses the inbound classifier, so files on
-// already-posted messages must be described here too. Registering the ref
+// Live inbound and REST history share the same attachment rendering contract.
+// Registering the ref
 // without also baking a `#N` placeholder into the text is not enough: the
 // agent has no way to learn the id exists, so look_at_channel_attachment stays
-// unreachable in practice. Kept in the classifier module so the live inbound
-// path can adopt the same rendering.
+// unreachable in practice.
 export function splitSlackFiles(text: string, files: readonly SlackFile[] | undefined): SplitSlackFiles {
   const attachments = (files ?? []).map(describeSlackFile)
   if (attachments.length === 0) return { text, attachments: [] }

--- a/src/channels/adapters/slack.test.ts
+++ b/src/channels/adapters/slack.test.ts
@@ -9,6 +9,7 @@ import type { InboundMessage, OutboundCallback } from '@/channels/types'
 import type { SlackAccountRecord } from '@/secrets/schema'
 
 import { createSlackAdapter, createSlackHistoryCallback, type SlackAdapterLogger } from './slack'
+import type { SlackInboundMessageEvent } from './slack-classify'
 
 const config = channelsSchema.parse({ slack: {} }).slack!
 
@@ -217,6 +218,53 @@ describe('createSlackAdapter', () => {
     expect(listener.stopped).toBe(true)
     expect(r.unregistered).toContain('outbound:slack')
     expect(r.unregistered).toContain('remove-reaction:slack')
+  })
+
+  test('subtype-less RTM file messages reach the router with the same attachment descriptors as history', async () => {
+    for (const [text, expectedText] of [
+      ['', '[Slack attachment #1: file application/pdf name=report.pdf]'],
+      ['please review', 'please review\n[Slack attachment #1: file application/pdf name=report.pdf]'],
+    ] as const) {
+      const r = router()
+      const listener = new FakeListener()
+      const adapter = createSlackAdapter({
+        router: r,
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () => fakeClient(),
+        createListener: () => listener as unknown as SlackListener,
+      })
+
+      await adapter.start()
+      listener.emit('message', {
+        type: 'message',
+        channel: 'C0123456789',
+        user: 'UUSER',
+        text,
+        ts: '1770000000.000100',
+        files: [
+          {
+            id: 'F0001',
+            name: 'report.pdf',
+            title: 'report.pdf',
+            mimetype: 'application/pdf',
+            size: 1024,
+            url_private: 'https://files.slack.com/files-pri/T1-F0001/report.pdf',
+            created: 1,
+            user: 'UUSER',
+          },
+        ],
+      } satisfies SlackInboundMessageEvent)
+      await adapter.stop()
+
+      expect(r.routed).toHaveLength(1)
+      expect(r.routed[0]?.text).toBe(expectedText)
+      expect(r.routed[0]?.externalMessageId).toBe('1770000000.000100')
+      expect(r.routed[0]?.attachments).toEqual([
+        { id: 1, kind: 'file', ref: 'F0001', filename: 'report.pdf', mimetype: 'application/pdf' },
+      ])
+    }
   })
 
   test('G-prefixed conversations use Slack metadata to distinguish MPIMs from private channels', async () => {


### PR DESCRIPTION
## Background

Slack's user-token live inbound path drops file attachments. `classifyInbound` in `slack-classify.ts` treated `event.text` as the whole message: a captionless file share arrives with empty text and hit `if ((event.text ?? '') === '') return { kind: 'drop', reason: 'empty_text' }` before files were ever inspected, and a captioned file share routed with only the caption — the files were ignored entirely.

Meanwhile `channel_history` already numbered Slack files correctly, because the REST history mapper reuses `splitSlackFiles` (added in #1397) to bake `[Slack attachment #N: ...]` placeholders into the text and register a matching ref. Live inbound never adopted that helper, so a Slack image posted live was invisible to the agent even though the identical image showed up correctly once re-fetched via history.

Slack retired the `file_share` message subtype on RTM in 2018 (https://docs.slack.dev/changelog/2018-05-file-threads-soon-tread/). A file upload today arrives over RTM as an ordinary subtype-less `message` event that carries a `files` array. This PR does not add any `file_share` handling — it teaches the classifier to read `files` off the subtype-less event it already receives.

## Summary

`classifyInbound` now calls the same `splitSlackFiles` helper history already uses, so live and history rendering share one contract instead of two independently-maintained ones:

- `event.files` is added to `SlackInboundMessageEvent` so the RTM/user-token event shape carries what `splitSlackFiles` needs, documented as arriving on modern subtype-less RTM messages rather than a `file_share` subtype.
- The classifier runs `splitSlackFiles(rawText, event.files)` before the empty-text drop check, so a captionless file share produces a non-empty placeholder text and passes through instead of being dropped as `empty_text`.
- The resulting `attachments` array is spread onto the routed payload only when non-empty, matching the existing optional-field pattern on that payload.

The classifier module comment is trimmed to reflect that both call sites (live inbound and REST history) now share the rendering, rather than describing history as the only consumer.

## What this does NOT do

- Does not change `channel_history`'s attachment rendering — it already used `splitSlackFiles`; this PR only brings live inbound to parity.
- Does not touch the Discord, Webex, KakaoTalk, or `slack-bot` adapters. `slack-bot`'s Events API transport is a separate integration that legitimately still receives a `file_share` subtype; this PR does not change its allowlist.
- Does not add new attachment kinds or metadata beyond what `splitSlackFiles` already describes (`describeSlackFile`).
- Does not change how `look_at_channel_attachment` resolves refs.

## Review notes

The load-bearing change is moving the `splitSlackFiles` call ahead of the empty-text drop check, so a captionless upload's synthesized placeholder text survives instead of being dropped as `empty_text`.

An earlier version of this PR also added `file_share` to `isRouteableSlackMessageSubtype`'s allowlist, on the assumption RTM still sends that subtype for uploads. It does not — Slack discontinued `file_share` on RTM in 2018, and a modern RTM file upload is a subtype-less `message` event. That allowlist change is reverted; `isRouteableSlackMessageSubtype` is unchanged by this PR.

`src/channels/adapters/slack.test.ts` adds a listener-to-router coverage test that drives a real subtype-less RTM `message` event carrying `files` through `createSlackAdapter` end to end and asserts on `router.routed[0]`, for both a captionless and a captioned file upload. This is the seam that was previously untested: `slack-classify.test.ts` covered the classifier in isolation, but nothing exercised the adapter's listener wiring against a live router, which is where the `files` field and the pre-drop-check ordering actually matter.

Closes #1398

## Verification

- `bun run lint` — 0 errors (70 pre-existing warnings, all in unrelated files)
- `bun run format:check` — clean
- `bun run typecheck` — clean
- `bun run test` — 13,335 pass / 31 skip / 0 fail
