### PR TITLE
Log cron run lifecycle

### DIFF
--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -8,7 +8,7 @@ import type { HookBus } from '@/plugin'
 import { createStream } from '@/stream'
 
 import { createCronConsumer, type CronConsumerLogger, type CronSession } from './consumer'
-import type { CronJob, ExecJob, PromptJob } from './schema'
+import type { CronJob, ExecJob, HandlerJob, PromptJob } from './schema'
 
 async function waitForFile(path: string): Promise<string> {
   for (let i = 0; i < 200; i++) {
@@ -98,6 +98,14 @@ const execJob = (id: string, command: string[]): ExecJob => ({
   command,
 })
 
+const handlerJob = (id: string): HandlerJob => ({
+  id,
+  schedule: '* * * * *',
+  enabled: true,
+  kind: 'handler',
+  handler: async () => {},
+})
+
 function publishCron(stream: ReturnType<typeof createStream>, job: CronJob): string {
   return stream.publish({ target: { kind: 'cron', jobId: job.id }, payload: job })
 }
@@ -124,6 +132,134 @@ function makeFakeSessionFactory(): {
 }
 
 describe('createCronConsumer', () => {
+  test('logs correlated start and successful end lines with elapsed time', async () => {
+    const stream = createStream()
+    const info: string[] = []
+    let time = 1_000
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({ prompt: async () => {} }),
+      invokeHandler: async () => {
+        time = 1_125
+      },
+      intervalNow: () => time,
+      logger: { ...silentLogger, info: (message) => info.push(message) },
+    })
+    consumer.start()
+
+    publishCron(stream, handlerJob('observed-success'))
+    await waitForConsumerIdle(consumer)
+
+    expect(info).toHaveLength(2)
+    const fireId = info[0]?.match(/fire_id=(\S+)/)?.[1]
+    expect(fireId).toBeTruthy()
+    expect(info[0]).toBe(`[cron] observed-success: run started fire_id=${fireId}`)
+    expect(info[1]).toBe(`[cron] observed-success: run ended fire_id=${fireId} outcome=success elapsed_ms=125`)
+
+    consumer.stop()
+  })
+
+  test('logs a failed end line when dispatch throws', async () => {
+    const stream = createStream()
+    const info: string[] = []
+    let time = 2_000
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({ prompt: async () => {} }),
+      invokeHandler: async () => {
+        time = 2_075
+        throw new Error('synthetic failure')
+      },
+      intervalNow: () => time,
+      logger: { ...silentLogger, info: (message) => info.push(message) },
+    })
+    consumer.start()
+
+    publishCron(stream, handlerJob('observed-failure'))
+    await waitForConsumerIdle(consumer)
+
+    expect(info).toHaveLength(2)
+    const fireId = info[0]?.match(/fire_id=(\S+)/)?.[1]
+    expect(fireId).toBeTruthy()
+    expect(info[1]).toBe(`[cron] observed-failure: run ended fire_id=${fireId} outcome=failed elapsed_ms=75`)
+
+    consumer.stop()
+  })
+
+  test('logs the blocking fire id and active duration for an overlapping skip', async () => {
+    const stream = createStream()
+    const info: string[] = []
+    const warnings: string[] = []
+    let time = 3_000
+    let release: (() => void) | undefined
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({ prompt: async () => {} }),
+      invokeHandler: async () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        }),
+      intervalNow: () => time,
+      logger: {
+        ...silentLogger,
+        info: (message) => info.push(message),
+        warn: (message) => warnings.push(message),
+      },
+    })
+    consumer.start()
+
+    const job = handlerJob('observed-overlap')
+    publishCron(stream, job)
+    await new Promise((resolve) => setImmediate(resolve))
+    time = 3_250
+    publishCron(stream, job)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const blockingFireId = info[0]?.match(/fire_id=(\S+)/)?.[1]
+    expect(blockingFireId).toBeTruthy()
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('previous run still in progress, skipping')
+    expect(warnings[0]).toContain(`blocking_fire_id=${blockingFireId}`)
+    expect(warnings[0]).toContain('active_for_ms=250')
+
+    release?.()
+    await waitForConsumerIdle(consumer)
+    consumer.stop()
+  })
+
+  test('releases the in-flight reservation when the completion logger throws', async () => {
+    const stream = createStream()
+    let runs = 0
+    const consumer = createCronConsumer({
+      stream,
+      cwd: root,
+      createSessionForCron: async () => ({ prompt: async () => {} }),
+      invokeHandler: async () => {
+        runs++
+      },
+      logger: {
+        ...silentLogger,
+        info: (message) => {
+          if (message.includes('run ended')) throw new Error('synthetic logger failure')
+        },
+      },
+    })
+    consumer.start()
+
+    const job = handlerJob('throwing-logger')
+    publishCron(stream, job)
+    await waitForConsumerIdle(consumer)
+    publishCron(stream, job)
+    await waitForConsumerIdle(consumer)
+
+    expect(runs).toBe(2)
+
+    consumer.stop()
+  })
+
   test('dispatches a prompt job to createSessionForCron and forwards the prompt text', async () => {
     const stream = createStream()
     const factory = makeFakeSessionFactory()
@@ -880,6 +1016,7 @@ describe('createCronConsumer model fallback', () => {
     try {
       const stream = createStream()
       const errors: string[] = []
+      const info: string[] = []
       const attempted: string[] = []
       const consumer = createCronConsumer({
         stream,
@@ -895,18 +1032,19 @@ describe('createCronConsumer model fallback', () => {
             }),
           }
         },
-        logger: { ...silentLogger, error: (m) => errors.push(m) },
+        logger: { ...silentLogger, error: (m) => errors.push(m), info: (m) => info.push(m) },
       })
       consumer.start()
 
       // when
       publishCron(stream, promptJob('all-down', 'attempt'))
-      await new Promise((r) => setImmediate(r))
+      await waitForConsumerIdle(consumer)
 
       // then
       expect(attempted).toEqual(['openai/gpt-5.4-nano', 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'])
       expect(errors.some((e) => /all 2 model\(s\) failed/.test(e))).toBe(true)
       expect(errors.some((e) => /down: fireworks/.test(e))).toBe(true)
+      expect(info.some((line) => /run ended .* outcome=failed elapsed_ms=\d+$/.test(line))).toBe(true)
 
       consumer.stop()
     } finally {

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -63,6 +63,7 @@ export type CreateCronConsumerOptions = {
   // count. Optional so test fakes that don't exercise counts stay one-liners.
   countStore?: ConsumerCountStore
   now?: () => number
+  intervalNow?: () => number
   logger?: CronConsumerLogger
 }
 
@@ -92,9 +93,10 @@ export function createCronConsumer({
   invokeHandler,
   countStore,
   now = Date.now,
+  intervalNow = () => performance.now(),
   logger = consoleLogger,
 }: CreateCronConsumerOptions): CronConsumer {
-  const inFlight = new Set<string>()
+  const inFlight = new Map<string, { fireId: string; activeSince: number }>()
   let unsubscribe: Unsubscribe | null = null
 
   return {
@@ -106,13 +108,19 @@ export function createCronConsumer({
           logger.warn(`[cron-consumer] received message ${msg.id} with invalid payload, ignoring`)
           return
         }
-        if (inFlight.has(job.id)) {
-          logger.warn(`[cron] ${job.id}: previous run still in progress, skipping`)
+        const blockingFire = inFlight.get(job.id)
+        if (blockingFire !== undefined) {
+          logger.warn(
+            `[cron] ${job.id}: previous run still in progress, skipping blocking_fire_id=${blockingFire.fireId} active_for_ms=${elapsedMs(blockingFire.activeSince, intervalNow())}`,
+          )
           return
         }
         // Reserve before the count gate so two close occurrences can't both
         // pass the `firedCount < count` check before either increment lands.
-        inFlight.add(job.id)
+        const fireId = msg.id
+        inFlight.set(job.id, { fireId, activeSince: intervalNow() })
+        let runStartedAt: number | undefined
+        let outcome: 'success' | 'failed' = 'success'
         try {
           if (job.count !== undefined && countStore !== undefined) {
             if (countStore.get(job.id, job) >= job.count) {
@@ -130,8 +138,10 @@ export function createCronConsumer({
               return
             }
           }
+          runStartedAt = intervalNow()
+          logger.info(`[cron] ${job.id}: run started fire_id=${fireId}`)
           if (job.kind === 'prompt') {
-            await runPrompt(job, createSessionForCron, stream, logger)
+            if (!(await runPrompt(job, createSessionForCron, stream, logger))) outcome = 'failed'
           } else if (job.kind === 'exec') {
             await runExec(job, cwd)
           } else {
@@ -143,10 +153,16 @@ export function createCronConsumer({
             await invokeHandler(job)
           }
         } catch (err) {
+          outcome = 'failed'
           const message = err instanceof Error ? err.message : String(err)
           logger.error(`[cron] ${job.id} failed: ${message}`)
         } finally {
           inFlight.delete(job.id)
+          if (runStartedAt !== undefined) {
+            logger.info(
+              `[cron] ${job.id}: run ended fire_id=${fireId} outcome=${outcome} elapsed_ms=${elapsedMs(runStartedAt, intervalNow())}`,
+            )
+          }
         }
       })
     },
@@ -160,12 +176,16 @@ export function createCronConsumer({
   }
 }
 
+function elapsedMs(startedAt: number, endedAt: number): number {
+  return Math.max(0, Math.round(endedAt - startedAt))
+}
+
 async function runPrompt(
   job: PromptJob,
   createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>,
   stream: Stream,
   logger: CronConsumerLogger,
-): Promise<void> {
+): Promise<boolean> {
   if (job.subagent !== undefined) {
     // Propagate the cron job's role and origin into the spawned subagent.
     // Without this, every cron-triggered subagent (e.g. memory dreaming)
@@ -187,14 +207,14 @@ async function runPrompt(
       },
       payload: job.payload,
     })
-    return
+    return true
   }
   // Resolve the model fallback chain for the cron profile (cron jobs run
   // under the `default` profile today). Single-ref configs produce a length-1
   // chain; multi-ref configs (e.g. `"default": ["openai/...", "fireworks/..."]`)
   // drive the retry-on-failure loop inside `runPromptOnce`.
   const refs = resolveFallbackChain(getConfig().models, undefined)
-  await runPromptOnce(job, refs, createSessionForCron, logger)
+  return runPromptOnce(job, refs, createSessionForCron, logger)
 }
 
 async function runPromptOnce(
@@ -202,7 +222,7 @@ async function runPromptOnce(
   refs: ModelRef[],
   createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>,
   logger: CronConsumerLogger,
-): Promise<void> {
+): Promise<boolean> {
   // Per-attempt lifecycle: every session we create gets full
   // turn-start → turn-end → session-end → dispose bracketing, regardless of
   // whether the helper chose it as the final session or disposed it as a
@@ -320,6 +340,7 @@ async function runPromptOnce(
     }
     await result.dispose()
   }
+  return result.success
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
## Background

Cron had no completion or duration observability: a run only logged on failure, and a skipped-due-to-overlap fire only logged that a previous run was still in progress, with no way to tell how long it had been running. There was no way to correlate a run's start with its end, no elapsed-time data for any occurrence, and no signal on how long an overlapping job had been blocking.

#1402 attempted to close a related gap — a genuinely hung `session.prompt()` never releasing its `inFlight` reservation, since that reservation only clears in the `finally` block — by adding a per-job timeout with abort/dispose. That PR was closed: it was opened during the 2026-08-28 outage investigation on a wedge hypothesis that host logs later refuted, and there was no duration data to justify picking any specific timeout value as a safe default.

This PR is the retained, uncontested half of #1402: pure logging, no timeout. The hung-`inFlight`-reservation property described there is still real and unaddressed — this PR does not fix it — but it has never been observed in practice, and shipping a deadline without duration data to pick a safe threshold would be guessing. This PR produces that duration data first.

## Summary

`createCronConsumer` now logs the full lifecycle of each occurrence, keyed by the stream message id as a `fire_id` so a start line and its matching end line can be correlated in logs:

- `inFlight` changes from a `Set<string>` to a `Map<string, { fireId, activeSince }>` so a blocked overlap can report which fire is blocking it and for how long.
- A `run started fire_id=<id>` info line logs immediately before dispatch (after the count-gate check, so gated/skipped occurrences don't log a start they never really made).
- A `run ended fire_id=<id> outcome=success|failed elapsed_ms=<n>` info line logs in `finally`, using the same `fire_id` and measuring from just before dispatch to completion.
- The existing overlap-skip warning now includes `blocking_fire_id=<id>` and `active_for_ms=<n>`, computed from the blocking occurrence's `activeSince`.

## What this does NOT do

- No deadline, timeout, or per-job `timeoutMs` override.
- No abort or dispose of a hung occurrence.
- No scheduling change — the count gate, overlap-skip behavior, and dispatch order are all unchanged.
- No other behavior change — this is additive logging only; every existing decision point (skip, gate, dispatch, error) still does exactly what it did before.

References closed #1402, which took the additional step this PR deliberately omits.

## Review notes

The load-bearing decision is using the stream message id as `fire_id` rather than minting a new one — it's already unique per occurrence and free to obtain from the existing dispatch handler. `runStartedAt` is only set once dispatch actually begins (after the count-gate return), so the `finally` block's `if (runStartedAt !== undefined)` guard correctly skips the end-of-run log for occurrences that never started.

## Verification

- `bun run typecheck`
- `bun run lint` — 0 errors (existing warnings only)
- `bun run format`
- `bun run format:check`
- `bun run test` — 13,357 pass, 31 skip, 0 fail
