### PR TITLE
runtime: close launch, backup, and rehydrate races

### DIFF
--- a/src/bundled-plugins/backup/README.md
+++ b/src/bundled-plugins/backup/README.md
@@ -38,10 +38,11 @@ If a new prompt arrives while the runner is in flight, the runner finishes its c
 
 ## What it commits
 
-The runner stages two categories of dirty paths:
+The runner stages an explicit snapshot from NUL-delimited porcelain status:
 
-- **Tracked or untracked agent paths** (anything `git status --porcelain=v1 --untracked-files=all` reports), **except** paths under `memory/` — those are owned by the memory plugin's dreaming subagent.
-- **Force-added `sessions/`** — gitignored, but force-added so transcripts survive across restarts.
+- **Tracked changes**, including deletions and both rename/copy endpoints, are staged even when an endpoint is no longer present on disk.
+- **Ordinary untracked paths** are staged only while still present. If one disappears between snapshot and `git add`, the runner re-reads status and retries that same snapshot once without the vanished path; paths discovered during that re-read are never added.
+- **`memory/`** remains excluded. Present **`sessions/` and `todo/`** paths remain force-added; tracked deletions under those prefixes stay in the ordinary snapshot. The post-message pass re-stages only `sessions/` paths that appeared while the message was selected.
 
 Commit message comes from the `backup-message` subagent, which sees a truncated `git status` and `git diff --cached --stat` and writes a single conventional-ish commit message to a tmp file. On any failure the runner falls back to `chore: backup`.
 

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { rmSync } from 'node:fs'
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -206,9 +207,10 @@ describe('runBackup', () => {
     const cwd = await makeRepo()
     await mkdir(join(cwd, 'sessions'))
     await writeFile(join(cwd, 'sessions', 'pre.jsonl'), '{}')
+    await mkdir(join(cwd, 'todo'))
 
     const firstStatus = '?? sessions/pre.jsonl\n M src/foo.ts\n'
-    const secondStatus = '?? sessions/pre.jsonl\n?? sessions/late.jsonl\n M src/foo.ts\n'
+    const secondStatus = '?? sessions/pre.jsonl\n?? sessions/late.jsonl\n?? todo/late.json\n M src/foo.ts\n'
     let statusCalls = 0
     let messagePicked = false
 
@@ -231,6 +233,7 @@ describe('runBackup', () => {
       pickCommitMessage: async () => {
         // when: simulate the late file appearing during message synthesis
         await writeFile(join(cwd, 'sessions', 'late.jsonl'), '{}')
+        await writeFile(join(cwd, 'todo', 'late.json'), '{}')
         messagePicked = true
         return 'chore: backup'
       },
@@ -252,6 +255,7 @@ describe('runBackup', () => {
     const lateAddPaths = addFCalls[1]?.args.slice(3) ?? []
     expect(lateAddPaths).toContain('sessions/late.jsonl')
     expect(lateAddPaths).toContain('sessions/pre.jsonl')
+    expect(lateAddPaths).not.toContain('todo/late.json')
 
     // and: there are exactly TWO status calls — one before staging, one after
     // pickCommitMessage returns. Asserting the count keeps a future "optimize"
@@ -531,19 +535,174 @@ describe('runBackup', () => {
     await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn, '   '))
     expect(captured).toBe('Backup')
   })
+  test('skips an ordinary untracked path that vanished before staging', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult('?? gone.txt\0')
+      return okResult()
+    })
+
+    const result = await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))
+
+    expect(result).toEqual({ ok: true, kind: 'clean' })
+    expect(calls.some((call) => call.args[0] === 'add')).toBe(false)
+  })
+
+  test('retries a failed explicit add once after an initial untracked path vanishes without widening scope', async () => {
+    const cwd = await makeRepo()
+    await writeFile(join(cwd, 'transient.txt'), 'temporary')
+    let statuses = 0
+    let adds = 0
+    let promptStatus = ''
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') {
+        statuses += 1
+        return okResult(statuses === 1 ? '?? transient.txt\0 M tracked.txt\0' : ' M tracked.txt\0?? later.txt\0')
+      }
+
+      if (args[0] === 'add' && args[1] === '--') {
+        adds += 1
+        if (adds === 1) {
+          rmSync(join(cwd, 'transient.txt'))
+          return failResult('pathspec did not match')
+        }
+        return okResult()
+      }
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    const result = await runBackup(
+      { cwd, pushToOrigin: false },
+      {
+        gitSpawn: spawn,
+        pickCommitMessage: async ({ status }) => {
+          promptStatus = status
+          return 'chore: test'
+        },
+      },
+    )
+
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    const ordinaryAdds = calls.filter((call) => call.args[0] === 'add' && call.args[1] === '--')
+    expect(ordinaryAdds).toHaveLength(2)
+    expect(ordinaryAdds[1]?.args).toEqual(['add', '--', 'tracked.txt'])
+    expect(ordinaryAdds[1]?.args).not.toContain('later.txt')
+    expect(calls.filter((call) => call.args[0] === 'status').every((call) => call.args.includes('-z'))).toBe(true)
+    expect(promptStatus).not.toContain('\0')
+  })
+
+  test('stages both tracked rename endpoints from the original snapshot', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult('R  renamed.txt\0original.txt\0')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((call) => call.args[0] === 'add')?.args).toEqual(['add', '--', 'renamed.txt', 'original.txt'])
+  })
+
+  test('stages a tracked deletion even when its path is absent', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' D removed.txt\0')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((call) => call.args[0] === 'add')?.args).toEqual(['add', '--', 'removed.txt'])
+  })
+
+  test('stages a tracked force-path deletion through the ordinary snapshot', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' D sessions/removed.jsonl\0')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((call) => call.args[0] === 'add')?.args).toEqual(['add', '--', 'sessions/removed.jsonl'])
+    expect(calls.some((call) => call.args[0] === 'add' && call.args[1] === '-f')).toBe(false)
+  })
+
+  test('surfaces an unchanged explicit-add failure without retrying', async () => {
+    const cwd = await makeRepo()
+    await writeFile(join(cwd, 'still-here.txt'), 'present')
+    let statuses = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') {
+        statuses += 1
+        return okResult('?? still-here.txt\0')
+      }
+      if (args[0] === 'add') return failResult('permission denied')
+      return okResult()
+    })
+
+    const result = await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))
+
+    expect(result).toEqual({ ok: false, kind: 'commit-failed', reason: 'git add failed: permission denied' })
+    expect(statuses).toBe(2)
+    expect(calls.filter((call) => call.args[0] === 'add')).toHaveLength(1)
+  })
+
+  test('surfaces the retry failure after one reconciliation attempt', async () => {
+    const cwd = await makeRepo()
+    await writeFile(join(cwd, 'vanishing.txt'), 'present')
+    let statuses = 0
+    let adds = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') {
+        statuses += 1
+        return okResult(statuses === 1 ? '?? vanishing.txt\0 M tracked.txt\0' : ' M tracked.txt\0')
+      }
+      if (args[0] === 'add') {
+        adds += 1
+        if (adds === 1) {
+          rmSync(join(cwd, 'vanishing.txt'))
+          return failResult('first failure')
+        }
+        return failResult('retry failure')
+      }
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({
+      ok: false,
+      kind: 'commit-failed',
+      reason: 'git add failed: retry failure',
+    })
+    expect(calls.filter((call) => call.args[0] === 'add')).toHaveLength(2)
+  })
 })
 
 describe('parsePorcelain', () => {
-  test('parses standard modified/added lines', () => {
-    expect(parsePorcelain(' M src/foo.ts\n?? bar.ts\n')).toEqual(['src/foo.ts', 'bar.ts'])
+  test('classifies tracked and untracked NUL-delimited records', () => {
+    expect(parsePorcelain(' M src/foo.ts\0?? bar.ts\0')).toEqual([
+      { status: ' M', kind: 'tracked', paths: ['src/foo.ts'] },
+      { status: '??', kind: 'untracked', paths: ['bar.ts'] },
+    ])
   })
 
-  test('returns the destination on rename lines', () => {
-    expect(parsePorcelain('R  old/path -> new/path\n')).toEqual(['new/path'])
+  test('preserves literal rename endpoints without pathname quoting', () => {
+    expect(parsePorcelain('R  new name\nfile\0old name\nfile\0')).toEqual([
+      { status: 'R ', kind: 'tracked', paths: ['new name\nfile', 'old name\nfile'] },
+    ])
   })
 
-  test('skips empty and short lines', () => {
-    expect(parsePorcelain('\n  \nXY\n')).toEqual([])
+  test('skips empty and short records', () => {
+    expect(parsePorcelain('\0  \0XY\0')).toEqual([])
   })
 })
 

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -95,29 +95,33 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
   const repo = resolveAgentGit(cwd)
   if (!repo) return { ok: true, kind: 'no-repo' }
 
-  const status = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '--untracked-files=all'], {
+  const status = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '-z', '--untracked-files=all'], {
     cwd,
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
   if (status.exitCode !== 0) return { ok: false, kind: 'aborted', reason: `git status failed: ${shortErr(status)}` }
-  const dirty = filterAgentOwned(parsePorcelain(status.stdout))
-  const force = filterForceAdd(parsePorcelain(status.stdout))
-  if (dirty.length === 0 && force.length === 0) return { ok: true, kind: 'clean' }
+  const snapshot = selectStagingSnapshot(parsePorcelain(status.stdout), cwd)
+  if (snapshot.paths.length === 0 && snapshot.forcePaths.length === 0) return { ok: true, kind: 'clean' }
 
-  if (dirty.length > 0) {
-    const add = await deps.gitSpawn([...repo.gitArgs, 'add', '--', ...dirty], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
-    if (add.exitCode !== 0) return { ok: false, kind: 'commit-failed', reason: `git add failed: ${shortErr(add)}` }
-  }
-  if (force.length > 0) {
-    const present = force.filter((p) => existsSync(join(cwd, p)))
-    if (present.length > 0) {
-      const addF = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...present], {
-        cwd,
-        timeoutMs: COMMIT_TIMEOUT_MS,
-      })
-      if (addF.exitCode !== 0) {
-        return { ok: false, kind: 'commit-failed', reason: `git add -f failed: ${shortErr(addF)}` }
+  if (snapshot.paths.length > 0) {
+    const add = await deps.gitSpawn([...repo.gitArgs, 'add', '--', ...snapshot.paths], {
+      cwd,
+      timeoutMs: COMMIT_TIMEOUT_MS,
+    })
+    if (add.exitCode !== 0) {
+      const retry = await retryAfterVanishedUntracked(cwd, deps, repo, snapshot)
+      if (!retry || retry.exitCode !== 0) {
+        return { ok: false, kind: 'commit-failed', reason: `git add failed: ${shortErr(retry ?? add)}` }
       }
+    }
+  }
+  if (snapshot.forcePaths.length > 0) {
+    const addF = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...snapshot.forcePaths], {
+      cwd,
+      timeoutMs: COMMIT_TIMEOUT_MS,
+    })
+    if (addF.exitCode !== 0) {
+      return { ok: false, kind: 'commit-failed', reason: `git add -f failed: ${shortErr(addF)}` }
     }
   }
 
@@ -132,7 +136,7 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
   const message = await deps.pickCommitMessage({
-    status: status.stdout.slice(0, 4096),
+    status: status.stdout.replaceAll('\0', '\n').slice(0, 4096),
     diffstat: diffstat.stdout.slice(0, 4096),
   })
 
@@ -144,12 +148,12 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
   // one-cycle-behind churn. Re-status, filter to `sessions/` additions
   // only (don't accidentally stage user work that arrived during the
   // window), and force-add anything new.
-  const reStatus = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '--untracked-files=all'], {
+  const reStatus = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '-z', '--untracked-files=all'], {
     cwd,
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
   if (reStatus.exitCode === 0) {
-    const lateForce = filterForceAdd(parsePorcelain(reStatus.stdout)).filter((p) => existsSync(join(cwd, p)))
+    const lateForce = selectForcePaths(parsePorcelain(reStatus.stdout), cwd, ['sessions/'])
     if (lateForce.length > 0) {
       const lateAdd = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...lateForce], {
         cwd,
@@ -372,23 +376,106 @@ function isNonFastForward(r: GitSpawnResult): boolean {
   return blob.includes('non-fast-forward') || blob.includes('updates were rejected')
 }
 
-export function parsePorcelain(stdout: string): string[] {
-  const out: string[] = []
-  for (const raw of stdout.split('\n')) {
+export type PorcelainEntry = {
+  status: string
+  kind: 'tracked' | 'untracked'
+  paths: readonly string[]
+}
+
+// `-z` makes paths literal rather than C-quoted. Rename/copy records carry the
+// destination followed by the source, and both are needed when staging a
+// snapshot that contains an endpoint which has since disappeared.
+export function parsePorcelain(stdout: string): PorcelainEntry[] {
+  const separator = stdout.includes('\0') ? '\0' : '\n'
+  const records = stdout.split(separator)
+  const entries: PorcelainEntry[] = []
+
+  for (let index = 0; index < records.length; index += 1) {
+    const raw = records[index] ?? ''
     if (raw.length < 4) continue
-    const rest = raw.slice(3)
-    const arrowIdx = rest.indexOf(' -> ')
-    out.push(arrowIdx === -1 ? rest : rest.slice(arrowIdx + 4))
+    const status = raw.slice(0, 2)
+    const path = raw.slice(3)
+    const renamedOrCopied = status.includes('R') || status.includes('C')
+    const source = renamedOrCopied && separator === '\0' ? records[++index] : undefined
+    const fallbackSource = renamedOrCopied && separator === '\n' ? path.split(' -> ')[0] : undefined
+    const destination = fallbackSource ? path.slice(fallbackSource.length + 4) : path
+    entries.push({
+      status,
+      kind: status === '??' ? 'untracked' : 'tracked',
+      paths: source ? [path, source] : fallbackSource ? [destination, fallbackSource] : [path],
+    })
   }
-  return out
+  return entries
 }
 
-function filterAgentOwned(paths: readonly string[]): string[] {
-  return paths.filter((p) => !RUNTIME_OWNED_PREFIXES.some((pre) => p.startsWith(pre)))
+type StagingSnapshot = {
+  paths: string[]
+  untrackedPaths: Set<string>
+  forcePaths: string[]
 }
 
-function filterForceAdd(paths: readonly string[]): string[] {
-  return paths.filter((p) => FORCE_ADD_PREFIXES.some((pre) => p.startsWith(pre)))
+function selectStagingSnapshot(entries: readonly PorcelainEntry[], cwd: string): StagingSnapshot {
+  const paths: string[] = []
+  const untrackedPaths = new Set<string>()
+  for (const entry of entries) {
+    for (const path of entry.paths) {
+      if (isAgentOwned(path)) continue
+      const forceAdded = FORCE_ADD_PREFIXES.some((prefix) => path.startsWith(prefix))
+      if (entry.kind === 'untracked') {
+        if (forceAdded || !existsSync(join(cwd, path))) continue
+        untrackedPaths.add(path)
+      }
+      paths.push(path)
+    }
+  }
+  return { paths: uniquePaths(paths), untrackedPaths, forcePaths: selectForcePaths(entries, cwd) }
+}
+
+async function retryAfterVanishedUntracked(
+  cwd: string,
+  deps: BackupRunnerDeps,
+  repo: AgentGit,
+  snapshot: StagingSnapshot,
+): Promise<GitSpawnResult | undefined> {
+  const reread = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '-z', '--untracked-files=all'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
+  if (reread.exitCode !== 0) return undefined
+
+  const reported = new Set(
+    parsePorcelain(reread.stdout)
+      .filter((entry) => entry.kind === 'untracked')
+      .flatMap((entry) => entry.paths),
+  )
+  const vanished = new Set(
+    [...snapshot.untrackedPaths].filter((path) => !existsSync(join(cwd, path)) && !reported.has(path)),
+  )
+  if (vanished.size === 0) return undefined
+
+  const retryPaths = snapshot.paths.filter((path) => !vanished.has(path))
+  if (retryPaths.length === 0) return { exitCode: 0, stdout: '', stderr: '', timedOut: false }
+  return deps.gitSpawn([...repo.gitArgs, 'add', '--', ...retryPaths], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+}
+
+function selectForcePaths(
+  entries: readonly PorcelainEntry[],
+  cwd: string,
+  prefixes: readonly string[] = FORCE_ADD_PREFIXES,
+): string[] {
+  return uniquePaths(
+    entries.flatMap((entry) =>
+      entry.paths.filter((path) => prefixes.some((prefix) => path.startsWith(prefix)) && existsSync(join(cwd, path))),
+    ),
+  )
+}
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths)]
+}
+
+function isAgentOwned(path: string): boolean {
+  return RUNTIME_OWNED_PREFIXES.some((prefix) => path.startsWith(prefix))
 }
 
 function sanitizeCommitMessage(raw: string): string {

--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -130,6 +130,7 @@ describe('buildHostdRestart', () => {
   test('forwards the daemon-supplied currentHostDaemon into start()', async () => {
     const starts: RestartOptions[] = []
     const register = async (): Promise<{ ok: true }> => ({ ok: true })
+    const deregister = async (): Promise<void> => {}
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {
       validateConfig: () => ({ ok: true }),
       loadConfigSync: () => configSchema.parse({ port: 61234 }),
@@ -142,11 +143,11 @@ describe('buildHostdRestart', () => {
     const result = await restart({
       containerName: 'agent',
       cwd: '/agent-dir',
-      currentHostDaemon: { httpPort: 8974, register },
+      currentHostDaemon: { httpPort: 8974, register, deregister },
     })
 
     expect(result.ok).toBe(true)
-    expect(starts[0]?.currentHostDaemon).toEqual({ httpPort: 8974, register })
+    expect(starts[0]?.currentHostDaemon).toEqual({ httpPort: 8974, register, deregister })
   })
 
   test('omits currentHostDaemon when the daemon does not supply one', async () => {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -3258,8 +3258,87 @@ describe('start (composition)', () => {
     }
   })
 
-  test('currentHostDaemon registers in-process and injects the hostd env triple without any socket RPC', async () => {
-    // given: a daemon-owned restart supplies its own httpPort + in-process registrar
+  test.each(['build', 'models'] as const)(
+    'refreshes hostd only after build and model provisioning when %s finishes first',
+    async (firstToFinish) => {
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: '^0.1.0' })
+      await writeTypeclawConfig(root)
+      const docker = fakeDockerExec({ imageExists: false, container: { exists: false } })
+      const buildGate = Promise.withResolvers<void>()
+      const buildStarted = Promise.withResolvers<void>()
+      const modelsGate = Promise.withResolvers<void>()
+      const buildFinished = Promise.withResolvers<void>()
+      const modelsStarted = Promise.withResolvers<void>()
+      const initialRegistration = Promise.withResolvers<void>()
+      const modelsFinished = Promise.withResolvers<void>()
+      const events: string[] = []
+      const registrations: HostDaemonRegisterPayload[] = []
+      const exec: DockerExec = async (args, options) => {
+        if (isBuildCall(args)) {
+          events.push('build-started')
+          buildStarted.resolve()
+          await buildGate.promise
+          events.push('build-finished')
+          buildFinished.resolve()
+        }
+        if (args[0] === 'run') events.push('docker-run')
+        return await docker.exec(args, options)
+      }
+
+      const startPromise = start({
+        cwd: root,
+        preferredHostPort: 8973,
+        exec,
+        allocatePort: deterministicAllocator,
+        cliEntry: '/placeholder/cli.ts',
+        reuseCurrentHostDaemon: true,
+        currentHostDaemon: {
+          httpPort: 49999,
+          register: async (payload) => {
+            registrations.push(payload)
+            events.push(registrations.length === 1 ? 'registration-before-work' : 'registration-at-launch')
+            if (registrations.length === 1) initialRegistration.resolve()
+            return { ok: true }
+          },
+          deregister: async () => {},
+        },
+        ensureDeps: noEnsureDeps,
+        ensureModels: async () => {
+          events.push('models-started')
+          modelsStarted.resolve()
+          await modelsGate.promise
+          events.push('models-ready')
+          modelsFinished.resolve()
+        },
+        verifyRunning: async () => ({ ok: true }),
+        archiveLogs: noArchiveLogs,
+        provisionGithubCliStore: noGithubCliProvision,
+        autoUpgrade: noAutoUpgrade,
+      })
+
+      await Promise.all([buildStarted.promise, modelsStarted.promise, initialRegistration.promise])
+      expect(registrations).toHaveLength(1)
+      const firstGate = firstToFinish === 'build' ? buildGate : modelsGate
+      const firstFinished = firstToFinish === 'build' ? buildFinished : modelsFinished
+      const secondGate = firstToFinish === 'build' ? modelsGate : buildGate
+      firstGate.resolve()
+      await firstFinished.promise
+      for (let pending = 0; pending < 5; pending += 1) await Promise.resolve()
+      expect(registrations).toHaveLength(1)
+
+      secondGate.resolve()
+      const result = await startPromise
+      expect(result.ok).toBe(true)
+      const launchRefresh = events.indexOf('registration-at-launch')
+      expect(launchRefresh).toBeGreaterThan(events.indexOf('build-finished'))
+      expect(launchRefresh).toBeGreaterThan(events.indexOf('models-ready'))
+      expect(events.slice(launchRefresh)).toEqual(['registration-at-launch', 'docker-run'])
+      expect(registrations).toHaveLength(2)
+    },
+  )
+
+  test('uses only replacement hostd tokens in the final docker run', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeTypeclawConfig(root)
@@ -3271,7 +3350,7 @@ describe('start (composition)', () => {
       preferredHostPort: 8973,
       exec,
       allocatePort: deterministicAllocator,
-      cliEntry: '/nonexistent/cli.ts',
+      cliEntry: '/placeholder/cli.ts',
       reuseCurrentHostDaemon: true,
       currentHostDaemon: {
         httpPort: 49999,
@@ -3279,83 +3358,137 @@ describe('start (composition)', () => {
           registered.push(payload)
           return { ok: true }
         },
+        deregister: async () => {},
       },
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
     if (!result.ok) return
-    expect(result.hostd.state).toBe('registered')
-    // then: the container is registered in-process (not over a socket)
-    expect(registered).toHaveLength(1)
-    expect(registered[0]).toMatchObject({ containerName: basename(root), cwd: root, wsHostPort: 8973 })
-    // then: the env triple points at the daemon's own http port
-    expect(result.plan.runArgs).toContain('TYPECLAW_HOSTD_URL=http://host.docker.internal:49999')
-    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_TOKEN=${registered[0]!.restartToken}`)
-    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_BROKER_TOKEN=${registered[0]!.brokerToken}`)
+    expect(registered).toHaveLength(2)
+    const [staleRegistration, launchRegistration] = registered
+    expect(launchRegistration).toBeDefined()
+    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_TOKEN=${launchRegistration!.restartToken}`)
+    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_BROKER_TOKEN=${launchRegistration!.brokerToken}`)
+    expect(result.plan.runArgs).not.toContain(`TYPECLAW_HOSTD_TOKEN=${staleRegistration!.restartToken}`)
+    expect(result.plan.runArgs).not.toContain(`TYPECLAW_HOSTD_BROKER_TOKEN=${staleRegistration!.brokerToken}`)
   })
 
-  test('currentHostDaemon register failure still boots the container (degraded, never dead)', async () => {
-    // given: in-process registration fails — the daemon-owned restart must not strand the agent
+  test('aborts before docker run and removes the initial registration when the launch refresh cannot be planned', async () => {
+    const previousHome = process.env.TYPECLAW_HOME
+    const home = await mkdtemp(join(tmpdir(), 'typeclaw-launch-refresh-'))
+    let daemon: Daemon | null = null
+    try {
+      process.env.TYPECLAW_HOME = home
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: '^0.1.0' })
+      await writeTypeclawConfig(root)
+      daemon = await startDaemon({ version: 'test-version', gcIntervalMs: 1_000_000 })
+      const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+      const result = await start({
+        cwd: root,
+        preferredHostPort: 8973,
+        exec,
+        allocatePort: deterministicAllocator,
+        cliEntry: '/placeholder/cli.ts',
+        reuseCurrentHostDaemon: true,
+        ensureDeps: noEnsureDeps,
+        autoUpgrade: noAutoUpgrade,
+        ensureModels: async () => {
+          await writeFile(join(root, 'typeclaw.json'), '{ not-json')
+        },
+        verifyRunning: async () => ({ ok: true }),
+        archiveLogs: noArchiveLogs,
+        provisionGithubCliStore: noGithubCliProvision,
+      })
+
+      expect(result.ok).toBe(false)
+      expect(calls.some((call) => call.args[0] === 'run')).toBe(false)
+      expect(daemon.registered()).not.toContain(basename(root))
+    } finally {
+      if (daemon) await daemon.stop().catch(() => {})
+      if (previousHome === undefined) delete process.env.TYPECLAW_HOME
+      else process.env.TYPECLAW_HOME = previousHome
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  test('launches without hostd control when the launch refresh is unavailable', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeTypeclawConfig(root)
     const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    let registrations = 0
+    const deregistrations: string[] = []
 
     const result = await start({
       cwd: root,
       preferredHostPort: 8973,
       exec,
       allocatePort: deterministicAllocator,
-      cliEntry: '/nonexistent/cli.ts',
-      reuseCurrentHostDaemon: true,
-      currentHostDaemon: {
-        httpPort: 49999,
-        register: async () => ({ ok: false, reason: 'daemon stopping' }),
-      },
-      ensureDeps: noEnsureDeps,
-      ...bypassVerify,
-    })
-
-    // then: the container still launches, but without the hostd env triple
-    expect(result.ok).toBe(true)
-    if (!result.ok) return
-    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'daemon stopping' })
-    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
-    expect(result.plan.runArgs.find((a) => a.startsWith('TYPECLAW_HOSTD_URL='))).toBeUndefined()
-  })
-
-  test('a throwing in-process registrar degrades to a booting container, never aborts the restart', async () => {
-    // given: the in-process registrar rejects (e.g. a throw from the shared registration path)
-    await writeDockerfile(root)
-    await writePackageJson(root, { typeclaw: '^0.1.0' })
-    await writeTypeclawConfig(root)
-    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
-
-    const result = await start({
-      cwd: root,
-      preferredHostPort: 8973,
-      exec,
-      allocatePort: deterministicAllocator,
-      cliEntry: '/nonexistent/cli.ts',
+      cliEntry: '/placeholder/cli.ts',
       reuseCurrentHostDaemon: true,
       currentHostDaemon: {
         httpPort: 49999,
         register: async () => {
-          throw new Error('registry write failed')
+          registrations += 1
+          return registrations === 1 ? { ok: true } : { ok: false, reason: 'registration-unavailable' }
+        },
+        deregister: async (containerName) => {
+          deregistrations.push(containerName)
         },
       },
       ensureDeps: noEnsureDeps,
       ...bypassVerify,
     })
 
-    // then: the throw is normalized to a degraded boot, not an aborted start
     expect(result.ok).toBe(true)
     if (!result.ok) return
-    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registry write failed' })
-    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
-    expect(result.plan.runArgs.find((a) => a.startsWith('TYPECLAW_HOSTD_URL='))).toBeUndefined()
+    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registration-unavailable' })
+    expect(calls.find((call) => call.args[0] === 'run')).toBeDefined()
+    expect(result.plan.runArgs.some((arg) => arg.includes('TYPECLAW_HOSTD_'))).toBe(false)
+    expect(deregistrations).toEqual([basename(root)])
+  })
+
+  test('launches without hostd control when the in-process registrar throws at the launch boundary', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    let registrations = 0
+    const deregistrations: string[] = []
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      cliEntry: '/placeholder/cli.ts',
+      reuseCurrentHostDaemon: true,
+      currentHostDaemon: {
+        httpPort: 49999,
+        register: async () => {
+          registrations += 1
+          if (registrations === 1) return { ok: true }
+          throw new Error('registration-unavailable')
+        },
+        deregister: async (containerName) => {
+          deregistrations.push(containerName)
+        },
+      },
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registration-unavailable' })
+    expect(calls.find((call) => call.args[0] === 'run')).toBeDefined()
+    expect(result.plan.runArgs.some((arg) => arg.includes('TYPECLAW_HOSTD_'))).toBe(false)
+    expect(deregistrations).toEqual([basename(root)])
   })
 
   test('forceBuild=false skips build entirely when image already exists', async () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -119,13 +119,14 @@ export type HostDaemonRegisterPayload = {
 }
 
 // Injected only on the daemon-owned restart path (reuseCurrentHostDaemon).
-// The daemon registers the container in-process and reports its own HTTP port,
-// so the restart skips the `http-info`/`register` self-RPCs — those round-trips
-// can time out under IPC congestion and silently drop the TYPECLAW_HOSTD_* env
-// triple, booting a container whose hostd-bridged adapters can't construct.
+// The daemon updates the container registration in-process and reports its own
+// HTTP port, so restart lifecycle changes skip socket self-RPCs — those
+// round-trips can time out under IPC congestion and silently drop the
+// TYPECLAW_HOSTD_* env triple or leave stale broker state behind.
 export type CurrentHostDaemon = {
   httpPort: number
   register: (payload: HostDaemonRegisterPayload) => Promise<{ ok: true } | { ok: false; reason: string }>
+  deregister: (containerName: string) => Promise<void>
 }
 
 export type StartOptions = {
@@ -140,9 +141,10 @@ export type StartOptions = {
   // Hostd's supervisor restart callback already runs inside the daemon process.
   // Reusing that daemon avoids a self-shutdown when disk source has drifted.
   reuseCurrentHostDaemon?: boolean
-  // Set by hostd's supervisor restart wrapper. When present, registration goes
-  // through the daemon in-process (no socket round-trips), so the env triple is
-  // injected from known-good values even under IPC congestion. See type docs.
+  // Set by hostd's supervisor restart wrapper. When present, registration
+  // lifecycle changes go through the daemon in-process (no socket round-trips),
+  // so known-good control values and rollback survive IPC congestion.
+  // See type docs.
   currentHostDaemon?: CurrentHostDaemon
   ensureDeps?: (cwd: string, opts?: { force?: boolean }) => Promise<EnsureDepsResult>
   // Test seam for host embedding model provisioning. Production callers use
@@ -573,6 +575,44 @@ async function runStart({
         ok: false,
         reason: `embedding model unavailable; ensure network access on first start or a populated model cache: ${error instanceof Error ? error.message : String(error)}`,
       }
+    }
+
+    // The build and model provisioning above can outlive a hostd registration.
+    // Refresh both the registry entry and the launch plan at the run boundary:
+    // a broker restart may have invalidated the initial control tokens while
+    // those pre-run steps were in flight. Keep that early registration because
+    // it remains the cleanup target for build/model failures.
+    const initialHostd = hostd
+    try {
+      if (cliEntry) {
+        const refreshedHostd = await registerWithDaemon({
+          cwd,
+          containerName,
+          cliEntry,
+          hostPort,
+          reuseCurrentHostDaemon,
+          currentHostDaemon,
+        })
+        if (refreshedHostd.state !== 'registered') {
+          await cleanupHostDaemonRegistration(containerName, initialHostd)
+        }
+        hostd = refreshedHostd
+        hostdControl = refreshedHostd.state === 'registered' ? refreshedHostd.control : undefined
+        plan = await planStart({
+          cwd,
+          hostPort,
+          imageExists: true,
+          forceBuild: false,
+          hostdControl,
+          publishHost,
+          tuiToken,
+          platform,
+          hostIdentity,
+        })
+      }
+    } catch (error) {
+      await cleanupHostDaemonRegistration(containerName, hostd.state === 'registered' ? hostd : initialHostd)
+      return { ok: false, reason: error instanceof Error ? error.message : String(error) }
     }
 
     let run = await execRunWithConflictRetry(exec, plan.runArgs, cwd, containerName, archiveBeforeRemove)
@@ -1448,6 +1488,7 @@ async function registerWithDaemon({
     return {
       state: 'registered',
       control: { url: `http://${CONTAINER_HOSTD_HOST}:${currentHostDaemon.httpPort}`, token, brokerToken },
+      deregister: (registeredContainerName) => currentHostDaemon.deregister(registeredContainerName),
     }
   }
 
@@ -1458,6 +1499,9 @@ async function registerWithDaemon({
   return {
     state: 'registered',
     control: { url: `http://${CONTAINER_HOSTD_HOST}:${prepared.httpPort}`, token, brokerToken },
+    deregister: async (registeredContainerName) => {
+      await sendToDaemon({ kind: 'deregister', containerName: registeredContainerName })
+    },
   }
 }
 
@@ -1492,7 +1536,7 @@ async function useCurrentHostDaemon(): Promise<{ ok: true; httpPort: number } | 
 }
 
 type PreparedHostDaemonStatus =
-  | { state: 'registered'; control: HostDaemonControl }
+  | { state: 'registered'; control: HostDaemonControl; deregister: (containerName: string) => Promise<void> }
   | { state: 'unavailable'; reason: string }
   | { state: 'disabled' }
 
@@ -1503,7 +1547,7 @@ function stripHostDaemonControl(status: PreparedHostDaemonStatus): HostDaemonSta
 
 async function cleanupHostDaemonRegistration(containerName: string, status: PreparedHostDaemonStatus): Promise<void> {
   if (status.state !== 'registered') return
-  await sendToDaemon({ kind: 'deregister', containerName }).catch(() => {})
+  await status.deregister(containerName).catch(() => {})
 }
 
 // process.env.TZ is honored first because users who explicitly set it (e.g.

--- a/src/hostd/current-host-daemon.test.ts
+++ b/src/hostd/current-host-daemon.test.ts
@@ -8,7 +8,11 @@ describe('createCurrentHostDaemonHolder', () => {
   test('ready() resolves with the value once set, even when awaited before set', async () => {
     // given: a caller awaits ready() before the daemon has booted
     const holder = createCurrentHostDaemonHolder()
-    const value: CurrentHostDaemon = { httpPort: 8974, register: async () => ({ ok: true }) }
+    const value: CurrentHostDaemon = {
+      httpPort: 8974,
+      register: async () => ({ ok: true }),
+      deregister: async () => {},
+    }
     const pending = holder.ready()
 
     // when: the daemon populates the holder after boot
@@ -20,7 +24,11 @@ describe('createCurrentHostDaemonHolder', () => {
 
   test('ready() resolves immediately when set has already happened', async () => {
     const holder = createCurrentHostDaemonHolder()
-    const value: CurrentHostDaemon = { httpPort: 49999, register: async () => ({ ok: true }) }
+    const value: CurrentHostDaemon = {
+      httpPort: 49999,
+      register: async () => ({ ok: true }),
+      deregister: async () => {},
+    }
     holder.set(value)
 
     expect(await holder.ready()).toBe(value)

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -336,7 +336,7 @@ describe('startDaemon', () => {
     expect(restartCalls[0]?.currentHostDaemon?.httpPort).toBeGreaterThan(0)
   })
 
-  test('populates the currentHostDaemon holder with an in-process registrar once booted', async () => {
+  test('populates the currentHostDaemon holder with in-process registration lifecycle callbacks', async () => {
     const holder = createCurrentHostDaemonHolder()
     daemon = await startDaemon({
       exec: fakeExec(),
@@ -344,7 +344,7 @@ describe('startDaemon', () => {
       currentHostDaemonHolder: holder,
     })
 
-    // then: the holder is populated and its registrar records a registration in-process
+    // then: the holder's callbacks mutate registration state in-process
     const current = await holder.ready()
     expect(current.httpPort).toBeGreaterThan(0)
     const reply = await current.register({
@@ -357,6 +357,9 @@ describe('startDaemon', () => {
     })
     expect(reply).toEqual({ ok: true })
     expect(daemon.registered()).toContain('coder')
+
+    await current.deregister('coder')
+    expect(daemon.registered()).not.toContain('coder')
   })
 
   test('restart RPC forwards build:true to the supervisor', async () => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -500,15 +500,20 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     return { ok: true, result }
   }
 
-  // Lets the supervisor's restart re-register the child in-process instead of
-  // over the socket. Awaits restore for the same no-mutation-before-restore
-  // invariant the socket dispatcher enforces before handleRegister.
+  // Lets the supervisor's restart update child registration lifecycle
+  // in-process instead of over the socket. Both callbacks await restore for
+  // the same no-mutation-before-restore invariant as the socket dispatcher.
   const registerCurrentChild = async (
     payload: HostDaemonRegisterPayload,
   ): Promise<{ ok: true } | { ok: false; reason: string }> => {
     await awaitRestored()
     const reply = await registerContainer(payload)
     return reply.ok ? { ok: true } : { ok: false, reason: reply.reason }
+  }
+
+  const deregisterCurrentChild = async (containerName: string): Promise<void> => {
+    await awaitRestored()
+    await handleDeregister({ containerName })
   }
 
   // Auth: only restart containers that registered with this daemon. The
@@ -531,7 +536,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       containerName: req.containerName,
       cwd,
       build: req.build,
-      currentHostDaemon: { httpPort, register: registerCurrentChild },
+      currentHostDaemon: { httpPort, register: registerCurrentChild, deregister: deregisterCurrentChild },
     })
     if (!ack.ok) return ack
     const result: RestartResult = { containerName: req.containerName, scheduled: true }
@@ -790,7 +795,11 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
   httpPort = httpServer.port ?? 0
   log({ kind: 'daemon-http-listening', host: httpHostname, port: httpPort })
-  opts.currentHostDaemonHolder?.set({ httpPort, register: registerCurrentChild })
+  opts.currentHostDaemonHolder?.set({
+    httpPort,
+    register: registerCurrentChild,
+    deregister: deregisterCurrentChild,
+  })
 
   const sockets = new Set<NetSocket>()
   const listener = createServer((socket) => {

--- a/src/run/channel-session-factory.test.ts
+++ b/src/run/channel-session-factory.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdtempSync } from 'node:fs'
+import { describe, expect, mock, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,14 +7,29 @@ import { SessionManager } from '@mariozechner/pi-coding-agent'
 import type { AgentSession } from '@mariozechner/pi-coding-agent'
 
 import type { CreateSessionOptions } from '@/agent'
-import type { ChannelRouter } from '@/channels'
+import * as realCapJsonlModule from '@/bundled-plugins/tool-result-cap/cap-jsonl'
+import {
+  capJsonlFileInPlace as realCapJsonlFileInPlace,
+  type CapJsonlStats,
+} from '@/bundled-plugins/tool-result-cap/cap-jsonl'
+import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
+import type { ChannelRouter, CreateSessionForChannel } from '@/channels'
 import type { ReloadRegistry } from '@/reload'
 import type { SessionFactory } from '@/sessions'
 import type { Stream } from '@/stream'
 
-import { buildChannelSessionFactory } from './channel-session-factory'
 import { createPluginRuntime, type PluginRuntime } from './plugin-runtime'
 
+let capJsonlFileInPlace = realCapJsonlFileInPlace
+
+mock.module('@/bundled-plugins/tool-result-cap/cap-jsonl', () => ({
+  ...realCapJsonlModule,
+  capJsonlFileInPlace: (path: string, options: CapOptions): CapJsonlStats => capJsonlFileInPlace(path, options),
+}))
+
+// The factory must load after the cap module mock so the test can model the
+// file race between the pre-open cap and SessionManager.open.
+const { buildChannelSessionFactory } = await import('./channel-session-factory')
 function makeFakeRouter(): ChannelRouter {
   return {} as ChannelRouter
 }
@@ -51,11 +66,97 @@ function makeRuntimeWithPlugin(): PluginRuntime {
     pluginSubagentByShim: new WeakMap(),
     hasAnyPluginContent: true,
     loadedPlugins: [{ name: 'memory', version: undefined, source: '<bundled>' }],
+
     materializedSkills: null,
   })
 }
 
+function writePersistedSession(sessionDir: string, sessionFile: string, sessionId: string): void {
+  mkdirSync(sessionDir, { recursive: true })
+  writeFileSync(
+    join(sessionDir, sessionFile),
+    `${JSON.stringify({
+      type: 'session',
+      id: sessionId,
+      timestamp: '2026-01-01T00:00:00Z',
+      cwd: sessionDir,
+      version: 3,
+    })}\n`,
+  )
+}
+
+function codedError(code: string, message: string, cause?: unknown): Error {
+  const error = new Error(message, cause === undefined ? undefined : { cause })
+  Object.defineProperty(error, 'code', { value: code })
+  return error
+}
+
 const STUB_SESSION = { dispose: () => {} } as unknown as AgentSession
+
+const CHANNEL_KEY = {
+  adapter: 'discord-bot' as const,
+  workspace: '@dm',
+  chat: 'c1',
+  thread: null,
+}
+
+const CHANNEL_ORIGIN = {
+  kind: 'channel' as const,
+  ...CHANNEL_KEY,
+  participants: [],
+}
+
+const REHYDRATE_CAP_OPTIONS: CapOptions = {
+  imageMaxBytes: 100,
+  textMaxBytes: 100,
+}
+
+type RehydrateHarness = {
+  factory: CreateSessionForChannel
+  warnings: string[]
+}
+
+function makeRehydrateHarness(
+  cwd: string,
+  rehydrateCapOptions: CapOptions | null = REHYDRATE_CAP_OPTIONS,
+): RehydrateHarness {
+  const warnings: string[] = []
+  const factory = buildChannelSessionFactory({
+    cwd,
+    sessionFactory: makeFakeSessionFactory(join(cwd, 'sessions')),
+    stream: makeFakeStream(),
+    reloadRegistry: makeFakeReloadRegistry(),
+    pluginRuntime: makeEmptyRuntime(),
+    getChannelRouter: makeFakeRouter,
+    createSession: async function createStubSession(): Promise<AgentSession> {
+      return STUB_SESSION
+    },
+    rehydrateCapOptions,
+    logger: {
+      info: function ignoreInfo() {},
+      warn: function captureWarning(message: string) {
+        warnings.push(message)
+      },
+    },
+  })
+  return { factory, warnings }
+}
+
+async function rehydrateChannelSession(
+  factory: CreateSessionForChannel,
+  existingSessionId: string,
+  existingSessionFile: string,
+): Promise<string> {
+  const result = await factory({
+    key: CHANNEL_KEY,
+    existingSessionId,
+    existingSessionFile,
+    participants: [],
+    origin: CHANNEL_ORIGIN,
+    originRef: { current: undefined },
+  })
+  return result.sessionId
+}
 
 type Captured = CreateSessionOptions | undefined
 
@@ -481,6 +582,179 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
 
     expect(readFileSync(bystander, 'utf8')).toBe(bystanderContent)
     expect(existsSync(join(sessionDir, '../bystander.jsonl.cap.tmp'))).toBe(false)
-    expect(warnLogs.some((l) => l.includes('invalid sessionFile'))).toBe(true)
+    expect(warnLogs).toContain('[channels] persisted session file is invalid; creating new')
+  })
+
+  test('suppresses an ENOENT cap race when the persisted session opens', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    writePersistedSession(join(tmp, 'sessions'), 'persisted.jsonl', 'persisted-session')
+    const originalCap = capJsonlFileInPlace
+    capJsonlFileInPlace = () => {
+      throw new Error('wrapper', { cause: codedError('ENOENT', 'private missing path') })
+    }
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      const sessionId = await rehydrateChannelSession(factory, 'persisted-session', 'persisted.jsonl')
+      expect(sessionId).toBe('persisted-session')
+      expect(warnings).toEqual([])
+    } finally {
+      capJsonlFileInPlace = originalCap
+    }
+  })
+
+  test('self-heals a missing transcript after an ENOENT cap without warning', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const originalCap = capJsonlFileInPlace
+    capJsonlFileInPlace = () => {
+      throw new Error('wrapper', { cause: codedError('ENOENT', 'private missing path') })
+    }
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      const sessionId = await rehydrateChannelSession(factory, 'missing-session', 'missing.jsonl')
+      expect(sessionId).not.toBe('missing-session')
+      expect(warnings).toEqual([])
+    } finally {
+      capJsonlFileInPlace = originalCap
+    }
+  })
+
+  test('warns for a non-ENOENT cap failure while reopening the session', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    writePersistedSession(join(tmp, 'sessions'), 'persisted.jsonl', 'persisted-session')
+    const originalCap = capJsonlFileInPlace
+    capJsonlFileInPlace = () => {
+      throw new Error('wrapper', { cause: codedError('EIO', 'private storage failure') })
+    }
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      const sessionId = await rehydrateChannelSession(factory, 'persisted-session', 'persisted.jsonl')
+      expect(sessionId).toBe('persisted-session')
+      expect(warnings).toEqual(['[channels] rehydrate-cap unavailable; continuing with open'])
+    } finally {
+      capJsonlFileInPlace = originalCap
+    }
+  })
+
+  test('self-heals a non-ENOENT open failure with a distinct warning', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    writePersistedSession(join(tmp, 'sessions'), 'persisted.jsonl', 'persisted-session')
+    const originalOpen = SessionManager.open
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw codedError('EIO', 'private open failure')
+      },
+      writable: true,
+    })
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp, null)
+      const sessionId = await rehydrateChannelSession(factory, 'persisted-session', 'persisted.jsonl')
+      expect(sessionId).not.toBe('persisted-session')
+      expect(warnings).toEqual(['[channels] persisted session rehydrate failed; creating new'])
+    } finally {
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+    }
+  })
+
+  test('self-heals a nested ENOENT open failure with an unavailable-file warning', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const originalOpen = SessionManager.open
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw new Error('wrapper', { cause: codedError('ENOENT', 'private open path') })
+      },
+      writable: true,
+    })
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp, null)
+      const sessionId = await rehydrateChannelSession(factory, 'missing-session', 'missing.jsonl')
+      expect(sessionId).not.toBe('missing-session')
+      expect(warnings).toEqual(['[channels] persisted session file unavailable; creating new'])
+    } finally {
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+    }
+  })
+
+  test('propagates fresh-session creation failures after rehydration fails', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const originalOpen = SessionManager.open
+    const originalCreate = SessionManager.create
+    const createFailure = codedError('ENOSPC', 'private create failure')
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw codedError('ENOENT', 'private open failure')
+      },
+      writable: true,
+    })
+    Object.defineProperty(SessionManager, 'create', {
+      configurable: true,
+      value: () => {
+        throw createFailure
+      },
+      writable: true,
+    })
+    try {
+      const { factory } = makeRehydrateHarness(tmp, null)
+      await expect(rehydrateChannelSession(factory, 'missing-session', 'missing.jsonl')).rejects.toBe(createFailure)
+    } finally {
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+      Object.defineProperty(SessionManager, 'create', {
+        configurable: true,
+        value: originalCreate,
+        writable: true,
+      })
+    }
+  })
+
+  test('sanitizes fallback warnings', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const sessionId = 'private-session-identifier'
+    const sessionFile = 'private-session-file.jsonl'
+    const privateDetail = 'private-path-and-error-detail'
+    writePersistedSession(join(tmp, 'sessions'), sessionFile, sessionId)
+    const originalCap = capJsonlFileInPlace
+    const originalOpen = SessionManager.open
+    capJsonlFileInPlace = () => {
+      throw codedError('EIO', privateDetail)
+    }
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw codedError('EIO', privateDetail)
+      },
+      writable: true,
+    })
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      await rehydrateChannelSession(factory, sessionId, sessionFile)
+      expect(warnings).toEqual([
+        '[channels] rehydrate-cap unavailable; continuing with open',
+        '[channels] persisted session rehydrate failed; creating new',
+      ])
+      expect(warnings.join('\n')).not.toContain(sessionId)
+      expect(warnings.join('\n')).not.toContain(sessionFile)
+      expect(warnings.join('\n')).not.toContain(privateDetail)
+    } finally {
+      capJsonlFileInPlace = originalCap
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+    }
   })
 })

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -89,6 +89,21 @@ function isValidSessionFileBasename(name: string): boolean {
   return name.endsWith('.jsonl')
 }
 
+function errorChainHasCode(error: unknown, expectedCode: string): boolean {
+  const seen = new Set<object>()
+  let current = error
+  while (typeof current === 'object' && current !== null && !seen.has(current)) {
+    seen.add(current)
+    try {
+      if ('code' in current && current.code === expectedCode) return true
+      current = 'cause' in current ? current.cause : undefined
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
 // The production wiring for channel-routed sessions. Channel inbounds arrive
 // at the router, the router calls this factory to get an AgentSession, and
 // the agent uses `channel_send` to reply. If `channelRouter` is missing here
@@ -103,14 +118,7 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
     const sessionDir = deps.sessionFactory.sessionDir()
     const sessionManager =
       existingSessionId !== undefined
-        ? tryReopenOrCreate(
-            deps.cwd,
-            sessionDir,
-            existingSessionId,
-            existingSessionFile,
-            deps.rehydrateCapOptions,
-            logger,
-          )
+        ? tryReopenOrCreate(deps.cwd, sessionDir, existingSessionFile, deps.rehydrateCapOptions, logger)
         : SessionManager.create(deps.cwd, sessionDir)
 
     const snap = deps.pluginRuntime.get()
@@ -175,21 +183,16 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
 function tryReopenOrCreate(
   cwd: string,
   sessionDir: string,
-  existingSessionId: string,
   existingSessionFile: string | undefined,
   capOptions: CapOptions | null,
   logger: FactoryLogger,
 ): SessionManager {
   if (existingSessionFile === undefined) {
-    logger.warn(
-      `[channels] session ${existingSessionId} has no sessionFile (v2 mapping not yet migrated); creating new`,
-    )
+    logger.warn('[channels] persisted session has no session file; creating new')
     return SessionManager.create(cwd, sessionDir)
   }
   if (!isValidSessionFileBasename(existingSessionFile)) {
-    logger.warn(
-      `[channels] session ${existingSessionId} has invalid sessionFile (${JSON.stringify(existingSessionFile)}); creating new`,
-    )
+    logger.warn('[channels] persisted session file is invalid; creating new')
     return SessionManager.create(cwd, sessionDir)
   }
   const path = join(sessionDir, existingSessionFile)
@@ -198,23 +201,27 @@ function tryReopenOrCreate(
       const stats = capJsonlFileInPlace(path, capOptions)
       if (stats.entriesMutated > 0) {
         logger.info(
-          `[channels] rehydrate-cap ${existingSessionFile}: entriesMutated=${stats.entriesMutated} imagesReplaced=${stats.imagesReplaced} textsTruncated=${stats.textsTruncated} bytesElided=${stats.bytesElided}`,
+          `[channels] rehydrate-cap complete: entriesMutated=${stats.entriesMutated} imagesReplaced=${stats.imagesReplaced} textsTruncated=${stats.textsTruncated} bytesElided=${stats.bytesElided}`,
         )
       }
     } catch (err) {
       // Capping is best-effort: if the rewrite fails, fall through to the
       // regular open path so the session still rehydrates uncapped rather
-      // than being killed by a transient FS error.
-      const reason = err instanceof Error ? err.message : String(err)
-      logger.warn(`[channels] rehydrate-cap failed for ${existingSessionFile}: ${reason}; continuing with open`)
+      // than being killed by a transient FS error. Missing files are expected
+      // during concurrent cleanup; open either creates a fresh transcript or
+      // reaches the fallback below.
+      if (!errorChainHasCode(err, 'ENOENT')) {
+        logger.warn('[channels] rehydrate-cap unavailable; continuing with open')
+      }
     }
   }
   try {
     return SessionManager.open(path)
   } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err)
     logger.warn(
-      `[channels] could not rehydrate session ${existingSessionId} from ${existingSessionFile}: ${reason}; creating new`,
+      errorChainHasCode(err, 'ENOENT')
+        ? '[channels] persisted session file unavailable; creating new'
+        : '[channels] persisted session rehydrate failed; creating new',
     )
     return SessionManager.create(cwd, sessionDir)
   }


### PR DESCRIPTION
## Background

Three independent lifecycle races could turn expected transient states into stale control data or failed recovery:

- Container start registered with hostd before a cold image build and model provisioning. Hostd garbage collection could remove that registration while no container existed, leaving the later launch plan with expired control tokens.
- Backup converted porcelain status to a path-only list. An ordinary untracked file disappearing between `git status` and explicit `git add` aborted the whole backup; a blanket existence filter would incorrectly drop tracked deletions.
- A persisted channel mapping can outlive its JSONL transcript. The pre-open cap pass reported missing files as path-bearing warnings even though session open/fallback already self-heals and the router persists the replacement session.

These fixes are not the only conceivable designs. Deferring all hostd registration or adding leases would require a wider lifecycle/protocol change; broad Git staging would admit concurrent work; filesystem preflight checks would retain the same TOCTOU window. This PR uses the narrowest changes that preserve the existing cleanup, explicit-snapshot, and best-effort-rehydrate contracts.

## Summary

- Refresh hostd registration and rebuild the launch plan after build/model work, immediately before `docker run`. Carry source-appropriate deregistration so daemon-owned restarts can roll back in-process without a socket self-RPC. If the refresh is unavailable, preserve the existing degraded launch behavior but remove hostd control from the final argv.
- Parse NUL-delimited porcelain status into tracked/untracked entries, preserve tracked deletions and rename endpoints, and stage only the original snapshot. If the first ordinary add fails and a previously observed untracked path is now proven absent, retry once without that path; never admit paths discovered by the reread.
- Classify nested `ENOENT` causes during channel rehydrate. Missing-file cap races stay silent, other cap/open failures use fixed privacy-safe warnings, and fresh-session creation errors still propagate.
- Add anonymous regressions for build/model completion ordering, token replacement, in-process rollback, managed-path deletion, no-scope-widening backup retry, and rehydrate warning/fallback branches.

## What this does NOT do

- Does not change hostd GC timing or add a lease/heartbeat protocol.
- Does not switch backup to `git add -A`, `git add -u`, or any repository-wide staging command.
- Does not delete channel mappings on a preflight existence check or change poisoned-session self-healing.
- Does not address Docker log archive limits or unrelated runtime warnings.

## Review notes

- Hostd: the final plan contains only replacement tokens; deferred tests exercise both build-first and model-first completion orders. In-process registration and deregistration share the daemon's per-container serialization.
- Backup: reread status is evidence for removing vanished original untracked paths only. Tracked deletions remain stageable even when absent; present `sessions/` and `todo/` paths retain force-add behavior.
- Channels: `SessionManager.open` may itself create a fresh transcript for an absent file; the explicit thrown-`ENOENT` branch is also covered. The router's existing write-after-factory behavior remains responsible for replacing the durable mapping.