### PR TITLE
Fix compose restart failing on absent containers

### DIFF
--- a/src/container/stop.test.ts
+++ b/src/container/stop.test.ts
@@ -282,6 +282,21 @@ describe('stop (composition)', () => {
     expect(calls.find((c) => c[0] === 'rm')).toBeUndefined()
   })
 
+  test('treats docker inspect "no such object" as an absent container', async () => {
+    const { exec, calls } = fakeDockerExec({
+      scenario: { exists: false },
+      inspectExitCode: 1,
+      inspectStderr: 'Error: No such object: anderson',
+    })
+
+    const result = await stop({ cwd: root, exec, archiveLogs })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.running).toBe(false)
+    expect(calls.some((call) => call[0] === 'stop' || call[0] === 'rm')).toBe(false)
+  })
+
   test('archives after graceful stop and before removal, targeting the inspected ID', async () => {
     const { exec, calls } = fakeDockerExec({ scenario: { exists: true, running: true } })
     const orderedArchive = async ({ containerId }: { containerId: string }) => {

--- a/src/container/stop.ts
+++ b/src/container/stop.ts
@@ -8,6 +8,7 @@ import {
   containerNameFromCwd,
   defaultDockerExec,
   type DockerExec,
+  isGenuineMissingContainer,
   parseContainerInspectOutput,
   sanitizeDockerStderr,
   waitForRemoval,
@@ -58,7 +59,7 @@ async function runStop({
       // `docker inspect` exits non-zero both when the container does not
       // exist AND when it exists but is in a transient state docker cannot
       // inspect (Removal In Progress, Dead, daemon hiccup). Discriminate by
-      if (inspect.stderr.toLowerCase().includes('no such container')) {
+      if (isGenuineMissingContainer(inspect.stderr)) {
         return { ok: true, containerName, running: false }
       }
       return {


### PR DESCRIPTION
## Background

`typeclaw compose restart` stops each configured agent's container before starting it again. `stop()` discriminates a genuinely-absent container from a transient inspect failure (Removal In Progress, Dead, daemon hiccup) by checking `docker inspect`'s stderr for `no such container` — anything else is treated as a real error and surfaced.

For an agent that has never been started, or whose container was already removed, Docker's actual response is `Error: No such object: <name>`, not `No such container`. That message is docker's canonical "the referenced object doesn't exist" phrasing, distinct from `no such container` which docker also emits in other contexts. `stop()`'s narrower check missed it, so restarting a never-started/absent agent's container failed with a spurious error instead of proceeding straight to start.

`start.ts` already discriminates the same failure correctly via `isGenuineMissingContainer()`, which checks both `no such container` and `no such object`. `stop.ts` had its own inline, narrower check instead of reusing that canonical classifier.

## Summary

`stop.ts` now calls the existing `isGenuineMissingContainer()` helper (already exported from `shared.ts` and already used by `start.ts`) instead of its own inline `no such container`-only check. No new classification logic — this reuses the classifier `start.ts` already relies on, so both call sites agree on what counts as "genuinely missing."

The archive-before-remove ordering and every other branch of `stop()` are unchanged; this only widens which inspect-failure messages are recognized as "container doesn't exist."

## What this does NOT do

- Does not change the transient-failure branch (Removal In Progress, Dead, daemon hiccup) — those still surface as errors, unchanged.
- Does not touch `start.ts`, which already had the correct check.
- Does not change archive-before-remove behavior or any other part of the stop/restart flow.

## Review notes

The load-bearing change is swapping the inline `inspect.stderr.toLowerCase().includes('no such container')` check for `isGenuineMissingContainer(inspect.stderr)` in `stop.ts`. Verify the new regression test (`treats docker inspect "no such object" as an absent container`) reflects docker's actual stderr shape for a never-started/absent container, and that no `stop`/`rm` calls are issued once it's classified as absent.

## Verification

- `bun run typecheck`
- `bun run lint` — 0 errors
- `bun run format:check`
- `bun run test` — 13,363 pass, 31 skip, 0 fail
- Oracle review: PASS