### PR TITLE
Report Teams realtime health truthfully

### DIFF
--- a/src/channels/adapters/teams.test.ts
+++ b/src/channels/adapters/teams.test.ts
@@ -496,16 +496,17 @@ describe('createTeamsAdapter', () => {
     expect(r.routed[0]?.chat).toBe('chat:chat-9')
   })
 
-  test('stays usable (REST) even after a realtime disconnected event', async () => {
+  test('reports unhealthy while realtime is disconnected and recovers when it reconnects', async () => {
     const r = router()
     const listener = new FakeListener()
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
     await adapter.start()
     expect(adapter.isConnected()).toBe(true)
-    // a realtime drop does not make the adapter unusable — send/read still work,
-    // so isConnected() stays true and the manager does not churn-restart it
     listener.emit('disconnected', undefined)
+    expect(adapter.isConnected()).toBe(false)
+
+    listener.emit('connected', { endpointId: 'ep-2' })
     expect(adapter.isConnected()).toBe(true)
 
     await adapter.stop()
@@ -515,7 +516,8 @@ describe('createTeamsAdapter', () => {
     const r = router()
     const listener = new FakeListener()
     const log = logger()
-    const adapter = adapterWith({ r, listener, client: fakeClient().client, log })
+    const { client, sends } = fakeClient()
+    const adapter = adapterWith({ r, listener, client, log })
 
     // given the listener connected fine at start
     await adapter.start()
@@ -532,9 +534,11 @@ describe('createTeamsAdapter', () => {
     expect(listener.stopped).toBe(true)
     expect(log.lines.filter((l) => l.startsWith('error:')).length).toBe(errorsBefore)
     expect(log.lines.some((l) => l.includes('continuing REST-only'))).toBe(true)
-    // REST send/read remain usable, callbacks stay registered
-    expect(adapter.isConnected()).toBe(true)
+    // REST send/read remain registered, but realtime health is reported truthfully
+    expect(adapter.isConnected()).toBe(false)
     expect(r.unregistered).toEqual([])
+    await r.outboundCb!(outbound({ text: 'still available' }))
+    expect(sends).toEqual([{ chatId: 'chat-1', content: 'still available' }])
 
     await adapter.stop()
   })
@@ -580,8 +584,7 @@ describe('createTeamsAdapter', () => {
 
     // start() resolves (does not throw): REST send/read remain usable
     await adapter.start()
-    // isConnected() reflects REST usability, so the manager won't churn-restart it
-    expect(adapter.isConnected()).toBe(true)
+    expect(adapter.isConnected()).toBe(false)
     // the REST callbacks stay registered — only the listener is torn down
     expect(r.registered).toEqual(['outbound:teams', 'self:teams', 'history:teams', 'edit:teams'])
     expect(r.unregistered).toEqual([])
@@ -602,7 +605,7 @@ describe('createTeamsAdapter', () => {
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
     await adapter.start()
-    expect(adapter.isConnected()).toBe(true)
+    expect(adapter.isConnected()).toBe(false)
     expect(r.unregistered).toEqual([])
     expect(listener.stopped).toBe(true)
 
@@ -621,7 +624,7 @@ describe('createTeamsAdapter', () => {
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
     await adapter.start()
-    expect(adapter.isConnected()).toBe(true)
+    expect(adapter.isConnected()).toBe(false)
     expect(r.unregistered).toEqual([])
     expect(listener.stopped).toBe(true)
 

--- a/src/channels/adapters/teams.ts
+++ b/src/channels/adapters/teams.ts
@@ -160,6 +160,7 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
   let channelTeamMap = new Map<string, string>()
   let sentEchoes: SentEcho[] = []
   let started = false
+  let realtimeConnected = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
 
@@ -270,6 +271,7 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
     async start(): Promise<void> {
       if (started) return
       started = true
+      realtimeConnected = false
       try {
         const account = await (options.credentialsStore ?? null)?.getAccount()
         if (account === null || account === undefined) {
@@ -296,6 +298,7 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
         logger.info(`[teams] authenticated as ${self.displayName}, ${chatsById.size} chats`)
       } catch (err) {
         started = false
+        realtimeConnected = false
         self = null
         loadedAccount = null
         chatsById = new Map()
@@ -327,6 +330,7 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
       // just don't get proactively woken by inbound Teams messages.
       const degradeToRestOnly = (cause: Error): void => {
         if (listener !== activeListener) return
+        realtimeConnected = false
         listener?.stop()
         listener = null
         logger.warn(
@@ -336,10 +340,12 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
 
       listener.on('connected', () => {
         if (!isActive()) return
+        realtimeConnected = true
         logger.info('[teams] connected')
       })
       listener.on('disconnected', () => {
         if (!isActive()) return
+        realtimeConnected = false
         logger.warn('[teams] disconnected')
       })
       // A post-connect `error` for the unrecoverable id_token failure would
@@ -380,6 +386,7 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
     async stop(): Promise<void> {
       if (!started) return
       started = false
+      realtimeConnected = false
       options.router.unregisterOutbound('teams', outboundCallback)
       options.router.unregisterSelfIdentity('teams', selfIdentityResolver)
       options.router.unregisterHistory('teams', historyCallback)
@@ -397,13 +404,8 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
       sentEchoes = []
     },
 
-    // REST auth being live is what makes the adapter usable (send/read); the
-    // realtime listener is a best-effort add-on. Returning true here even in
-    // REST-only mode is deliberate: the channel manager restarts any adapter
-    // whose isConnected() is false, which would pointlessly churn a healthy
-    // REST-only Teams adapter that can never get a realtime listener.
     isConnected(): boolean {
-      return started && self !== null
+      return started && self !== null && realtimeConnected
     },
   }
 }

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -294,6 +294,48 @@ describe('channel manager — connection recovery', () => {
 
     await mgr.stop()
   })
+
+  test('backs off repeated restarts when replacements remain disconnected', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock({ checkIntervalMs: 10, disconnectedGraceMs: 100, retryBaseMs: 200 })
+    const adapters = [makeFakeAdapter(), makeFakeAdapter(), makeFakeAdapter(), makeFakeAdapter()]
+    for (const adapter of adapters) {
+      adapter.start = async () => {
+        adapter.startCalls++
+        adapter.connected = false
+      }
+    }
+    let constructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => adapters[constructions++]!,
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    clock.advanceBy(101)
+    await flushManagerWork()
+    expect(constructions).toBe(2)
+
+    clock.advanceBy(194)
+    await flushManagerWork()
+    expect(constructions).toBe(2)
+    clock.advanceBy(1)
+    await flushManagerWork()
+    expect(constructions).toBe(3)
+
+    clock.advanceBy(394)
+    await flushManagerWork()
+    expect(constructions).toBe(3)
+    clock.advanceBy(1)
+    await flushManagerWork()
+    expect(constructions).toBe(4)
+
+    await mgr.stop()
+  })
+
   test('does not queue duplicate recovery restarts while the first restart is pending', async () => {
     cfg['discord-bot'] = enabledAdapterCfg()
     let now = 1_000

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -192,6 +192,8 @@ type AdapterEntry = {
   adapter: AnyAdapter
   credentialSignature: string
   disconnectedSinceMs: number | null
+  nextRecoveryRestartAtMs: number | null
+  recoveryRestartAttempts: number
   recoveryRestartQueued: boolean
 }
 
@@ -512,6 +514,8 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         adapter,
         credentialSignature: signature,
         disconnectedSinceMs: adapter.isConnected() ? null : recoveryNow(),
+        nextRecoveryRestartAtMs: null,
+        recoveryRestartAttempts: 0,
         recoveryRestartQueued: false,
       })
       return { status: 'started' }
@@ -722,6 +726,8 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     for (const [name, entry] of live) {
       if (entry.adapter.isConnected()) {
         entry.disconnectedSinceMs = null
+        entry.nextRecoveryRestartAtMs = null
+        entry.recoveryRestartAttempts = 0
         entry.recoveryRestartQueued = false
         continue
       }
@@ -731,7 +737,11 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         continue
       }
       const disconnectedForMs = now - entry.disconnectedSinceMs
-      if (disconnectedForMs < recoveryDisconnectedGraceMs || entry.recoveryRestartQueued) continue
+      const nextRestartAtMs = Math.max(
+        entry.disconnectedSinceMs + recoveryDisconnectedGraceMs,
+        entry.nextRecoveryRestartAtMs ?? Number.NEGATIVE_INFINITY,
+      )
+      if (now < nextRestartAtMs || entry.recoveryRestartQueued) continue
       entry.recoveryRestartQueued = true
       logger.warn(
         `[channels] adapter "${name}" disconnected for ${Math.round(disconnectedForMs)}ms; restarting adapter`,
@@ -756,6 +766,12 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
               return running && queuedEpoch === lifecycleEpoch && cfg !== undefined && cfg.enabled !== false
             })
             applyStartResult(name, latestCfg, result)
+            const replacement = live.get(name)
+            if (replacement !== undefined && !replacement.adapter.isConnected()) {
+              const attempts = entry.recoveryRestartAttempts + 1
+              replacement.recoveryRestartAttempts = attempts
+              replacement.nextRecoveryRestartAtMs = recoveryNow() + retryDelayMs(attempts)
+            }
           } catch (err) {
             const cfg = options.channelsConfigRef()[name]
             if (running && queuedEpoch === lifecycleEpoch && cfg !== undefined && cfg.enabled !== false) {


### PR DESCRIPTION
## Background

Teams `isConnected()` always returned `started && self !== null`, ignoring the realtime listener entirely. The comment above it explained this was deliberate: REST auth alone makes the adapter usable, and returning `true` even in REST-only mode avoided the channel manager churning a healthy REST-only adapter that can never get a realtime listener.

That tradeoff hid a real failure: once a realtime `disconnected` (or an unrecoverable id_token error triggering `degradeToRestOnly`) fired, `isConnected()` kept reporting `true` forever, because it never looked at listener state. The channel manager's disconnect-triggers-restart recovery path treats `isConnected()` as ground truth (`src/channels/manager.ts`), so a Teams adapter stuck without a realtime connection was invisible to that recovery loop — it looked healthy indefinitely and never triggered a restart to try re-establishing realtime.

Separately, the recovery restart itself had no backoff: a restart whose `start()` call resolved successfully, but whose `isConnected()` remained false, could be re-queued on every recovery tick with no growing delay, unlike the adapter-start-failure path which already backs off via `retryDelayMs`.

## Summary

- `teams.ts` adds a `realtimeConnected` flag, set `true` on the listener's `connected` event and `false` on `disconnected`, `degradeToRestOnly`, `start()` entry/failure, and `stop()`. `isConnected()` now returns `started && self !== null && realtimeConnected`, so realtime health is reported truthfully instead of always `true` once REST auth succeeds.
- `manager.ts` adds `nextRecoveryRestartAtMs` and `recoveryRestartAttempts` to `AdapterEntry`. When a recovery restart completes but the adapter is still not connected, the manager schedules the next restart attempt using the same exponential jittered capped backoff (`retryDelayMs`) already used for adapter start failures, instead of retrying on the next tick unconditionally. A successful reconnect resets both fields to their initial state.
- REST send and history callbacks stay registered throughout realtime degradation — `isConnected()` going `false` only reflects the realtime listener, it doesn't unregister REST capability. Proactive inbound (a message arriving without a REST poll) is unavailable until realtime reconnects, but REST-based operations continue to work between the bounded recovery attempts scheduled by the backoff above.

## What this does NOT do

- Does not add explicit `trouter.message_loss` event surfacing. Upstream `agent-messenger` (2.35.0 through 2.37.1) exposes no loss event on its public API for the realtime transport to report through — there is nothing to wire up yet. #1407 is addressed by making `isConnected()` truthful and giving recovery a working signal to act on, but explicit message-loss detection is a separate, currently-blocked piece.
- Does not change REST polling, chat/message fetch, or any other Teams capability.
- Does not change the backoff formula itself — `retryDelayMs` (base 30s, doubling, ±20% jitter, 15 min cap) is reused as-is from the existing adapter-start-failure path.

## Review notes

The load-bearing change is `isConnected()` in `teams.ts` now depending on `realtimeConnected` rather than only `started && self !== null`. Verify every code path that can end realtime connectivity (`disconnected` listener event, `degradeToRestOnly`, `start()`'s catch block, `stop()`) sets the flag back to `false`, and that the `connected` listener event is the only place it's set to `true`.

In `manager.ts`, the restart-scheduling change in the recovery loop computes `nextRestartAtMs` as `Math.max(disconnectedSinceMs + recoveryDisconnectedGraceMs, nextRecoveryRestartAtMs ?? -Infinity)` — the grace period still applies on first disconnect, and backoff only takes over once at least one restart attempt has completed without reconnecting.

Addresses #1407.

## Verification

- `bun run lint`
- `bun run format:check`
- `bun typecheck`
- `bun run test` — 13,360 pass, 31 skip, 0 fail