### PR TITLE
Stop stranding completed terminal replies

### DIFF
--- a/src/agent/todo/continuation-policy.test.ts
+++ b/src/agent/todo/continuation-policy.test.ts
@@ -188,6 +188,20 @@ describe('decideContinuation', () => {
     expect(d.kind).toBe('inject')
   })
 
+  test('trusts terminal channel-reply provenance independently of the transport stop reason', () => {
+    const d = decide(
+      baseState({
+        lastTurnOutcome: {
+          turnId: 't',
+          stopReason: 'unknown',
+          termination: 'terminal-after-channel-reply',
+          endedAt: 1,
+        },
+      }),
+    )
+    expect(d.kind).toBe('inject')
+  })
+
   test('injects after a length truncation (budget exhaustion is continuation-eligible)', () => {
     const d = decide(baseState({ lastTurnOutcome: { turnId: 't', stopReason: 'length', endedAt: 1 } }))
     expect(d.kind).toBe('inject')

--- a/src/agent/todo/continuation-policy.ts
+++ b/src/agent/todo/continuation-policy.ts
@@ -213,12 +213,11 @@ export function decideContinuation(args: {
   if (state.autoResumeBlockedUntilRealUserTurn) return { kind: 'skip', reason: 'user-abort-blocked' }
 
   const outcome = state.lastTurnOutcome
-  const isSafeTerminalReplyAbort =
-    outcome?.stopReason === 'aborted' && outcome.termination === 'terminal-after-channel-reply'
+  const isSafeTerminalReply = outcome?.termination === 'terminal-after-channel-reply'
   if (
     outcome === null ||
-    outcome.stopReason === 'unknown' ||
-    (outcome.stopReason === 'aborted' && !isSafeTerminalReplyAbort)
+    (outcome.stopReason === 'unknown' && !isSafeTerminalReply) ||
+    (outcome.stopReason === 'aborted' && !isSafeTerminalReply)
   ) {
     return { kind: 'skip', reason: 'turn-not-safe' }
   }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7506,6 +7506,34 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('empty_turn_retry attempt=1'))).toBe(true)
   })
 
+  // Regression for the 2026-08-28 Discord fingerprint. A terminal
+  // channel_reply deliberately ends on its matching toolResult with no
+  // follow-up assistant message. That is a completed turn, not the
+  // `more_work_this_turn: true` stranded-work shape above.
+  test('terminal channel_reply does not enter stranded-toolUse recovery after its result is persisted', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'is it done?' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Done.' })
+      const terminal = await sessions[0]!.agent.afterToolCall!(terminalReplyContext('Done.'))
+      expect(terminal).toMatchObject({ terminate: true })
+      strandOnUnansweredToolUse(sessions[0]!, 'terminal-reply')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toEqual(['Done.'])
+    expect(logs.some((message) => message.includes('cause=stranded_toolUse_after_send'))).toBe(false)
+  })
+
   test('continue-reply guard: logs policy-denied abort provenance when retrying stranded toolUse', async () => {
     const dir = await tempDir()
     const logs: string[] = []
@@ -7526,6 +7554,7 @@ describe('ChannelRouter channel-turn protocol', () => {
           await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'checking now' })
         }
         strandOnUnansweredToolUse(sessions[0]!, 'policy-denied')
+        sessions[0]!.emit({ type: 'message_end', message: { ...assistantMessage(''), stopReason: 'aborted' } })
         return
       }
       expect(text).toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
@@ -14416,16 +14445,18 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     return sessions[0]!.agent
   }
 
-  test('aborts the run after a successful channel_reply so no post-tool follow-up LLM call runs', async () => {
+  test('terminates the tool batch after a successful channel_reply without aborting result persistence', async () => {
     // given a live channel session with the terminal hook installed
     const agent = await liveAgentAfterRoute(await tempDir())
     expect(agent.afterToolCall).toBeDefined()
 
     // when channel_reply succeeds (details.ok === true, not an error)
-    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
+    const result = await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
 
-    // then the run's abort signal is fired — the follow-up stream sees it aborted
-    expect(agent.signal.aborted).toBe(true)
+    // then pi-agent-core persists the matching toolResult before honoring the
+    // terminate flag, and no aborted run can leave the branch looking stranded.
+    expect(result).toMatchObject({ terminate: true })
+    expect(agent.signal.aborted).toBe(false)
   })
 
   test('does NOT abort when channel_reply opts out with more_work_this_turn: true', async () => {
@@ -14442,9 +14473,10 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     await router.__testing!.flushDebounce(KEY)
     const agent = sessions[0]!.agent
 
-    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
+    const result = await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
 
-    expect(agent.signal.aborted).toBe(true)
+    expect(result).toMatchObject({ terminate: true })
+    expect(agent.signal.aborted).toBe(false)
     const abortLog = logs.find((m) => m.includes('site=terminal_after_channel_reply'))
     expect(abortLog).toBeDefined()
     expect(abortLog).toContain('session=ses_fake_1')
@@ -14553,8 +14585,11 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
 
   test('stashes the reply text on a terminal channel_reply so the willingness nudge can read it', async () => {
     const agent = await liveAgentAfterRoute(await tempDir())
-    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false, '바로 계속 확인하겠습니다'))
-    expect(agent.signal.aborted).toBe(true)
+    const result = await agent.afterToolCall!(
+      afterToolContext('channel_reply', { ok: true }, false, '바로 계속 확인하겠습니다'),
+    )
+    expect(result).toMatchObject({ terminate: true })
+    expect(agent.signal.aborted).toBe(false)
   })
 
   test('does NOT stash when more_work_this_turn:true (the turn stays alive, no nudge needed)', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3,8 +3,21 @@ import { mkdir, mkdtemp, rm, writeFile as writeFileFs } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 
-import type { AfterToolCallContext, AfterToolCallResult, StreamFn } from '@mariozechner/pi-agent-core'
-import type { AssistantMessage } from '@mariozechner/pi-ai'
+import {
+  Agent,
+  type AgentMessage,
+  type AfterToolCallContext,
+  type AfterToolCallResult,
+  type StreamFn,
+} from '@mariozechner/pi-agent-core'
+import {
+  fauxAssistantMessage,
+  fauxText,
+  fauxToolCall,
+  registerFauxProvider,
+  Type,
+  type AssistantMessage,
+} from '@mariozechner/pi-ai'
 import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 
 import type { AgentSession, SessionOriginRef } from '@/agent'
@@ -166,6 +179,30 @@ class FakeSession {
   public sessionManager = {
     getLeafEntry: (): SessionEntry | undefined => this.leafEntry,
     getEntry: (id: string): SessionEntry | undefined => this.entriesById.get(id),
+    getBranch: (): SessionEntry[] => {
+      const reversed: SessionEntry[] = []
+      let cursor = this.leafEntry
+      while (cursor) {
+        reversed.push(cursor)
+        cursor = cursor.parentId ? this.entriesById.get(cursor.parentId) : undefined
+      }
+      return reversed.reverse()
+    },
+    appendMessage: (message: AgentMessage): string => {
+      const parentId = this.leafEntry?.id ?? null
+      if (this.leafEntry) this.entriesById.set(this.leafEntry.id, this.leafEntry)
+      const id = `appended-${this.entriesById.size + 1}`
+      const entry: SessionEntry = {
+        type: 'message',
+        id,
+        parentId,
+        timestamp: '2026-08-28T10:20:18.000Z',
+        message,
+      }
+      this.entriesById.set(id, entry)
+      this.leafEntry = entry
+      return id
+    },
   }
 
   private subscribers = new Set<(event: Record<string, unknown> & { type: string }) => void>()
@@ -234,6 +271,42 @@ async function streamOnce(session: FakeSession): Promise<void> {
   )
 }
 
+function connectCoreAgent(session: FakeSession, coreAgent: Agent): void {
+  const fallbackController = new AbortController()
+  let eventPersistence = Promise.resolve()
+  coreAgent.subscribe((event) => {
+    if (event.type !== 'message_end') return
+    eventPersistence = eventPersistence.then(async () => {
+      if (event.message.role === 'toolResult') await new Promise((resolve) => setTimeout(resolve, 5))
+      session.sessionManager.appendMessage(event.message)
+      session.emit(event)
+    })
+  })
+  session.agent = {
+    controller: fallbackController,
+    get signal(): AbortSignal {
+      return coreAgent.signal ?? fallbackController.signal
+    },
+    get state(): { messages: Array<{ role: string; stopReason?: string }> } {
+      return coreAgent.state
+    },
+    continue: async () => await coreAgent.continue(),
+    abort: () => coreAgent.abort(),
+    get afterToolCall() {
+      return coreAgent.afterToolCall
+    },
+    set afterToolCall(hook) {
+      coreAgent.afterToolCall = hook
+    },
+    get streamFn() {
+      return coreAgent.streamFn
+    },
+    set streamFn(fn) {
+      coreAgent.streamFn = fn
+    },
+  }
+}
+
 function assistantMessage(text: string): AssistantMessage {
   return {
     role: 'assistant',
@@ -296,6 +369,23 @@ function strandOnUnansweredToolUse(session: FakeSession, id: string = 'strand'):
   session.leafEntry = toolResultEntry
 }
 
+function strandOnMissingToolResult(session: FakeSession, id: string = 'missing-result'): void {
+  const assistantEntry: SessionEntry = {
+    type: 'message',
+    id: `assistant-${id}`,
+    parentId: null,
+    timestamp: '2026-08-28T10:20:18.000Z',
+    message: {
+      ...assistantMessage(''),
+      content: [{ type: 'toolCall', id: `tool-${id}`, name: 'channel_reply', arguments: { text: 'Done.' } }],
+      stopReason: 'toolUse',
+    },
+  }
+  session.entriesById.set(assistantEntry.id, assistantEntry)
+  session.leafEntry = assistantEntry
+  session.agent.state.messages = [assistantEntry.message]
+}
+
 // A bare-empty `stop` leaf whose parentId chain runs back through a web_search
 // tool call to a bounding user entry — the production shape recoverableAssistantText
 // recovers as { text: '', source: 'leaf' } while attemptMadeToolCall still finds
@@ -351,14 +441,19 @@ function emptyStopAfterToolWork(session: FakeSession, id: string = 'tw', userId:
 }
 
 function terminalReplyContext(replyText: string): AfterToolCallContext {
+  const toolCall = {
+    type: 'toolCall' as const,
+    id: 'tc-terminal-reply',
+    name: 'channel_reply',
+    arguments: { text: replyText },
+  }
   return {
-    assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
-    toolCall: {
-      type: 'toolCall',
-      id: 'tc-terminal-reply',
-      name: 'channel_reply',
-      arguments: { text: replyText },
-    } as AfterToolCallContext['toolCall'],
+    assistantMessage: {
+      ...assistantMessage(''),
+      content: [toolCall],
+      stopReason: 'toolUse',
+    } as AfterToolCallContext['assistantMessage'],
+    toolCall: toolCall as AfterToolCallContext['toolCall'],
     args: { text: replyText },
     result: {
       content: [{ type: 'text' as const, text: 'ignored' }],
@@ -7524,13 +7619,66 @@ describe('ChannelRouter channel-turn protocol', () => {
     sessions[0]!.onPrompt = async () => {
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Done.' })
       const terminal = await sessions[0]!.agent.afterToolCall!(terminalReplyContext('Done.'))
-      expect(terminal).toMatchObject({ terminate: true })
+      expect(terminal).toBeUndefined()
       strandOnUnansweredToolUse(sessions[0]!, 'terminal-reply')
+      await streamOnce(sessions[0]!)
     }
     await router.__testing!.flushDebounce(KEY)
 
     expect(sessions[0]!.prompts).toHaveLength(1)
     expect(sent).toEqual(['Done.'])
+    expect(logs.some((message) => message.includes('cause=stranded_toolUse_after_send'))).toBe(false)
+  })
+
+  test('repairs an already-poisoned unmatched toolUse before later user messages run', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      onSessionCreated: (session) => strandOnMissingToolResult(session, 'persisted-terminal-reply'),
+    })
+    router.registerOutbound('discord-bot', async (message) => {
+      sent.push(message.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'are you still there?' }))
+    sessions[0]!.onPrompt = async () => {
+      const leaf = sessions[0]!.sessionManager.getLeafEntry()
+      if (leaf?.type !== 'message' || leaf.message.role !== 'toolResult') return
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Yes — continuing normally.' })
+      sessions[0]!.setAssistantText('Yes — continuing normally.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toEqual(['Yes — continuing normally.'])
+    expect(logs.some((message) => message.includes('branch_repair=missing_tool_result'))).toBe(true)
+
+    await router.route(inbound({ text: 'and this one?', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).toEqual(['Yes — continuing normally.', 'Yes — continuing normally.'])
+  })
+
+  test('textless terminal channel_reply still records completion and avoids stranded recovery', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: 'send the file' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1' })
+      const context = terminalReplyContext('unused')
+      context.toolCall.arguments = {}
+      await sessions[0]!.agent.afterToolCall!(context)
+      strandOnUnansweredToolUse(sessions[0]!, 'terminal-attachment')
+      await streamOnce(sessions[0]!)
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
     expect(logs.some((message) => message.includes('cause=stranded_toolUse_after_send'))).toBe(false)
   })
 
@@ -8450,8 +8598,6 @@ describe('ChannelRouter commands', () => {
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Stopping as requested.' })
       await sessions[0]!.agent.afterToolCall!(terminalReplyContext('Stopping as requested.'))
       await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
-      sessions[0]!.setAssistantMidTurn('Stopping as requested.', 'aborted')
-      sessions[0]!.emit({ type: 'message_end', message: { ...assistantMessage(''), stopReason: 'aborted' } })
     }
     await router.__testing!.flushDebounce(KEY)
 
@@ -8497,7 +8643,7 @@ describe('ChannelRouter commands', () => {
     sessions[0]!.onPrompt = async () => {
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Stopping as requested.' })
       await sessions[0]!.agent.afterToolCall!(terminalReplyContext('Stopping as requested.'))
-      sessions[0]!.setAssistantMidTurn('Stopping as requested.', 'aborted')
+      await streamOnce(sessions[0]!)
       sessions[0]!.emit({ type: 'message_end', message: { ...assistantMessage(''), stopReason: 'aborted' } })
       await waitFor(() => terminalWriteStarted)
       const stopping = router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
@@ -14428,9 +14574,14 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
       details: result,
     }
     const args = replyText !== undefined ? { text: replyText } : {}
+    const toolCall = { type: 'toolCall' as const, id: 'tc1', name: toolName, arguments: args }
     return {
-      assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
-      toolCall: { type: 'toolCall', id: 'tc1', name: toolName, arguments: args } as AfterToolCallContext['toolCall'],
+      assistantMessage: {
+        ...assistantMessage(''),
+        content: [toolCall],
+        stopReason: 'toolUse',
+      } as AfterToolCallContext['assistantMessage'],
+      toolCall: toolCall as AfterToolCallContext['toolCall'],
       args,
       result: toolResult as AfterToolCallContext['result'],
       isError,
@@ -14438,31 +14589,209 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     }
   }
 
-  async function liveAgentAfterRoute(dir: string): Promise<FakeSession['agent']> {
+  async function liveSessionAfterRoute(dir: string): Promise<FakeSession> {
     const { router, sessions } = makeRouter(dir)
     await router.route(inbound())
     await router.__testing!.flushDebounce(KEY)
-    return sessions[0]!.agent
+    return sessions[0]!
   }
 
-  test('terminates the tool batch after a successful channel_reply without aborting result persistence', async () => {
+  async function liveAgentAfterRoute(dir: string): Promise<FakeSession['agent']> {
+    return (await liveSessionAfterRoute(dir)).agent
+  }
+
+  test('suppresses the provider at the post-tool stream boundary', async () => {
     // given a live channel session with the terminal hook installed
-    const agent = await liveAgentAfterRoute(await tempDir())
+    const session = await liveSessionAfterRoute(await tempDir())
+    const agent = session.agent
     expect(agent.afterToolCall).toBeDefined()
 
     // when channel_reply succeeds (details.ok === true, not an error)
     const result = await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
 
-    // then pi-agent-core persists the matching toolResult before honoring the
-    // terminate flag, and no aborted run can leave the branch looking stranded.
-    expect(result).toMatchObject({ terminate: true })
+    // The hook itself does not abort before pi-agent-core emits the result.
+    expect(result).toBeUndefined()
     expect(agent.signal.aborted).toBe(false)
+
+    await streamOnce(session)
+
+    expect(agent.signal.aborted).toBe(false)
+    expect(session.lastStreamMaxTokens).toBeUndefined()
+  })
+
+  test('preserves a prior afterToolCall result when adding terminal completion', async () => {
+    const { router, sessions } = makeRouter(await tempDir(), {
+      onSessionCreated: (session) => {
+        session.agent.afterToolCall = async () => ({
+          content: [{ type: 'text', text: 'prior content' }],
+          details: { prior: true },
+          isError: false,
+        })
+      },
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const result = await sessions[0]!.agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
+
+    expect(result).toMatchObject({
+      content: [{ type: 'text', text: 'prior content' }],
+      details: { prior: true },
+      isError: false,
+    })
+  })
+
+  test('preserves assistant token usage in the explicit terminal outcome', async () => {
+    const writes: Array<{ termination?: string; tokens?: number }> = []
+    const { router, sessions } = makeRouter(await tempDir(), {
+      recordTurnOutcome: async (args) => {
+        writes.push({
+          ...(args.termination !== undefined ? { termination: args.termination } : {}),
+          ...(args.tokens !== undefined ? { tokens: args.tokens } : {}),
+        })
+      },
+    })
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+    const context = afterToolContext('channel_reply', { ok: true }, false)
+    context.assistantMessage = {
+      ...context.assistantMessage,
+      usage: { ...context.assistantMessage.usage, totalTokens: 73 },
+    }
+
+    await sessions[0]!.agent.afterToolCall!(context)
+    await streamOnce(sessions[0]!)
+    sessions[0]!.emit({ type: 'message_end', message: { ...assistantMessage(''), stopReason: 'aborted' } })
+    await waitFor(() => writes.some((write) => write.termination === 'terminal-after-channel-reply'))
+
+    expect(writes.filter((write) => write.termination === 'terminal-after-channel-reply')).toEqual([
+      { termination: 'terminal-after-channel-reply', tokens: 73 },
+    ])
+  })
+
+  test('the pinned parallel agent loop finalizes a mixed batch and makes exactly one provider call', async () => {
+    const registration = registerFauxProvider({
+      provider: 'router-terminal-reply-test',
+      api: 'router-terminal-reply-test',
+      tokenSize: { min: 1, max: 1 },
+    })
+    try {
+      const model = registration.getModel()
+      const executed: string[] = []
+      const tool = (name: string, delayMs: number) => ({
+        name,
+        label: name,
+        description: name,
+        parameters: Type.Object({ text: Type.String() }),
+        execute: async (_toolCallId: string, params: unknown) => {
+          await new Promise((resolve) => setTimeout(resolve, delayMs))
+          executed.push(name)
+          const text =
+            typeof params === 'object' && params !== null && 'text' in params && typeof params.text === 'string'
+              ? params.text
+              : ''
+          return {
+            content: [{ type: 'text' as const, text: `${name}:${text}` }],
+            details: { ok: true },
+          }
+        },
+      })
+      registration.setResponses([
+        fauxAssistantMessage(
+          [
+            fauxToolCall('channel_reply', { text: 'Done.' }, { id: 'reply-call' }),
+            fauxToolCall('sibling', { text: 'Result.' }, { id: 'sibling-call' }),
+          ],
+          { stopReason: 'toolUse' },
+        ),
+        fauxAssistantMessage(fauxText('duplicate follow-up')),
+      ])
+      const coreAgent = new Agent({
+        initialState: {
+          model,
+          tools: [tool('channel_reply', 20), tool('sibling', 1)],
+        },
+        toolExecution: 'parallel',
+      })
+      let sessionRef: FakeSession | undefined
+      let persistedResultsAtOutcome = 0
+      const { router } = makeRouter(await tempDir(), {
+        recordTurnOutcome: async (args) => {
+          if (args.termination !== 'terminal-after-channel-reply') return
+          persistedResultsAtOutcome =
+            sessionRef?.sessionManager
+              .getBranch()
+              .filter((entry) => entry.type === 'message' && entry.message.role === 'toolResult').length ?? 0
+        },
+        onSessionCreated: (session) => {
+          sessionRef = session
+          connectCoreAgent(session, coreAgent)
+        },
+      })
+      await router.route(inbound())
+      await router.__testing!.flushDebounce(KEY)
+
+      await coreAgent.prompt('run both tools')
+      await waitFor(() => persistedResultsAtOutcome > 0)
+
+      expect(executed).toEqual(['sibling', 'channel_reply'])
+      expect(
+        coreAgent.state.messages
+          .filter((message) => message.role === 'toolResult')
+          .map((message) => message.toolCallId),
+      ).toEqual(['reply-call', 'sibling-call'])
+      expect(persistedResultsAtOutcome).toBe(2)
+      expect(
+        sessionRef?.sessionManager
+          .getBranch()
+          .filter((entry) => entry.type === 'message' && entry.message.role === 'toolResult')
+          .map((entry) =>
+            entry.type === 'message' && entry.message.role === 'toolResult' ? entry.message.toolCallId : '',
+          ),
+      ).toEqual(['reply-call', 'sibling-call'])
+      expect(registration.state.callCount).toBe(1)
+    } finally {
+      registration.unregister()
+    }
+  })
+
+  test('keeps a mixed batch alive when its sole channel_reply fails', async () => {
+    const session = await liveSessionAfterRoute(await tempDir())
+    const agent = session.agent
+    const replyCall = {
+      type: 'toolCall' as const,
+      id: 'reply-call',
+      name: 'channel_reply',
+      arguments: { text: 'Done.' },
+    }
+    const readCall = { type: 'toolCall' as const, id: 'read-call', name: 'read', arguments: { path: 'README.md' } }
+    const assistant = {
+      ...assistantMessage(''),
+      content: [replyCall, readCall],
+      stopReason: 'toolUse' as const,
+    }
+
+    const replyResult = await agent.afterToolCall!({
+      ...afterToolContext('channel_reply', { ok: false }, false, 'Done.'),
+      assistantMessage: assistant,
+      toolCall: replyCall,
+    } as AfterToolCallContext)
+
+    expect(replyResult).toBeUndefined()
+    await streamOnce(session)
+    expect(agent.signal.aborted).toBe(false)
+    expect(session.lastStreamMaxTokens).toBeDefined()
   })
 
   test('does NOT abort when channel_reply opts out with more_work_this_turn: true', async () => {
-    const agent = await liveAgentAfterRoute(await tempDir())
-    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true, more_work_this_turn: true }, false))
-    expect(agent.signal.aborted).toBe(false)
+    const session = await liveSessionAfterRoute(await tempDir())
+    const result = await session.agent.afterToolCall!(
+      afterToolContext('channel_reply', { ok: true, more_work_this_turn: true }, false),
+    )
+    expect(result).toBeUndefined()
+    await streamOnce(session)
+    expect(session.agent.signal.aborted).toBe(false)
+    expect(session.lastStreamMaxTokens).toBeDefined()
   })
 
   test('logs a diagnostic line identifying the session, reason, and site when channel_reply ends the turn', async () => {
@@ -14475,7 +14804,7 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
 
     const result = await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false))
 
-    expect(result).toMatchObject({ terminate: true })
+    expect(result).toBeUndefined()
     expect(agent.signal.aborted).toBe(false)
     const abortLog = logs.find((m) => m.includes('site=terminal_after_channel_reply'))
     expect(abortLog).toBeDefined()
@@ -14497,13 +14826,15 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
 
   test('does NOT abort after a read-only tool so genuine multi-step turns continue', async () => {
     const agent = await liveAgentAfterRoute(await tempDir())
-    await agent.afterToolCall!(afterToolContext('read', { ok: true }, false))
+    const result = await agent.afterToolCall!(afterToolContext('read', { ok: true }, false))
+    expect(result?.terminate).not.toBe(true)
     expect(agent.signal.aborted).toBe(false)
   })
 
   test('does NOT abort after a successful channel_send (only channel_reply is terminal)', async () => {
     const agent = await liveAgentAfterRoute(await tempDir())
-    await agent.afterToolCall!(afterToolContext('channel_send', { ok: true }, false))
+    const result = await agent.afterToolCall!(afterToolContext('channel_send', { ok: true }, false))
+    expect(result?.terminate).not.toBe(true)
     expect(agent.signal.aborted).toBe(false)
   })
 
@@ -14588,7 +14919,7 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     const result = await agent.afterToolCall!(
       afterToolContext('channel_reply', { ok: true }, false, '바로 계속 확인하겠습니다'),
     )
-    expect(result).toMatchObject({ terminate: true })
+    expect(result).toBeUndefined()
     expect(agent.signal.aborted).toBe(false)
   })
 
@@ -14619,15 +14950,21 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     sessions[0]!.onPrompt = async (text) => {
       attempt++
       if (attempt === 1) {
+        // Match pi 0.73.1 ordering: the assistant toolUse message ends before
+        // channel_reply executes; the matching toolResult persists before the
+        // deferred abort prevents a later provider call.
+        sessions[0]!.setAssistantMidTurn('')
+        sessions[0]!.emit({
+          type: 'message_end',
+          message: { ...assistantMessage(''), stopReason: 'toolUse' },
+        })
         await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'First step is done.' })
         await sessions[0]!.agent.afterToolCall!(
           afterToolContext('channel_reply', { ok: true }, false, 'First step is done.'),
         )
-        sessions[0]!.setAssistantMidTurn('First step is done.', 'aborted')
-        sessions[0]!.emit({
-          type: 'message_end',
-          message: { ...assistantMessage(''), stopReason: 'aborted' },
-        })
+        strandOnUnansweredToolUse(sessions[0]!, 'terminal-todo')
+        await streamOnce(sessions[0]!)
+        sessions[0]!.emit({ type: 'message_end', message: { ...assistantMessage(''), stopReason: 'aborted' } })
         return
       }
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1,7 +1,7 @@
 import { statSync } from 'node:fs'
 import { basename } from 'node:path'
 
-import type { AssistantMessage } from '@mariozechner/pi-ai'
+import { createAssistantMessageEventStream, type AssistantMessage, type ToolResultMessage } from '@mariozechner/pi-ai'
 import { type SessionEntry, SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSession } from '@/agent'
@@ -1116,13 +1116,20 @@ type LiveSession = {
   // user batch starts (batch.length > 0), NOT on the reminder-only iteration the
   // nudge itself queues — same anti-reloop discipline as the empty-turn budget.
   willingnessNudges: number
-  // Stashed by `installChannelReplyTerminalHook` just before it aborts the turn
-  // after a successful `channel_reply` that omitted `more_work_this_turn: true`. Read once
+  // Stashed by `installChannelReplyTerminalHook` after a successful
+  // `channel_reply` that omitted `more_work_this_turn: true`. Read once
   // by `validateChannelTurn` to decide the continuation nudge. `turnSeq`-stamped
   // (like `skippedTurn`/`skipLockedSendTurn`) so a stale record from an earlier
   // turn can never trigger a nudge on a later one. `null` when no such reply
   // ended this turn.
-  lastTerminalReplyAbort: { turnSeq: number; text: string } | null
+  lastTerminalReplyCompletion: { turnSeq: number; text?: string; tokens: number } | null
+  // Armed after a successful terminal reply. pi-agent-core invokes streamFn
+  // again only after emitting every matching toolResult into its event queue;
+  // the wrapper consumes this marker at that awaited provider boundary and
+  // returns a local aborted response instead of calling the provider. Event
+  // queue ordering then persists every toolResult before the synthetic aborted
+  // assistant. Cleared on consumption, stop, or a fresh user turn.
+  pendingTerminalReplyStop: { turnSeq: number; tokens: number } | null
   // Stamped by `installChannelReplyTerminalHook` when a successful `channel_reply`
   // set `more_work_this_turn: true` — the machine-readable "I'll keep working this turn"
   // promise. `validateChannelTurn` reads it to recover a turn that made that promise,
@@ -2503,7 +2510,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         toolLeakRetries: 0,
         emptyStopAfterToolWorkArmed: false,
         willingnessNudges: 0,
-        lastTerminalReplyAbort: null,
+        lastTerminalReplyCompletion: null,
+        pendingTerminalReplyStop: null,
         continueReplyTurn: null,
         abortReasonThisTurn: null,
         userStoppedTurnSeq: null,
@@ -2551,7 +2559,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         if (usage === null) return
         const stampedAbort = live.abortReasonThisTurn
         const termination: 'terminal-after-channel-reply' | undefined =
-          (usage.stopReason === 'aborted' || usage.stopReason === 'unknown') &&
+          usage.stopReason === 'aborted' &&
           live.userStoppedTurnSeq !== live.turnSeq &&
           stampedAbort?.turnSeq === live.turnSeq &&
           stampedAbort.reason === 'terminal_after_channel_reply'
@@ -2563,6 +2571,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // the exact internal reason. A fresh user batch clears the stamp, and
         // every reader also requires a matching turnSeq, so retaining it cannot
         // attribute a later turn to this abort.
+        // AgentSession processes message events through one serial queue. By
+        // the time this synthetic aborted message_end reaches the subscriber,
+        // every preceding toolResult event has completed extension handling
+        // and SessionManager persistence. Preserve the original assistant
+        // usage rather than recording this local stream's zero-token envelope.
+        const terminalCompletion = live.lastTerminalReplyCompletion
+        if (termination !== undefined && terminalCompletion?.turnSeq === live.turnSeq) {
+          enqueueTodoOutcomeWrite(live, {
+            agentDir: options.agentDir,
+            origin: buildLiveOrigin(live),
+            turnId: live.sessionId,
+            stopReason: usage.stopReason,
+            termination,
+            tokens: terminalCompletion.tokens,
+          })
+          return
+        }
         const outcomeArgs = {
           agentDir: options.agentDir,
           origin: buildLiveOrigin(live),
@@ -2889,18 +2914,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // multi-step chains can continue. On a terminal reply there is nothing left
   // to say, and Fireworks' kimi-k2p6-turbo can degenerate that empty follow-up
   // into a 32000-token repetition loop (see CHANNEL_MAX_OUTPUT_TOKENS).
-  // `ToolResult.terminate` is the SDK's clean stop boundary: pi-agent-core emits
-  // and persists the matching toolResult, then exits without another provider
-  // call. Do not abort here. In the 2026-08-28 Discord incident, the abort path
-  // could finish without a persisted aborted assistant leaf, so validation saw
-  // the preceding tool result as `stranded_toolUse_after_send` and opened a
-  // recovery turn after an already-complete reply.
+  // Suppress the provider only at its next stream boundary. agent-core reaches
+  // that boundary after emitting every toolResult for the batch, and
+  // AgentSession preserves the event order even when extensions delay
+  // persistence. In the 2026-08-28 Discord incident, aborting from afterToolCall
+  // left validation looking at the preceding result as
+  // `stranded_toolUse_after_send` and opened a recovery turn after an
+  // already-complete reply.
   //
   // Scope is deliberately narrow: only `channel_reply` (the current-chat user-
   // facing response), only on success, and only for channel sessions. Read-only
   // tools and `channel_send` must keep the follow-up so genuine multi-step turns
-  // continue. A prior non-typeclaw `afterToolCall` (none today) is composed, and
-  // its result fields are preserved when the terminal flag is added.
+  // continue. A prior non-typeclaw `afterToolCall` (none today) is composed.
   //
   // `channel_reply({ more_work_this_turn: true })` is the explicit opt-out: a
   // mid-turn status reply ("working on it…") that the model follows with more
@@ -2941,12 +2966,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           `[channels] ${live.keyId} terminal_after_channel_reply site=terminal_after_channel_reply session=${live.sessionId} reason=terminal_after_channel_reply`,
         )
         const replyText = (context.toolCall.arguments as { text?: unknown } | undefined)?.text
-        live.lastTerminalReplyAbort = typeof replyText === 'string' ? { turnSeq: live.turnSeq, text: replyText } : null
-        // This stamp now records semantic termination rather than an actual
-        // signal abort. Outcome persistence still needs the same provenance so
-        // completed terminal replies may authorize bounded todo continuation.
-        live.abortReasonThisTurn = { turnSeq: live.turnSeq, reason: 'terminal_after_channel_reply' }
-        return { ...result, terminate: true }
+        live.lastTerminalReplyCompletion = {
+          turnSeq: live.turnSeq,
+          ...(typeof replyText === 'string' ? { text: replyText } : {}),
+          tokens: context.assistantMessage.usage.totalTokens,
+        }
+        live.pendingTerminalReplyStop = {
+          turnSeq: live.turnSeq,
+          tokens: context.assistantMessage.usage.totalTokens,
+        }
       }
       return result
     }
@@ -2963,13 +2991,48 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const installChannelOutputCap = (live: LiveSession): void => {
     const { agent } = live.session
     const inner = agent.streamFn
-    agent.streamFn = (model, context, options) => {
-      let maxTokens = options?.maxTokens
+    agent.streamFn = async (model, context, streamOptions) => {
+      const pendingTerminalStop = live.pendingTerminalReplyStop
+      if (pendingTerminalStop?.turnSeq === live.turnSeq && live.userStoppedTurnSeq !== pendingTerminalStop.turnSeq) {
+        live.pendingTerminalReplyStop = null
+        live.abortReasonThisTurn = {
+          turnSeq: pendingTerminalStop.turnSeq,
+          reason: 'terminal_after_channel_reply',
+        }
+        // This boundary runs only after agent-core has emitted all toolResults
+        // for the batch. Return a local aborted assistant event instead of
+        // entering the provider. Its later message_end is queued behind those
+        // result events; that persistence-ordered subscriber records the
+        // trusted outcome and original token usage.
+        const message: AssistantMessage = {
+          role: 'assistant',
+          content: [],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: 'aborted',
+          errorMessage: 'terminal channel reply completed',
+          timestamp: Date.now(),
+        }
+        const stream = createAssistantMessageEventStream()
+        stream.push({ type: 'start', partial: message })
+        stream.push({ type: 'error', reason: 'aborted', error: message })
+        return stream
+      }
+      let maxTokens = streamOptions?.maxTokens
       if (maxTokens === undefined && live.nextPromptMaxTokens !== undefined) {
         maxTokens = live.nextPromptMaxTokens
         live.nextPromptMaxTokens = undefined
       }
-      return inner(model, context, { ...options, maxTokens: maxTokens ?? CHANNEL_MAX_OUTPUT_TOKENS })
+      return await inner(model, context, { ...streamOptions, maxTokens: maxTokens ?? CHANNEL_MAX_OUTPUT_TOKENS })
     }
   }
 
@@ -3326,7 +3389,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const stopCurrentChannelTurn = async (live: LiveSession): Promise<void> => {
     live.userStoppedTurnSeq = live.turnSeq
-    live.lastTerminalReplyAbort = null
+    live.lastTerminalReplyCompletion = null
+    live.pendingTerminalReplyStop = null
     live.abortReasonThisTurn = { turnSeq: live.turnSeq, reason: 'user_stop' }
     if (live.debounceTimer) clearTimeout(live.debounceTimer)
     live.debounceTimer = null
@@ -3578,6 +3642,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             live.stagedFallbackCause = null
           }
           live.abortReasonThisTurn = null
+          live.pendingTerminalReplyStop = null
           live.userStoppedTurnSeq = null
           live.nextPromptMaxTokens = undefined
           // Cleared with the retry budgets (NOT beside resetReviewTurn below) so a
@@ -3626,6 +3691,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           systemReminders: reminders.map((r) => r.text),
           role: liveRole,
         })
+
+        const repairedToolCalls = repairDanglingToolUseBranch(live.session, now())
+        if (repairedToolCalls.length > 0) {
+          logger.warn(
+            `[channels] ${live.keyId} branch_repair=missing_tool_result session=${live.sessionId} ` +
+              `count=${repairedToolCalls.length} tools=${repairedToolCalls.join(',')}`,
+          )
+        }
 
         // Bracketing logs around the LLM call so a hung prompt() is
         // diagnosable from logs alone (we see prompting without prompted).
@@ -5245,18 +5318,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
-  // The turn ended via the terminal-reply abort. If that reply promised to keep
+  // The turn ended via terminal channel_reply completion. If that reply promised to keep
   // working but omitted `more_work_this_turn: true`, queue ONE reminder-only re-prompt so
-  // the model gets a second chance to actually do it. The abort already fired
-  // (safe default preserved); this only adds an optional nudge. Bounded by
+  // the model gets a second chance to actually do it. The tool batch already
+  // terminated (safe default preserved); this only adds an optional nudge. Bounded by
   // MAX_WILLINGNESS_NUDGES and gated on `promptQueue` being empty so a real
   // inbound that coalesced into this turn is never answered with a stale nudge.
   const maybeNudgeContinuationWillingness = (live: LiveSession): void => {
-    const record = live.lastTerminalReplyAbort
-    live.lastTerminalReplyAbort = null
+    const record = live.lastTerminalReplyCompletion
+    live.lastTerminalReplyCompletion = null
     if (record === null || record.turnSeq !== live.turnSeq) return
     if (live.willingnessNudges >= MAX_WILLINGNESS_NUDGES) return
     if (live.promptQueue.length > 0) return
+    if (record.text === undefined) return
     if (!detectContinuationWillingness(record.text)) return
     live.willingnessNudges++
     logger.info(
@@ -5414,7 +5488,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // the send is narration the model emitted with/before the reply that already
     // landed — suppress it, as before.
     if (live.successfulChannelSends > successfulSendsBeforePrompt) {
-      const terminalReplyCompletedThisTurn = live.lastTerminalReplyAbort?.turnSeq === live.turnSeq
+      const terminalReplyCompletedThisTurn = live.lastTerminalReplyCompletion?.turnSeq === live.turnSeq
       maybeNudgeContinuationWillingness(live)
 
       // A `channel_reply({ more_work_this_turn: true })` progress ack landed this turn (the
@@ -5462,7 +5536,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // then an EMPTY `stop` leaf: the model computed the answer in its reasoning
       // / tool results but never sent it (the Kimi/Fireworks empty-completion
       // flake). `maybeNudgeContinuationWillingness` above can't catch this — it
-      // reads `lastTerminalReplyAbort`, which only a `channel_reply` sets;
+      // reads `lastTerminalReplyCompletion`, which only a `channel_reply` sets;
       // `channel_send` keeps the turn alive and stamps nothing. And the
       // stranded-toolUse retry below requires `source !== 'leaf'`, but an empty
       // `stop` leaf recovers as `source: 'leaf'`, so this shape would otherwise
@@ -7942,6 +8016,57 @@ function leafIsStrandedToolUse(session: AgentSession): boolean {
     cursor = parent
   }
   return false
+}
+
+// Permanently close a trailing tool batch whose assistant toolUse has one or
+// more missing results. PR #1386 could recognize this shape and re-prompt, but
+// the 2026-08-28 Discord fingerprint showed the poisoned branch rejecting each
+// retry in ~53ms before provider generation: 15 user entries accumulated with
+// no assistant entry until idle rollover. Append-only error results preserve
+// the full conversation and any completed sibling results while making both
+// the live Agent state and persisted SessionManager branch valid again.
+function repairDanglingToolUseBranch(session: AgentSession, timestamp: number): string[] {
+  const branch = session.sessionManager.getBranch?.()
+  if (!branch) return []
+  const messages = branch.filter(
+    (entry): entry is Extract<SessionEntry, { type: 'message' }> => entry.type === 'message',
+  )
+  if (messages.length === 0) return []
+
+  const completed = new Set<string>()
+  let index = messages.length - 1
+  while (index >= 0) {
+    const message = messages[index]!.message
+    if (message.role !== 'toolResult') break
+    completed.add(message.toolCallId)
+    index--
+  }
+
+  const assistantEntry = messages[index]
+  if (!assistantEntry || assistantEntry.message.role !== 'assistant') return []
+  if (assistantEntry.message.stopReason !== 'toolUse') return []
+  const missing = assistantEntry.message.content.filter(
+    (block): block is Extract<(typeof assistantEntry.message.content)[number], { type: 'toolCall' }> =>
+      block.type === 'toolCall' && !completed.has(block.id),
+  )
+  if (missing.length === 0) return []
+
+  const repairedMessages: ToolResultMessage[] = missing.map((toolCall) => ({
+    role: 'toolResult',
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    content: [
+      {
+        type: 'text',
+        text: 'Tool execution was interrupted before its result was recorded. Continue from the preserved conversation without assuming the tool succeeded.',
+      },
+    ],
+    isError: true,
+    timestamp,
+  }))
+  for (const message of repairedMessages) session.sessionManager.appendMessage(message)
+  session.agent.state.messages = [...session.agent.state.messages, ...repairedMessages]
+  return missing.map((toolCall) => toolCall.name)
 }
 
 // The turn-end leaf is a FRESH empty `stop` — an assistant message with no visible

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2551,13 +2551,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         if (usage === null) return
         const stampedAbort = live.abortReasonThisTurn
         const termination: 'terminal-after-channel-reply' | undefined =
-          usage.stopReason === 'aborted' &&
+          (usage.stopReason === 'aborted' || usage.stopReason === 'unknown') &&
           live.userStoppedTurnSeq !== live.turnSeq &&
           stampedAbort?.turnSeq === live.turnSeq &&
           stampedAbort.reason === 'terminal_after_channel_reply'
             ? 'terminal-after-channel-reply'
             : undefined
-        if (stampedAbort?.turnSeq === live.turnSeq) live.abortReasonThisTurn = null
+        // Keep the same-turn stamp through validateChannelTurn. Clearing it on
+        // the aborted assistant event made the later stranded-toolUse retry log
+        // `abort_reason=unknown`, even though this subscriber had just consumed
+        // the exact internal reason. A fresh user batch clears the stamp, and
+        // every reader also requires a matching turnSeq, so retaining it cannot
+        // attribute a later turn to this abort.
         const outcomeArgs = {
           agentDir: options.agentDir,
           origin: buildLiveOrigin(live),
@@ -2879,23 +2884,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   // After a successful `channel_reply`, the model has delivered its user-facing
-  // response and the turn is semantically done. pi-agent-core's loop, however,
-  // unconditionally makes one more LLM call after any tool result (the
-  // "post-tool follow-up") to let multi-step tool chains continue. On a turn
-  // that ended with `channel_reply` there is nothing left to say, and Fireworks'
-  // kimi-k2p6-turbo degenerates that empty follow-up into a 32000-token
-  // repetition loop (see CHANNEL_MAX_OUTPUT_TOKENS). Aborting the run's signal
-  // from `afterToolCall` — which runs during tool execution, before the loop
-  // re-enters the LLM stream — makes the follow-up stream observe an already-
-  // aborted signal and return `stopReason: 'aborted'` without generating. This
-  // is the same `agent.abort()` lever the policy-denied-send cap uses; the
-  // tool's own result is already persisted, so the reply still lands.
+  // response and the turn is semantically done. pi-agent-core otherwise makes
+  // one more LLM call after the tool result (the "post-tool follow-up") so real
+  // multi-step chains can continue. On a terminal reply there is nothing left
+  // to say, and Fireworks' kimi-k2p6-turbo can degenerate that empty follow-up
+  // into a 32000-token repetition loop (see CHANNEL_MAX_OUTPUT_TOKENS).
+  // `ToolResult.terminate` is the SDK's clean stop boundary: pi-agent-core emits
+  // and persists the matching toolResult, then exits without another provider
+  // call. Do not abort here. In the 2026-08-28 Discord incident, the abort path
+  // could finish without a persisted aborted assistant leaf, so validation saw
+  // the preceding tool result as `stranded_toolUse_after_send` and opened a
+  // recovery turn after an already-complete reply.
   //
   // Scope is deliberately narrow: only `channel_reply` (the current-chat user-
   // facing response), only on success, and only for channel sessions. Read-only
   // tools and `channel_send` must keep the follow-up so genuine multi-step turns
-  // continue. A prior non-typeclaw `afterToolCall` (none today) would be
-  // composed, not clobbered.
+  // continue. A prior non-typeclaw `afterToolCall` (none today) is composed, and
+  // its result fields are preserved when the terminal flag is added.
   //
   // `channel_reply({ more_work_this_turn: true })` is the explicit opt-out: a
   // mid-turn status reply ("working on it…") that the model follows with more
@@ -2931,14 +2936,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.continueReplyTurn = { turnSeq: live.turnSeq, sendCount: live.successfulChannelSends }
         }
       }
-      if (succeeded && !keepTurnAlive && agent.signal?.aborted !== true && live.userStoppedTurnSeq !== live.turnSeq) {
+      if (succeeded && !keepTurnAlive && live.userStoppedTurnSeq !== live.turnSeq) {
         logger.info(
           `[channels] ${live.keyId} terminal_after_channel_reply site=terminal_after_channel_reply session=${live.sessionId} reason=terminal_after_channel_reply`,
         )
         const replyText = (context.toolCall.arguments as { text?: unknown } | undefined)?.text
         live.lastTerminalReplyAbort = typeof replyText === 'string' ? { turnSeq: live.turnSeq, text: replyText } : null
+        // This stamp now records semantic termination rather than an actual
+        // signal abort. Outcome persistence still needs the same provenance so
+        // completed terminal replies may authorize bounded todo continuation.
         live.abortReasonThisTurn = { turnSeq: live.turnSeq, reason: 'terminal_after_channel_reply' }
-        agent.abort()
+        return { ...result, terminate: true }
       }
       return result
     }
@@ -5406,6 +5414,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // the send is narration the model emitted with/before the reply that already
     // landed — suppress it, as before.
     if (live.successfulChannelSends > successfulSendsBeforePrompt) {
+      const terminalReplyCompletedThisTurn = live.lastTerminalReplyAbort?.turnSeq === live.turnSeq
       maybeNudgeContinuationWillingness(live)
 
       // A `channel_reply({ more_work_this_turn: true })` progress ack landed this turn (the
@@ -5484,6 +5493,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         }
         return
       }
+
+      // A terminal channel_reply now ends the SDK tool batch with
+      // ToolResult.terminate after its matching result is persisted. The leaf
+      // therefore has the same toolResult-under-toolUse shape as genuinely
+      // stranded post-status work, but this turn already delivered its final
+      // answer and explicitly terminated. The 2026-08-28 Discord incident
+      // crossed this distinction: validation re-prompted the completed turn as
+      // `stranded_toolUse_after_send`, then subsequent inbounds accumulated on
+      // the failed recovery branch. Keep willingness nudges queued above, but do
+      // not send terminal completion through stranded-work recovery.
+      if (terminalReplyCompletedThisTurn) return
 
       const trailing = recoverableAssistantText(live.session)
       if (trailing === null || trailing.source !== 'leaf') {


### PR DESCRIPTION
## Summary

This fixes both creation and recovery of the terminal-reply branch corruption behind the 2026-08-28 channel incident.

### Prevent new corruption

A successful terminal `channel_reply` no longer calls `agent.abort()` from `afterToolCall`, where a result or mixed-batch sibling may still be finalizing. The hook now arms same-turn state. At the next `streamFn` boundary — after pinned `pi-agent-core@0.73.1` has finalized and emitted every result in the batch — the router returns a local aborted stream instead of making a second provider call. Its synthetic aborted `message_end` is processed behind the result events in AgentSession’s serial queue; only then, after durable `SessionManager` appends, does the subscriber record the trusted terminal outcome with the original token count.

This preserves the original `terminal_after_channel_reply` behavior: the delivered reply remains terminal, so no duplicate follow-up reply or Kimi repetition call is reintroduced.

### Repair sessions already poisoned in the wild

Before each channel prompt, the router checks the trailing tool batch for calls with no matching result. It appends synthetic error `toolResult`s to both the persisted `SessionManager` branch and the live Agent state. Completed sibling results and all prior conversation context remain intact; there is no rollover, truncation, or context discard.

This turns #1386's symptom recovery into an actual branch repair for the proven unmatched-`toolUse` shape.

### Preserve abort provenance

`abortReasonThisTurn` is retained through turn validation and remains `turnSeq`-gated, then clears on the next real user turn. The policy-denial regression now proves an aborted `message_end` cannot erase the reason before the stranded-turn log reads it. `abort_reason=unknown` remains valid only when no internal abort site fired.

Terminal completion is recorded only at the post-persistence stream boundary. Todo continuation trusts the runtime-owned `terminal-after-channel-reply` provenance independently of the transport stop reason.

## Q1: red-test verification

The committed history cannot prove that the original test was authored before its production change.

Empirically, the pre-existing regression is red with the `router.ts` production change stashed: it expected one prompt and received three. However, inspection found that it modeled a `toolUse` **with a matching `toolResult`**, not the proven unmatched shape, so it was insufficient.

A new exact regression constructs a branch ending in `toolUse` with **no matching `toolResult`**. It was added before the repair. With `router.ts` stashed, it fails for the right reason (`expected 1 prompt, received 3`); after restoring production, it passes and a second later user message is answered normally.

## Review coverage

- A real pinned-SDK integration test runs a parallel batch containing successful `channel_reply` plus a sibling tool. Both execute and finalize, results remain in assistant source order, and provider call count is exactly **1**.
- Failed `channel_reply`, `more_work_this_turn: true`, read-only tools, and `channel_send` keep their normal follow-up provider path.
- Existing regression coverage for `NO_REPLY`, `skip_response`, `isAwaitingBackgroundChild`, healthy long/tool-heavy turns, `/stop` races, and token/todo accounting remains green.
- No watcher, fingerprint poller, health detector, rollover, reload, handoff, cron, engagement, or adapter-backfill machinery is added.

## Root-cause status and scope

- **New corruption:** fixed here.
- **Already-poisoned branch repair:** fixed here without discarding context.
- **`abort_reason=unknown` diagnostic gap:** fixed here.
- **Deferred root causes:** none; no follow-up issue was needed.

References #184 without closing it. Draft PR #1413 remains a separate symptom-level proposal; this PR neither depends on nor reintroduces its watcher machinery, and does not close it.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run format` / `bun run format:check`
- `bun test --parallel src/channels/ src/agent/` — 5,439 pass, 27 skip, 0 fail
- `bun run test` — 13,342 pass, 31 skip, 0 fail
- LSP diagnostics clean on all changed files