### PR TITLE
Report Slack socket liveness accurately

### DIFF
--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { SlackBotClient, SlackFile, SlackMessage } from 'agent-messenger/slackbot'
+import type { SlackBotClient, SlackBotListener, SlackFile, SlackMessage } from 'agent-messenger/slackbot'
 
 import { MEMBERSHIP_CACHE_TRANSIENT_TTL_MS } from '@/channels/membership'
-import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
+import type { ChannelRouter } from '@/channels/router'
+import { channelsSchema, defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
 import type { ChannelKey, FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
 import { SLACK_APP_MANIFEST } from '@/cli/ui'
 
 import {
   createOutboundCallback,
+  createSlackBotAdapter,
   createSlackHistoryCallback,
   createSlackListCallback,
   createSlackMembershipResolver,
@@ -25,6 +27,98 @@ import {
 import { classifyInbound, type SlackInboundAppMentionEvent } from './slack-bot-classify'
 import { createSlackDedupe } from './slack-bot-dedupe'
 import { encodeSlackReactionRef } from './slack-bot-reactions'
+
+class FakeSlackBotListener {
+  private handlers = new Map<string, Array<(value: unknown) => void>>()
+
+  on(event: string, handler: (value: unknown) => void): void {
+    this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler])
+  }
+
+  async start(): Promise<void> {}
+
+  stop(): void {}
+
+  emit(event: string, value: unknown): void {
+    for (const handler of this.handlers.get(event) ?? []) handler(value)
+  }
+}
+
+function lifecycleRouter(): ChannelRouter {
+  const noop = (): void => {}
+  return {
+    route: async () => {},
+    executeCommand: async () => ({ kind: 'unknown-command' }),
+    registerOutbound: noop,
+    unregisterOutbound: noop,
+    registerReaction: noop,
+    unregisterReaction: noop,
+    registerRemoveReaction: noop,
+    unregisterRemoveReaction: noop,
+    registerTyping: noop,
+    unregisterTyping: noop,
+    setTypingCapability: noop,
+    registerChannelNameResolver: noop,
+    unregisterChannelNameResolver: noop,
+    registerSelfIdentity: noop,
+    unregisterSelfIdentity: noop,
+    registerMembership: noop,
+    unregisterMembership: noop,
+    registerHistory: noop,
+    unregisterHistory: noop,
+    registerMessageGet: noop,
+    unregisterMessageGet: noop,
+    registerList: noop,
+    unregisterList: noop,
+    registerEditMessage: noop,
+    unregisterEditMessage: noop,
+    registerFetchAttachment: noop,
+    unregisterFetchAttachment: noop,
+  } as unknown as ChannelRouter
+}
+
+describe('createSlackBotAdapter', () => {
+  test('reports Socket Mode disconnects and reconnects independently of authenticated identity', async () => {
+    const listener = new FakeSlackBotListener()
+    const adapter = createSlackBotAdapter({
+      router: lifecycleRouter(),
+      configRef: () => channelsSchema.parse({ 'slack-bot': {} })['slack-bot']!,
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createClient: () =>
+        ({
+          login: async () => {},
+          testAuth: async () => ({ user_id: 'U0123456789', team_id: 'T0123456789' }),
+        }) as unknown as SlackBotClient,
+      createListener: () => listener as unknown as SlackBotListener,
+    })
+
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(false)
+
+    listener.emit('connected', { app_id: 'A0123456789' })
+    expect(adapter.isConnected()).toBe(true)
+
+    listener.emit('error', { code: 'socket_error' })
+    expect(adapter.isConnected()).toBe(true)
+
+    listener.emit('disconnected', undefined)
+    expect(adapter.isConnected()).toBe(false)
+
+    listener.emit('connected', { app_id: 'A0123456789' })
+    expect(adapter.isConnected()).toBe(true)
+
+    listener.emit('error', { code: 'disconnect_terminal' })
+    expect(adapter.isConnected()).toBe(false)
+
+    listener.emit('connected', { app_id: 'A0123456789' })
+    expect(adapter.isConnected()).toBe(true)
+
+    await adapter.stop()
+    expect(adapter.isConnected()).toBe(false)
+  })
+})
 
 describe('slack-bot createTypingCallback', () => {
   type SetStatusCall = { channel: string; threadTs: string; status: string }

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -289,6 +289,8 @@ export type SlackBotAdapterOptions = {
   // tests and ad-hoc adapter constructions stay backwards-compatible.
   selfAliasesRef?: () => readonly string[]
   fetchImpl?: typeof fetch
+  createClient?: () => SlackBotClient
+  createListener?: (client: SlackBotClient, appToken: string) => SlackBotListener
 }
 
 export type SlackBotAdapter = {
@@ -1146,11 +1148,12 @@ function stringField(record: Record<string, unknown>, key: string): string | nul
 
 export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBotAdapter {
   const logger = options.logger ?? consoleLogger
-  const client = new SlackBotClient()
+  const client = options.createClient?.() ?? new SlackBotClient()
   const fetchImpl = options.fetchImpl ?? fetch
   let listener: SlackBotListener | null = null
   let botUserId: string | null = null
   let teamId: string | null = null
+  let socketConnected = false
   let started = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
@@ -1376,14 +1379,19 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         throw err
       }
 
-      listener = new SlackBotListener(client, { appToken: options.appToken })
+      listener =
+        options.createListener?.(client, options.appToken) ??
+        new SlackBotListener(client, { appToken: options.appToken })
       listener.on('connected', (info) => {
+        socketConnected = started
         logger.info(`[slack-bot] connected (app_id=${info.app_id ?? 'unknown'})`)
       })
       listener.on('disconnected', () => {
+        socketConnected = false
         logger.warn('[slack-bot] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
+        if (recordValue(err)?.code === 'disconnect_terminal') socketConnected = false
         logger.error(`[slack-bot] socket-mode error: ${describeError(err)}`)
       })
       listener.on('message', ({ ack, event }) => {
@@ -1461,6 +1469,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         listener = null
         botUserId = null
         teamId = null
+        socketConnected = false
         started = false
         logger.error(`[slack-bot] listener start failed: ${describeError(err)}`)
         throw err
@@ -1470,6 +1479,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     async stop(): Promise<void> {
       if (!started) return
       started = false
+      socketConnected = false
       options.router.unregisterOutbound('slack-bot', outboundCallback)
       options.router.unregisterReaction('slack-bot', reactionCallback)
       options.router.unregisterRemoveReaction('slack-bot', removeReactionCallback)
@@ -1495,7 +1505,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     },
 
     isConnected(): boolean {
-      return botUserId !== null && teamId !== null
+      return started && socketConnected
     },
   }
 }

--- a/src/channels/adapters/slack.test.ts
+++ b/src/channels/adapters/slack.test.ts
@@ -378,6 +378,30 @@ describe('createSlackAdapter', () => {
     expect(adapter.isConnected()).toBe(true)
   })
 
+  test('reports RTM disconnects and reconnects', async () => {
+    const listener = new FakeListener()
+    const adapter = createSlackAdapter({
+      router: router(),
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient(),
+      createListener: () => listener as unknown as SlackListener,
+    })
+
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
+
+    listener.emit('disconnected', undefined)
+    expect(adapter.isConnected()).toBe(false)
+
+    listener.emitConnected()
+    expect(adapter.isConnected()).toBe(true)
+
+    await adapter.stop()
+    expect(adapter.isConnected()).toBe(false)
+  })
+
   test('an error before connected rolls back with the real reason, not [object ErrorEvent]', async () => {
     const r = router()
     const log = logger()


### PR DESCRIPTION
## Background

`slack-bot` (Socket Mode) holds a persistent WebSocket open for the life of the session, and `manager.ts`'s recovery loop restarts an adapter based on `isConnected()` alone. `slack-bot.ts` answered it wrong:

- The listener's `disconnected` handler only logged; nothing cleared the flag `isConnected()` read.
- `isConnected()` itself checked cached bot/team identity rather than socket state — so it kept reporting HEALTHY while Socket Mode was down.

This is the same health-reporting defect #1195 fixed for `discord-bot`, still present on `slack-bot`. A drop during active use went unnoticed by the liveness check, so `manager.ts` never restarted the `slack-bot` adapter and inbound messages sent during the gap were silently dropped.

`slack` (RTM) already toggles `connected` correctly on `disconnected`/reconnect, so `manager.ts` can observe an RTM drop and does restart that adapter — but it had no regression coverage confirming the transition. That restart cannot recover messages already missed during the outage: RTM still has no replay path for the gap, since Slack's RTM protocol has no server-side replay cursor.

Closes #1406.

## Summary

`slack-bot`'s `isConnected()` now reflects actual socket state (`started && socketConnected`) instead of cached auth identity. `socketConnected` is set on the listener's `connected` event, cleared on `disconnected`, and cleared on an `error` event carrying `disconnect_terminal` (the SDK's terminal-failure signal), plus on `stop()`. `createClient`/`createListener` injection points were added to `SlackBotAdapterOptions` so the listener's lifecycle events can be driven directly in tests without a real Socket Mode connection.

`slack.ts` already cleared `connected` correctly; this PR adds regression coverage for the RTM disconnect/reconnect transition so the same class of gap can't silently regress there.

## What this does NOT do

- Does not add message replay or backfill for the gap between disconnect and reconnect, for either adapter. Per #1406, Slack's Socket Mode/RTM protocol has no server-side replay cursor comparable to Discord's snowflake IDs, so #1405's cursor + REST-backfill approach can't be mechanically ported. A bounded `conversations.history` backfill design is left as separate follow-up work.
- Does not touch `github`'s inbound delivery sweep — already covered by its own bounded recovery path per #1406's scope note.

## Review notes

- `isConnected()`'s new definition (`started && socketConnected`) is the load-bearing change — verify the `disconnect_terminal` error-code check in the listener's `error` handler matches how the SDK actually signals a terminal failure vs. a transient one, since only the terminal case should clear liveness independently of the `disconnected` event.
- `slack-bot.test.ts` drives the fake listener through connected → error(transient) → disconnected → connected → error(disconnect_terminal) → connected to cover both error paths.

## Testing

- `bun run lint` — 0 errors (existing warnings unchanged)
- `bun run format:check`
- `bun typecheck`
- `bun run test` — 13,361 pass, 31 skip, 0 fail