### PR TITLE
fix(cron): re-arm long timer delays

### DIFF
--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -199,6 +199,34 @@ describe('createScheduler', () => {
     scheduler.stop()
   })
 
+  test('does not fire a long-delay job when Node clamps an oversized timer', async () => {
+    const clock = createFakeClock()
+    const nodeMaxTimeoutMs = 2 ** 31 - 1
+    const nodeLikeClock: SchedulerClock & Pick<typeof clock, 'advance'> = {
+      ...clock,
+      setTimeout: (cb, ms) => clock.setTimeout(cb, ms > nodeMaxTimeoutMs ? 1 : ms),
+    }
+    const recorder = createFireRecorder()
+    const dueAt = new Date('2026-02-01T00:00:00Z').toISOString()
+    const scheduler = createScheduler({
+      jobs: [{ id: 'long-delay', at: dueAt, kind: 'prompt', prompt: 'run', enabled: true }],
+      onFire: recorder.onFire,
+      clock: nodeLikeClock,
+      logger: silentLogger,
+    })
+
+    scheduler.start()
+    await nodeLikeClock.advance(nodeMaxTimeoutMs)
+
+    expect(recorder.fires).toHaveLength(0)
+
+    await nodeLikeClock.advance(new Date(dueAt).getTime() - nodeLikeClock.now())
+
+    expect(recorder.firesByJob.get('long-delay')).toHaveLength(1)
+
+    scheduler.stop()
+  })
+
   test('stop() prevents future fires', async () => {
     const clock = createFakeClock()
     const recorder = createFireRecorder()

--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -7,7 +7,9 @@ const silentLogger: SchedulerLogger = { info: () => {}, warn: () => {}, error: (
 
 function createFakeClock(start = new Date('2026-01-01T00:00:00Z').getTime()): SchedulerClock & {
   advance: (ms: number) => Promise<void>
+  fireNext: () => void
   handleCount: () => number
+  setNow: (next: number) => void
 } {
   let now = start
   const timers: Array<{ fireAt: number; cb: () => void; cancelled: boolean }> = []
@@ -39,7 +41,16 @@ function createFakeClock(start = new Date('2026-01-01T00:00:00Z').getTime()): Sc
       }
       now = target
     },
+    fireNext: () => {
+      const next = timers.filter((t) => !t.cancelled).sort((a, b) => a.fireAt - b.fireAt)[0]
+      if (!next) throw new Error('no timer to fire')
+      next.cancelled = true
+      next.cb()
+    },
     handleCount: () => Array.from(handles.values()).filter((t) => !t.cancelled).length,
+    setNow: (next) => {
+      now = next
+    },
   }
 }
 
@@ -223,6 +234,31 @@ describe('createScheduler', () => {
     await nodeLikeClock.advance(new Date(dueAt).getTime() - nodeLikeClock.now())
 
     expect(recorder.firesByJob.get('long-delay')).toHaveLength(1)
+
+    scheduler.stop()
+  })
+
+  test('retains a long-delay occurrence across a backward clock adjustment', async () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const nodeMaxTimeoutMs = 2 ** 31 - 1
+    const scheduler = createScheduler({
+      jobs: [promptJob('monthly', '0 0 1 * *')],
+      onFire: recorder.onFire,
+      clock,
+      logger: silentLogger,
+    })
+
+    scheduler.start()
+    clock.setNow(new Date('2025-12-15T00:00:00Z').getTime())
+    clock.fireNext()
+    await clock.advance(nodeMaxTimeoutMs)
+
+    expect(recorder.fires).toHaveLength(0)
+
+    await clock.advance(new Date('2026-02-01T00:00:00Z').getTime() - clock.now())
+
+    expect(recorder.firesByJob.get('monthly')).toHaveLength(1)
 
     scheduler.stop()
   })

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -99,17 +99,21 @@ export function createScheduler({
       return
     }
 
+    arm(id, result.nextFire)
+  }
+
+  function arm(id: string, nextFire: number): void {
     cancel(id)
 
-    const delay = Math.max(0, result.nextFire - clock.now())
+    const delay = Math.max(0, nextFire - clock.now())
     const handle = clock.setTimeout(
       () => {
         handles.delete(id)
         if (!started) return
         const live = currentEnabled(id)
         if (!live) return
-        if (clock.now() < result.nextFire) {
-          scheduleNext(id)
+        if (clock.now() < nextFire) {
+          arm(id, nextFire)
           return
         }
         fire(live)

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -58,6 +58,10 @@ const consoleLogger: SchedulerLogger = {
   error: (m) => console.error(m),
 }
 
+// Node clamps delays greater than this to 1ms. Re-arm long waits instead of
+// allowing an early callback to dispatch a future occurrence.
+const maxTimeoutMs = 2 ** 31 - 1
+
 export function createScheduler({
   jobs,
   onFire,
@@ -98,14 +102,21 @@ export function createScheduler({
     cancel(id)
 
     const delay = Math.max(0, result.nextFire - clock.now())
-    const handle = clock.setTimeout(() => {
-      handles.delete(id)
-      if (!started) return
-      const live = currentEnabled(id)
-      if (!live) return
-      fire(live)
-      scheduleNext(id)
-    }, delay)
+    const handle = clock.setTimeout(
+      () => {
+        handles.delete(id)
+        if (!started) return
+        const live = currentEnabled(id)
+        if (!live) return
+        if (clock.now() < result.nextFire) {
+          scheduleNext(id)
+          return
+        }
+        fire(live)
+        scheduleNext(id)
+      },
+      Math.min(delay, maxTimeoutMs),
+    )
     handles.set(id, handle)
   }
 


### PR DESCRIPTION
## Background

A cron occurrence more than Node's signed 32-bit timer limit in the future was passed directly to `setTimeout`. Node clamps such delays to 1 ms, so the scheduler could dispatch the occurrence immediately and repeatedly instead of waiting for its scheduled instant.

## Summary

- Cap every timer arm at Node's maximum supported delay.
- Capture the occurrence timestamp once, then re-arm directly toward that same timestamp until it is due.
- Only compute a new cron occurrence after dispatch or when an explicit job replacement has cancelled and re-scheduled its arm.
- Add deterministic regressions for both Node's overflow clamp and a backward wall-clock adjustment during an intermediate arm.

### Why this resolves the failure

The failure requires a delay above Node's timer limit. Each arm is now bounded, so Node never substitutes a 1 ms timer. At each intermediate wake-up the scheduler compares the clock with the captured occurrence: if it is still early, it re-arms toward the same timestamp and does not call `onFire`; when it is due, it dispatches once and computes the next occurrence normally.

Retaining the captured timestamp is necessary. Re-parsing a cron expression during an intermediate arm could select an earlier occurrence after a backward wall-clock adjustment, violating the original schedule. The fix therefore treats a selected occurrence as immutable until it dispatches, is cancelled by `replaceJobs`, or the scheduler stops.

### Conditions considered

- **Node overflow:** each requested timer delay is at most `2 ** 31 - 1` ms.
- **Early intermediate wake-up:** it only re-arms; it never dispatches early.
- **Backward clock adjustment:** it retains the originally selected occurrence rather than parsing an earlier cron boundary.
- **Normal scheduled firing:** at or after the captured timestamp it preserves the existing fire-then-schedule-next flow.
- **Stop, disable, and replacement:** the existing handle cancellation and enabled-job checks remain authoritative; replacement cancels the old arm and computes a new occurrence from the replacement job.
- **Cron semantics:** cron expression, timezone, missed-tick, overlap, count, and `until` behavior are unchanged.

This is intentionally a bounded timer-chain rather than a background worker, persistence layer, or cron-parser change: the defect is specifically the unsupported single timer duration, and chaining preserves the scheduler's current in-process ownership and existing cancellation/reload semantics with the smallest behavior change.

## What this does NOT do

- Does not diagnose or alter downstream cron consumer/channel dispatch behavior.
- Does not change cron expression, timezone, missed-tick, overlap, count, or `until` semantics.
- Does not add persistence or a background worker for long delays.

## Review notes

The load-bearing invariant is that `onFire` must not run before the immutable occurrence selected for its current arm. Every arm is at most `2 ** 31 - 1` ms; an intermediate arm only re-arms toward that same occurrence. The regressions model Node's 1 ms overflow clamp and a clock moving backward across a monthly cron boundary.

## Verification

- `bun test --parallel src/cron/scheduler.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`