### PR TITLE
backup: reconcile vanished untracked snapshot paths

### DIFF
--- a/src/bundled-plugins/backup/README.md
+++ b/src/bundled-plugins/backup/README.md
@@ -38,10 +38,11 @@ If a new prompt arrives while the runner is in flight, the runner finishes its c
 
 ## What it commits
 
-The runner stages two categories of dirty paths:
+The runner stages an explicit snapshot from NUL-delimited porcelain status:
 
-- **Tracked or untracked agent paths** (anything `git status --porcelain=v1 --untracked-files=all` reports), **except** paths under `memory/` — those are owned by the memory plugin's dreaming subagent.
-- **Force-added `sessions/`** — gitignored, but force-added so transcripts survive across restarts.
+- **Tracked changes**, including deletions and both rename/copy endpoints, are staged even when an endpoint is no longer present on disk.
+- **Ordinary untracked paths** are staged only while still present. If one disappears between snapshot and `git add`, the runner re-reads status and retries that same snapshot once without the vanished path; paths discovered during that re-read are never added.
+- **`memory/`** remains excluded. Present **`sessions/` and `todo/`** paths remain force-added; tracked deletions under those prefixes stay in the ordinary snapshot. The post-message pass re-stages only `sessions/` paths that appeared while the message was selected.
 
 Commit message comes from the `backup-message` subagent, which sees a truncated `git status` and `git diff --cached --stat` and writes a single conventional-ish commit message to a tmp file. On any failure the runner falls back to `chore: backup`.
 

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { rmSync } from 'node:fs'
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -206,9 +207,10 @@ describe('runBackup', () => {
     const cwd = await makeRepo()
     await mkdir(join(cwd, 'sessions'))
     await writeFile(join(cwd, 'sessions', 'pre.jsonl'), '{}')
+    await mkdir(join(cwd, 'todo'))
 
     const firstStatus = '?? sessions/pre.jsonl\n M src/foo.ts\n'
-    const secondStatus = '?? sessions/pre.jsonl\n?? sessions/late.jsonl\n M src/foo.ts\n'
+    const secondStatus = '?? sessions/pre.jsonl\n?? sessions/late.jsonl\n?? todo/late.json\n M src/foo.ts\n'
     let statusCalls = 0
     let messagePicked = false
 
@@ -231,6 +233,7 @@ describe('runBackup', () => {
       pickCommitMessage: async () => {
         // when: simulate the late file appearing during message synthesis
         await writeFile(join(cwd, 'sessions', 'late.jsonl'), '{}')
+        await writeFile(join(cwd, 'todo', 'late.json'), '{}')
         messagePicked = true
         return 'chore: backup'
       },
@@ -252,6 +255,7 @@ describe('runBackup', () => {
     const lateAddPaths = addFCalls[1]?.args.slice(3) ?? []
     expect(lateAddPaths).toContain('sessions/late.jsonl')
     expect(lateAddPaths).toContain('sessions/pre.jsonl')
+    expect(lateAddPaths).not.toContain('todo/late.json')
 
     // and: there are exactly TWO status calls — one before staging, one after
     // pickCommitMessage returns. Asserting the count keeps a future "optimize"
@@ -531,19 +535,218 @@ describe('runBackup', () => {
     await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn, '   '))
     expect(captured).toBe('Backup')
   })
+  test('skips an ordinary untracked path that vanished before staging', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult('?? gone.txt\0')
+      return okResult()
+    })
+
+    const result = await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))
+
+    expect(result).toEqual({ ok: true, kind: 'clean' })
+    expect(calls.some((call) => call.args[0] === 'add')).toBe(false)
+  })
+
+  test('retries a failed explicit add once after an initial untracked path vanishes without widening scope', async () => {
+    const cwd = await makeRepo()
+    await writeFile(join(cwd, 'transient.txt'), 'temporary')
+    let statuses = 0
+    let adds = 0
+    let promptStatus = ''
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') {
+        statuses += 1
+        return okResult(statuses === 1 ? '?? transient.txt\0 M tracked.txt\0' : ' M tracked.txt\0?? later.txt\0')
+      }
+
+      if (args[0] === 'add' && args[1] === '--') {
+        adds += 1
+        if (adds === 1) {
+          rmSync(join(cwd, 'transient.txt'))
+          return failResult('pathspec did not match')
+        }
+        return okResult()
+      }
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    const result = await runBackup(
+      { cwd, pushToOrigin: false },
+      {
+        gitSpawn: spawn,
+        pickCommitMessage: async ({ status }) => {
+          promptStatus = status
+          return 'chore: test'
+        },
+      },
+    )
+
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    const ordinaryAdds = calls.filter((call) => call.args[0] === 'add' && call.args[1] === '--')
+    expect(ordinaryAdds).toHaveLength(2)
+    expect(ordinaryAdds[1]?.args).toEqual(['add', '--', 'tracked.txt'])
+    expect(ordinaryAdds[1]?.args).not.toContain('later.txt')
+    expect(calls.filter((call) => call.args[0] === 'status').every((call) => call.args.includes('-z'))).toBe(true)
+    expect(promptStatus).not.toContain('\0')
+  })
+
+  test('keeps a dangling untracked symlink stageable while dropping a path that vanishes after the status snapshot', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'autobackup-dangling-symlink-'))
+    const realGit = makeDefaultGitSpawn()
+    const runGit = async (args: string[]): Promise<GitSpawnResult> => {
+      const result = await realGit(args, { cwd, timeoutMs: 30_000 })
+      expect(result.exitCode).toBe(0)
+      return result
+    }
+
+    try {
+      await runGit(['init', '-q', '-b', 'main'])
+      await runGit(['config', 'user.name', 'Test'])
+      await runGit(['config', 'user.email', 'test@example.com'])
+      await writeFile(join(cwd, 'initial.txt'), 'initial\n')
+      await runGit(['add', 'initial.txt'])
+      await runGit(['commit', '-qm', 'initial'])
+      await symlink('missing-target', join(cwd, 'dangling-link'))
+      await writeFile(join(cwd, 'transient.txt'), 'temporary\n')
+
+      let removeBeforeFirstAdd = true
+      const result = await runBackup(
+        { cwd, pushToOrigin: false },
+        {
+          gitSpawn: async (args, opts) => {
+            if (removeBeforeFirstAdd && args[0] === 'add' && args[1] === '--') {
+              removeBeforeFirstAdd = false
+              await rm(join(cwd, 'transient.txt'))
+            }
+            return realGit(args, opts)
+          },
+          pickCommitMessage: async () => 'chore: preserve dangling symlink',
+        },
+      )
+
+      expect(result).toEqual({ ok: true, kind: 'committed' })
+      const tree = await runGit(['ls-tree', '-r', 'HEAD'])
+      expect(tree.stdout).toContain('120000 blob')
+      expect(tree.stdout).toContain('\tdangling-link\n')
+      expect(tree.stdout).not.toContain('transient.txt')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('stages both tracked rename endpoints from the original snapshot', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult('R  renamed.txt\0original.txt\0')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((call) => call.args[0] === 'add')?.args).toEqual(['add', '--', 'renamed.txt', 'original.txt'])
+  })
+
+  test('stages a tracked deletion even when its path is absent', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' D removed.txt\0')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((call) => call.args[0] === 'add')?.args).toEqual(['add', '--', 'removed.txt'])
+  })
+
+  test('stages a tracked force-path deletion through the ordinary snapshot', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' D sessions/removed.jsonl\0')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'diff' && args[2] === '--stat') return okResult()
+      if (args[0] === 'commit') return okResult()
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((call) => call.args[0] === 'add')?.args).toEqual(['add', '--', 'sessions/removed.jsonl'])
+    expect(calls.some((call) => call.args[0] === 'add' && call.args[1] === '-f')).toBe(false)
+  })
+
+  test('surfaces an unchanged explicit-add failure without retrying', async () => {
+    const cwd = await makeRepo()
+    await writeFile(join(cwd, 'still-here.txt'), 'present')
+    let statuses = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') {
+        statuses += 1
+        return okResult('?? still-here.txt\0')
+      }
+      if (args[0] === 'add') return failResult('permission denied')
+      return okResult()
+    })
+
+    const result = await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))
+
+    expect(result).toEqual({ ok: false, kind: 'commit-failed', reason: 'git add failed: permission denied' })
+    expect(statuses).toBe(2)
+    expect(calls.filter((call) => call.args[0] === 'add')).toHaveLength(1)
+  })
+
+  test('surfaces the retry failure after one reconciliation attempt', async () => {
+    const cwd = await makeRepo()
+    await writeFile(join(cwd, 'vanishing.txt'), 'present')
+    let statuses = 0
+    let adds = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') {
+        statuses += 1
+        return okResult(statuses === 1 ? '?? vanishing.txt\0 M tracked.txt\0' : ' M tracked.txt\0')
+      }
+      if (args[0] === 'add') {
+        adds += 1
+        if (adds === 1) {
+          rmSync(join(cwd, 'vanishing.txt'))
+          return failResult('first failure')
+        }
+        return failResult('retry failure')
+      }
+      return okResult()
+    })
+
+    expect(await runBackup({ cwd, pushToOrigin: false }, baseDeps(spawn))).toEqual({
+      ok: false,
+      kind: 'commit-failed',
+      reason: 'git add failed: retry failure',
+    })
+    expect(calls.filter((call) => call.args[0] === 'add')).toHaveLength(2)
+  })
 })
 
 describe('parsePorcelain', () => {
-  test('parses standard modified/added lines', () => {
-    expect(parsePorcelain(' M src/foo.ts\n?? bar.ts\n')).toEqual(['src/foo.ts', 'bar.ts'])
+  test('classifies tracked and untracked NUL-delimited records', () => {
+    expect(parsePorcelain(' M src/foo.ts\0?? bar.ts\0')).toEqual([
+      { status: ' M', kind: 'tracked', paths: ['src/foo.ts'] },
+      { status: '??', kind: 'untracked', paths: ['bar.ts'] },
+    ])
   })
 
-  test('returns the destination on rename lines', () => {
-    expect(parsePorcelain('R  old/path -> new/path\n')).toEqual(['new/path'])
+  test('preserves literal rename endpoints without pathname quoting', () => {
+    expect(parsePorcelain('R  new name\nfile\0old name\nfile\0')).toEqual([
+      { status: 'R ', kind: 'tracked', paths: ['new name\nfile', 'old name\nfile'] },
+    ])
   })
 
-  test('skips empty and short lines', () => {
-    expect(parsePorcelain('\n  \nXY\n')).toEqual([])
+  test('skips empty and short records', () => {
+    expect(parsePorcelain('\0  \0XY\0')).toEqual([])
   })
 })
 

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { lstatSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { hooklessGitArgs } from '@/git/hookless'
@@ -95,29 +95,33 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
   const repo = resolveAgentGit(cwd)
   if (!repo) return { ok: true, kind: 'no-repo' }
 
-  const status = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '--untracked-files=all'], {
+  const status = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '-z', '--untracked-files=all'], {
     cwd,
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
   if (status.exitCode !== 0) return { ok: false, kind: 'aborted', reason: `git status failed: ${shortErr(status)}` }
-  const dirty = filterAgentOwned(parsePorcelain(status.stdout))
-  const force = filterForceAdd(parsePorcelain(status.stdout))
-  if (dirty.length === 0 && force.length === 0) return { ok: true, kind: 'clean' }
+  const snapshot = selectStagingSnapshot(parsePorcelain(status.stdout), cwd)
+  if (snapshot.paths.length === 0 && snapshot.forcePaths.length === 0) return { ok: true, kind: 'clean' }
 
-  if (dirty.length > 0) {
-    const add = await deps.gitSpawn([...repo.gitArgs, 'add', '--', ...dirty], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
-    if (add.exitCode !== 0) return { ok: false, kind: 'commit-failed', reason: `git add failed: ${shortErr(add)}` }
-  }
-  if (force.length > 0) {
-    const present = force.filter((p) => existsSync(join(cwd, p)))
-    if (present.length > 0) {
-      const addF = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...present], {
-        cwd,
-        timeoutMs: COMMIT_TIMEOUT_MS,
-      })
-      if (addF.exitCode !== 0) {
-        return { ok: false, kind: 'commit-failed', reason: `git add -f failed: ${shortErr(addF)}` }
+  if (snapshot.paths.length > 0) {
+    const add = await deps.gitSpawn([...repo.gitArgs, 'add', '--', ...snapshot.paths], {
+      cwd,
+      timeoutMs: COMMIT_TIMEOUT_MS,
+    })
+    if (add.exitCode !== 0) {
+      const retry = await retryAfterVanishedUntracked(cwd, deps, repo, snapshot)
+      if (!retry || retry.exitCode !== 0) {
+        return { ok: false, kind: 'commit-failed', reason: `git add failed: ${shortErr(retry ?? add)}` }
       }
+    }
+  }
+  if (snapshot.forcePaths.length > 0) {
+    const addF = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...snapshot.forcePaths], {
+      cwd,
+      timeoutMs: COMMIT_TIMEOUT_MS,
+    })
+    if (addF.exitCode !== 0) {
+      return { ok: false, kind: 'commit-failed', reason: `git add -f failed: ${shortErr(addF)}` }
     }
   }
 
@@ -132,7 +136,7 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
   const message = await deps.pickCommitMessage({
-    status: status.stdout.slice(0, 4096),
+    status: status.stdout.replaceAll('\0', '\n').slice(0, 4096),
     diffstat: diffstat.stdout.slice(0, 4096),
   })
 
@@ -144,12 +148,12 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
   // one-cycle-behind churn. Re-status, filter to `sessions/` additions
   // only (don't accidentally stage user work that arrived during the
   // window), and force-add anything new.
-  const reStatus = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '--untracked-files=all'], {
+  const reStatus = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '-z', '--untracked-files=all'], {
     cwd,
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
   if (reStatus.exitCode === 0) {
-    const lateForce = filterForceAdd(parsePorcelain(reStatus.stdout)).filter((p) => existsSync(join(cwd, p)))
+    const lateForce = selectForcePaths(parsePorcelain(reStatus.stdout), cwd, ['sessions/'])
     if (lateForce.length > 0) {
       const lateAdd = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...lateForce], {
         cwd,
@@ -372,23 +376,112 @@ function isNonFastForward(r: GitSpawnResult): boolean {
   return blob.includes('non-fast-forward') || blob.includes('updates were rejected')
 }
 
-export function parsePorcelain(stdout: string): string[] {
-  const out: string[] = []
-  for (const raw of stdout.split('\n')) {
+export type PorcelainEntry = {
+  status: string
+  kind: 'tracked' | 'untracked'
+  paths: readonly string[]
+}
+
+// `-z` makes paths literal rather than C-quoted. Rename/copy records carry the
+// destination followed by the source, and both are needed when staging a
+// snapshot that contains an endpoint which has since disappeared.
+export function parsePorcelain(stdout: string): PorcelainEntry[] {
+  const separator = stdout.includes('\0') ? '\0' : '\n'
+  const records = stdout.split(separator)
+  const entries: PorcelainEntry[] = []
+
+  for (let index = 0; index < records.length; index += 1) {
+    const raw = records[index] ?? ''
     if (raw.length < 4) continue
-    const rest = raw.slice(3)
-    const arrowIdx = rest.indexOf(' -> ')
-    out.push(arrowIdx === -1 ? rest : rest.slice(arrowIdx + 4))
+    const status = raw.slice(0, 2)
+    const path = raw.slice(3)
+    const renamedOrCopied = status.includes('R') || status.includes('C')
+    const source = renamedOrCopied && separator === '\0' ? records[++index] : undefined
+    const fallbackSource = renamedOrCopied && separator === '\n' ? path.split(' -> ')[0] : undefined
+    const destination = fallbackSource ? path.slice(fallbackSource.length + 4) : path
+    entries.push({
+      status,
+      kind: status === '??' ? 'untracked' : 'tracked',
+      paths: source ? [path, source] : fallbackSource ? [destination, fallbackSource] : [path],
+    })
   }
-  return out
+  return entries
 }
 
-function filterAgentOwned(paths: readonly string[]): string[] {
-  return paths.filter((p) => !RUNTIME_OWNED_PREFIXES.some((pre) => p.startsWith(pre)))
+type StagingSnapshot = {
+  paths: string[]
+  untrackedPaths: Set<string>
+  forcePaths: string[]
 }
 
-function filterForceAdd(paths: readonly string[]): string[] {
-  return paths.filter((p) => FORCE_ADD_PREFIXES.some((pre) => p.startsWith(pre)))
+function selectStagingSnapshot(entries: readonly PorcelainEntry[], cwd: string): StagingSnapshot {
+  const paths: string[] = []
+  const untrackedPaths = new Set<string>()
+  for (const entry of entries) {
+    for (const path of entry.paths) {
+      if (isAgentOwned(path)) continue
+      const forceAdded = FORCE_ADD_PREFIXES.some((prefix) => path.startsWith(prefix))
+      if (entry.kind === 'untracked') {
+        if (forceAdded || !hasDirectoryEntry(join(cwd, path))) continue
+        untrackedPaths.add(path)
+      }
+      paths.push(path)
+    }
+  }
+  return { paths: uniquePaths(paths), untrackedPaths, forcePaths: selectForcePaths(entries, cwd) }
+}
+
+async function retryAfterVanishedUntracked(
+  cwd: string,
+  deps: BackupRunnerDeps,
+  repo: AgentGit,
+  snapshot: StagingSnapshot,
+): Promise<GitSpawnResult | undefined> {
+  const reread = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '-z', '--untracked-files=all'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
+  if (reread.exitCode !== 0) return undefined
+
+  const reported = new Set(
+    parsePorcelain(reread.stdout)
+      .filter((entry) => entry.kind === 'untracked')
+      .flatMap((entry) => entry.paths),
+  )
+  const vanished = new Set(
+    [...snapshot.untrackedPaths].filter((path) => !hasDirectoryEntry(join(cwd, path)) && !reported.has(path)),
+  )
+  if (vanished.size === 0) return undefined
+
+  const retryPaths = snapshot.paths.filter((path) => !vanished.has(path))
+  if (retryPaths.length === 0) return { exitCode: 0, stdout: '', stderr: '', timedOut: false }
+  return deps.gitSpawn([...repo.gitArgs, 'add', '--', ...retryPaths], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+}
+
+function selectForcePaths(
+  entries: readonly PorcelainEntry[],
+  cwd: string,
+  prefixes: readonly string[] = FORCE_ADD_PREFIXES,
+): string[] {
+  return uniquePaths(
+    entries.flatMap((entry) =>
+      entry.paths.filter(
+        (path) => prefixes.some((prefix) => path.startsWith(prefix)) && hasDirectoryEntry(join(cwd, path)),
+      ),
+    ),
+  )
+}
+
+function hasDirectoryEntry(path: string): boolean {
+  return lstatSync(path, { throwIfNoEntry: false }) !== undefined
+}
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths)]
+}
+
+function isAgentOwned(path: string): boolean {
+  return RUNTIME_OWNED_PREFIXES.some((prefix) => path.startsWith(prefix))
 }
 
 function sanitizeCommitMessage(raw: string): string {


### PR DESCRIPTION
## Background

The bundled backup plugin is deliberately a deterministic idle-time Git runner, not an autonomous Git agent. It takes one `git status` snapshot, stages only the paths admitted by that snapshot, and uses the model only to phrase the commit message. That is what prevents a file created later by a user, runtime, or subagent from being swept into the same commit.

Agent directories are live while this happens. A transient untracked file can exist when status is read and disappear before `git add -- <snapshot paths>`. Git rejects the entire add with a pathspec error, so one disposable file can block tracked modifications and deletions that were valid members of the same backup.

## The explicit snapshot is the safety boundary

Replacing the add with `git add -A` would hide the immediate failure, but it would also erase the plugin's central concurrency guarantee. Re-reading status and staging the new result has the same problem: files that appeared after the original decision point would enter the commit. Filtering every absent path is worse, because tracked deletions and rename sources are correctly absent on disk and still must be staged.

The old parser could not make that distinction. It retained path strings but discarded whether Git reported each record as tracked or untracked, and its line-oriented form could not safely represent every filename or both endpoints of a rename/copy record.

This PR moves the snapshot to NUL-delimited porcelain records, preserves tracked/untracked kind and both rename endpoints, and records the exact original untracked subset. The normal path still performs one explicit add. Only if that add fails does the runner re-read status once and remove a path when all three facts agree:

1. it was untracked in the original snapshot;
2. its directory entry is now absent;
3. Git no longer reports it as untracked.

The retry is always the original path set minus that proven-vanished subset. It can never acquire a later path.

## A missing target is not a missing path

The directory-entry check uses `lstat`, not `existsSync`. An untracked dangling symlink has no live target, but the link itself exists and Git can stage it. Following the target would classify the link as vanished and could make a symlink-only repository look clean forever.

The same entry-presence rule now applies to initial ordinary-path selection, retry reconciliation, and runtime-owned force paths. A real temporary-repository regression test stages a dangling symlink while another untracked file disappears between status and add; the resulting commit contains the link and excludes only the vanished file.

This is narrower than the tempting alternatives:

- `git add -A` or a fresh status snapshot widens the commit boundary;
- filtering all absent paths loses tracked deletions and rename sources;
- ignoring pathspec failures hides permission, repository, and index errors;
- retrying indefinitely turns a bounded backup pass into a race loop.

## Summary

- Parse `git status --porcelain=v1 -z` into typed tracked/untracked entries.
- Preserve both source and destination for rename/copy records.
- Retry once after proving which original untracked paths vanished.
- Check directory-entry presence with `lstat`, preserving dangling symlinks.
- Keep newly discovered paths outside the retry and preserve the separate `add -f` policy.

## Side effects and failure semantics

The success path adds no extra Git process. Reconciliation performs one additional status read only after explicit staging fails. A second race or retry failure remains loud; unrelated add failures are returned unchanged when no original untracked path is proven vanished.

Tracked deletions, rename endpoints, and runtime-owned force-add behavior are unchanged. The lstat check also stops treating unreadable or otherwise exceptional metadata access as simple absence: those errors surface instead of silently dropping a path.

## What this does NOT do

- Does not replace explicit staging with `git add -A`, `git add -u`, or a new full snapshot.
- Does not ignore arbitrary pathspec, permission, index, or repository failures.
- Does not stage files first observed during reconciliation.
- Does not change push, rebase, commit-message, maintenance, or index-lock behavior.

## Review notes

The load-bearing contract is in `selectStagingSnapshot`, `retryAfterVanishedUntracked`, and `hasDirectoryEntry`: only `snapshot.untrackedPaths` may be removed, and retry paths must be filtered from `snapshot.paths`. Under porcelain `-z`, rename/copy records arrive destination then source; both remain in the explicit add. The dangling-symlink test must use a real Git repository because mocked status and add calls cannot prove Git's symlink behavior.

## Verification

- Rebased onto `d43da137` (`0.48.9`).
- Focused backup runner suite: 43 pass, 0 fail.
- `bun run typecheck`: pass.
- `bun run lint`: 0 errors (70 pre-existing warnings).
- `bun run format`: clean.
- GitHub CI: Linux, Windows, and oversubscribed flake guard pass.
