### PR TITLE
Fix Discord /stop rejecting idle live sessions

### DIFF
--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -2041,7 +2041,7 @@ describe('createInteractionHandler', () => {
     expect(routerCalls).toHaveLength(1)
     expect(fetchCalls).toHaveLength(1)
     const body = JSON.parse(fetchCalls[0]!.init.body as string)
-    expect(body.data.content).toContain('Nothing to stop')
+    expect(body.data.content).toBe('Nothing to stop — no active turn in this channel. Send a new message to start one.')
   })
 
   test('non-CHAT_INPUT interactions (buttons, modals, autocomplete) are silently dropped', async () => {

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -88,7 +88,7 @@ const SLASH_COMMANDS: readonly DiscordCommandDeclaration[] = [
 const SLASH_COMMAND_NAMES: ReadonlySet<string> = new Set(SLASH_COMMANDS.map((c) => c.name))
 
 const STOP_REPLY_ABORTED = 'Stopped the current turn.'
-const STOP_REPLY_NO_LIVE_SESSION = 'Nothing to stop — no active turn in this channel.'
+const STOP_REPLY_NO_LIVE_SESSION = 'Nothing to stop — no active turn in this channel. Send a new message to start one.'
 const STOP_REPLY_FAILED = 'Could not stop the current turn (internal error).'
 const STOP_REPLY_PERMISSION_DENIED = 'You do not have permission to stop the current turn in this channel.'
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -9104,6 +9104,28 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     expect(sessions[0]!.aborted).toBe(1)
   })
 
+  // Production fingerprint, Discord 2026-08-28: one registered session
+  // consumed repeated user messages while every prompt completed without an
+  // assistant entry. Native /stop resolved the exact channel key but rejected
+  // the idle-between-prompts session as "no-live-session", removing the only
+  // user-controlled escape hatch until stale rollover.
+  test('Discord /stop aborts an exact live session that repeatedly produced no assistant output', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'first attempt', externalMessageId: 'm-first' }))
+    await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ text: 'second attempt', externalMessageId: 'm-second' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    const result = await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
+
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
+    expect(sessions[0]!.aborted).toBe(1)
+  })
+
   test('stop on a queued (pre-drain) session clears the queue and aborts', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
@@ -9336,20 +9358,30 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
     expect(sessions[0]!.aborted).toBe(0)
   })
 
-  test('stop on an observe-only exact-thread session reports no-live-session and aborts nothing', async () => {
+  test('Slack stop on an observe-only exact-thread session reports no-live-session and aborts nothing', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
+    const slackThreadKey: ChannelKey = { adapter: 'slack-bot', workspace: 'g1', chat: 'c1', thread: 'thr-1' }
     // Prime a second human so the strict multi-human gate applies and an
     // unaddressed thread message observes (creating a live session) rather than
     // engaging — the bystander state the fix must treat as "nothing to stop".
-    await router.route(inbound({ thread: 'thr-1', isBotMention: true, authorId: 'carol', authorName: 'carol' }))
-    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+    await router.route(
+      inbound({ adapter: 'slack-bot', thread: 'thr-1', isBotMention: true, authorId: 'carol', authorName: 'carol' }),
+    )
+    await router.__testing!.flushDebounce(slackThreadKey)
     const engagedSessions = sessions.length
     await router.route(
-      inbound({ thread: 'thr-1', isBotMention: false, authorId: 'bob', authorName: 'bob', externalMessageId: 'm-obs' }),
+      inbound({
+        adapter: 'slack-bot',
+        thread: 'thr-1',
+        isBotMention: false,
+        authorId: 'bob',
+        authorName: 'bob',
+        externalMessageId: 'm-obs',
+      }),
     )
 
-    const result = await router.executeCommand({ ...KEY, thread: 'thr-1' }, 'stop', { invokerId: 'alice' })
+    const result = await router.executeCommand(slackThreadKey, 'stop', { invokerId: 'alice' })
 
     expect(result).toEqual({ kind: 'no-live-session' })
     // The observe-only inbound created no new session that got aborted, and the

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -6648,9 +6648,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (resolved.kind === 'ambiguous') {
         return { kind: 'ambiguous', matchCount: resolved.count }
       }
-      // A resolved session that isn't actually running has nothing for /stop to
-      // cancel; report it as no-live-session so bystander agents stay silent.
-      if (lowered === 'stop' && !hasStoppableWork(resolved.session)) {
+      // Slack broadcasts slash commands to every installed app, so an idle
+      // fallback/observe-only session must stay silent instead of claiming it
+      // stopped work. Discord interactions are delivered only to the selected
+      // application, and its exact channel key is authoritative even between
+      // prompts. In the 2026-08-28 incident, one exact Discord session consumed
+      // 14 messages into a no-assistant-output branch; each prompt ended in
+      // ~53ms, so /stop landed while `draining`, queues, and reminders were all
+      // empty and incorrectly reported no-live-session. Always pass that exact
+      // session to stopCurrentChannelTurn so the user's escape hatch remains.
+      const exactDiscordSession = key.adapter === 'discord-bot' && resolved.session.keyId === channelKeyId(key)
+      if (lowered === 'stop' && !exactDiscordSession && !hasStoppableWork(resolved.session)) {
         return { kind: 'no-live-session' }
       }
       live = resolved.session


### PR DESCRIPTION
## Background

Discord's `/stop` slash-command interaction handler (`createInteractionHandler` in `discord-bot.ts`) calls `router.executeCommand`, which resolves the exact live session for the channel key and then re-checks it with `hasStoppableWork` before honoring the stop. That gate exists so a bystander agent that only *observed* a thread (Slack's broadcast-to-every-installed-app model) doesn't abort someone else's idle session and falsely claim it stopped work.

In the 2026-08-28 incident, one Discord session was resolved exactly by key but was poisoned: it consumed 14 user messages into a no-assistant-output branch, with each prompt completing in roughly 53ms. Between prompts the session was genuinely idle — `draining` false, `promptQueue` empty, `pendingSystemReminders` empty — so `hasStoppableWork` returned false and `/stop` reported `no-live-session` even though `executeCommand` had already resolved the exact channel's live session. The user's only escape hatch for a stuck session was gated shut by the same check meant to protect bystanders in a different messaging model.

The text-based `/stop` message path (`runChannelCommand`, reached from `router.route` via `commands.execute` directly) never applied this gate at all — it resolves and dispatches without calling `hasStoppableWork`. Only the native-command surface (`executeCommand`, used by Discord's interaction handler) had the extra check, so the same stuck session could be stopped by typing `/stop` as a message but not via the Discord slash command.

Reopened issue: #184.

## Summary

`executeCommand`'s `hasStoppableWork` gate now only applies when the resolved session is not an exact Discord-bot match. Discord interactions are delivered only to the selected application for that exact channel key, so once `executeCommand` has resolved a session at that exact key, its liveness is authoritative — there is no bystander ambiguity to guard against, unlike Slack's broadcast delivery. Slack (and any other adapter without an exact-key match) keeps the original `hasStoppableWork` gate unchanged, so an observe-only bystander session still reports `no-live-session` instead of falsely claiming a stop.

This also makes the cold "nothing to stop" reply for Discord actionable: it now tells the user to send a new message to start a turn, instead of leaving them with no next step.

## What this does NOT do

- Does not touch the Slack broadcast/observe-only guard — `hasStoppableWork` still applies unchanged whenever the resolved session isn't an exact Discord-bot key match.
- Does not change the text `/stop` path — it was never subject to this gate and needed no fix.
- Does not re-fix the stranded-`toolUse` branch shape. PR #1415 fixed the related underlying stranding (a poisoned session with an unmatched `toolUse` at the tail of its branch). This PR does not re-fix that stranding; it independently restores `/stop` for an exact live Discord session while it is idle between prompts with no draining, queued, or reminder state.

## Review notes

The load-bearing change is the `exactDiscordSession` check in `router.ts`'s `executeCommand`, right before the `hasStoppableWork` gate: `key.adapter === 'discord-bot' && resolved.session.keyId === channelKeyId(key)`. This is deliberately scoped to the adapter plus an exact key match, not a general "trust every resolved session" relaxation — Slack's fallback/observe-only resolution can still return a session whose key doesn't exactly match the invoking key, and that path keeps the gate.

TDD: the new regression (`Discord /stop aborts an exact live session that repeatedly produced no assistant output`) drives two prompts through the same session so it goes idle between them with empty queue/reminders/draining state, then calls `executeCommand(KEY, 'stop', ...)`. With the production change stashed, it failed red — the command returned `{ kind: 'no-live-session' }` instead of aborting. Restoring the fix turns it green: the session aborts and the reply is `Stopped the current turn.`

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (70 pre-existing warnings, all in unrelated files)
- `bun run format` / `bun run format:check` — clean
- `bun test --parallel src/channels/` — 3188 pass, 0 fail
- `bun run test` (full suite) — 13355 pass, 31 skip, 0 fail