### PR TITLE
channels: classify session rehydrate fallback failures

### DIFF
--- a/src/run/channel-session-factory.test.ts
+++ b/src/run/channel-session-factory.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdtempSync } from 'node:fs'
+import { describe, expect, mock, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,14 +7,29 @@ import { SessionManager } from '@mariozechner/pi-coding-agent'
 import type { AgentSession } from '@mariozechner/pi-coding-agent'
 
 import type { CreateSessionOptions } from '@/agent'
-import type { ChannelRouter } from '@/channels'
+import * as realCapJsonlModule from '@/bundled-plugins/tool-result-cap/cap-jsonl'
+import {
+  capJsonlFileInPlace as realCapJsonlFileInPlace,
+  type CapJsonlStats,
+} from '@/bundled-plugins/tool-result-cap/cap-jsonl'
+import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
+import type { ChannelRouter, CreateSessionForChannel } from '@/channels'
 import type { ReloadRegistry } from '@/reload'
 import type { SessionFactory } from '@/sessions'
 import type { Stream } from '@/stream'
 
-import { buildChannelSessionFactory } from './channel-session-factory'
 import { createPluginRuntime, type PluginRuntime } from './plugin-runtime'
 
+let capJsonlFileInPlace = realCapJsonlFileInPlace
+
+mock.module('@/bundled-plugins/tool-result-cap/cap-jsonl', () => ({
+  ...realCapJsonlModule,
+  capJsonlFileInPlace: (path: string, options: CapOptions): CapJsonlStats => capJsonlFileInPlace(path, options),
+}))
+
+// The factory must load after the cap module mock so the test can model the
+// file race between the pre-open cap and SessionManager.open.
+const { buildChannelSessionFactory } = await import('./channel-session-factory')
 function makeFakeRouter(): ChannelRouter {
   return {} as ChannelRouter
 }
@@ -51,11 +66,97 @@ function makeRuntimeWithPlugin(): PluginRuntime {
     pluginSubagentByShim: new WeakMap(),
     hasAnyPluginContent: true,
     loadedPlugins: [{ name: 'memory', version: undefined, source: '<bundled>' }],
+
     materializedSkills: null,
   })
 }
 
+function writePersistedSession(sessionDir: string, sessionFile: string, sessionId: string): void {
+  mkdirSync(sessionDir, { recursive: true })
+  writeFileSync(
+    join(sessionDir, sessionFile),
+    `${JSON.stringify({
+      type: 'session',
+      id: sessionId,
+      timestamp: '2026-01-01T00:00:00Z',
+      cwd: sessionDir,
+      version: 3,
+    })}\n`,
+  )
+}
+
+function codedError(code: string, message: string, cause?: unknown): Error {
+  const error = new Error(message, cause === undefined ? undefined : { cause })
+  Object.defineProperty(error, 'code', { value: code })
+  return error
+}
+
 const STUB_SESSION = { dispose: () => {} } as unknown as AgentSession
+
+const CHANNEL_KEY = {
+  adapter: 'discord-bot' as const,
+  workspace: '@dm',
+  chat: 'c1',
+  thread: null,
+}
+
+const CHANNEL_ORIGIN = {
+  kind: 'channel' as const,
+  ...CHANNEL_KEY,
+  participants: [],
+}
+
+const REHYDRATE_CAP_OPTIONS: CapOptions = {
+  imageMaxBytes: 100,
+  textMaxBytes: 100,
+}
+
+type RehydrateHarness = {
+  factory: CreateSessionForChannel
+  warnings: string[]
+}
+
+function makeRehydrateHarness(
+  cwd: string,
+  rehydrateCapOptions: CapOptions | null = REHYDRATE_CAP_OPTIONS,
+): RehydrateHarness {
+  const warnings: string[] = []
+  const factory = buildChannelSessionFactory({
+    cwd,
+    sessionFactory: makeFakeSessionFactory(join(cwd, 'sessions')),
+    stream: makeFakeStream(),
+    reloadRegistry: makeFakeReloadRegistry(),
+    pluginRuntime: makeEmptyRuntime(),
+    getChannelRouter: makeFakeRouter,
+    createSession: async function createStubSession(): Promise<AgentSession> {
+      return STUB_SESSION
+    },
+    rehydrateCapOptions,
+    logger: {
+      info: function ignoreInfo() {},
+      warn: function captureWarning(message: string) {
+        warnings.push(message)
+      },
+    },
+  })
+  return { factory, warnings }
+}
+
+async function rehydrateChannelSession(
+  factory: CreateSessionForChannel,
+  existingSessionId: string,
+  existingSessionFile: string,
+): Promise<string> {
+  const result = await factory({
+    key: CHANNEL_KEY,
+    existingSessionId,
+    existingSessionFile,
+    participants: [],
+    origin: CHANNEL_ORIGIN,
+    originRef: { current: undefined },
+  })
+  return result.sessionId
+}
 
 type Captured = CreateSessionOptions | undefined
 
@@ -386,7 +487,6 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
   })
 
   test('leaves the JSONL untouched when rehydrateCapOptions is null', async () => {
-    const { mkdirSync, writeFileSync, readFileSync } = await import('node:fs')
     const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
     const sessionDir = join(tmp, 'sessions')
     mkdirSync(sessionDir, { recursive: true })
@@ -481,6 +581,200 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
 
     expect(readFileSync(bystander, 'utf8')).toBe(bystanderContent)
     expect(existsSync(join(sessionDir, '../bystander.jsonl.cap.tmp'))).toBe(false)
-    expect(warnLogs.some((l) => l.includes('invalid sessionFile'))).toBe(true)
+    expect(warnLogs).toContain('[channels] persisted session file is invalid; creating new')
+  })
+
+  test('suppresses an ENOENT cap race when the persisted session opens', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    writePersistedSession(join(tmp, 'sessions'), 'persisted.jsonl', 'persisted-session')
+    const originalCap = capJsonlFileInPlace
+    capJsonlFileInPlace = () => {
+      throw new Error('wrapper', { cause: codedError('ENOENT', 'private missing path') })
+    }
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      const sessionId = await rehydrateChannelSession(factory, 'persisted-session', 'persisted.jsonl')
+      expect(sessionId).toBe('persisted-session')
+      expect(warnings).toEqual([])
+    } finally {
+      capJsonlFileInPlace = originalCap
+    }
+  })
+
+  test('self-heals a missing transcript after an ENOENT cap without warning', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const originalCap = capJsonlFileInPlace
+    capJsonlFileInPlace = () => {
+      throw new Error('wrapper', { cause: codedError('ENOENT', 'private missing path') })
+    }
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      const sessionId = await rehydrateChannelSession(factory, 'missing-session', 'missing.jsonl')
+      expect(sessionId).not.toBe('missing-session')
+      expect(warnings).toEqual([])
+    } finally {
+      capJsonlFileInPlace = originalCap
+    }
+  })
+
+  test('warns for a non-ENOENT cap failure while reopening the session', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    writePersistedSession(join(tmp, 'sessions'), 'persisted.jsonl', 'persisted-session')
+    const originalCap = capJsonlFileInPlace
+    capJsonlFileInPlace = () => {
+      throw new Error('wrapper', { cause: codedError('EIO', 'private storage failure') })
+    }
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      const sessionId = await rehydrateChannelSession(factory, 'persisted-session', 'persisted.jsonl')
+      expect(sessionId).toBe('persisted-session')
+      expect(warnings).toEqual(['[channels] rehydrate-cap unavailable; continuing with open'])
+    } finally {
+      capJsonlFileInPlace = originalCap
+    }
+  })
+
+  test('warns when malformed JSONL is silently replaced during rehydrate', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const sessionId = 'private-persisted-session'
+    const sessionFile = 'private-persisted-session.jsonl'
+    const malformedJsonl = 'private malformed JSONL payload'
+    const sessionDir = join(tmp, 'sessions')
+    mkdirSync(sessionDir, { recursive: true })
+    writeFileSync(join(sessionDir, sessionFile), malformedJsonl)
+
+    const { factory, warnings } = makeRehydrateHarness(tmp, null)
+    const replacementSessionId = await rehydrateChannelSession(factory, sessionId, sessionFile)
+
+    expect(replacementSessionId).not.toBe(sessionId)
+    expect(readFileSync(join(sessionDir, sessionFile), 'utf8')).not.toContain(malformedJsonl)
+    expect(warnings).toEqual(['[channels] persisted session was replaced during rehydrate'])
+    expect(warnings.join('\n')).not.toContain(sessionId)
+    expect(warnings.join('\n')).not.toContain(sessionFile)
+    expect(warnings.join('\n')).not.toContain(tmp)
+    expect(warnings.join('\n')).not.toContain(malformedJsonl)
+  })
+
+  test('self-heals a non-ENOENT open failure with a distinct warning', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    writePersistedSession(join(tmp, 'sessions'), 'persisted.jsonl', 'persisted-session')
+    const originalOpen = SessionManager.open
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw codedError('EIO', 'private open failure')
+      },
+      writable: true,
+    })
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp, null)
+      const sessionId = await rehydrateChannelSession(factory, 'persisted-session', 'persisted.jsonl')
+      expect(sessionId).not.toBe('persisted-session')
+      expect(warnings).toEqual(['[channels] persisted session rehydrate failed; creating new'])
+    } finally {
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+    }
+  })
+
+  test('self-heals a nested ENOENT open failure without warning', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const originalOpen = SessionManager.open
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw new Error('wrapper', { cause: codedError('ENOENT', 'private open path') })
+      },
+      writable: true,
+    })
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp, null)
+      const sessionId = await rehydrateChannelSession(factory, 'missing-session', 'missing.jsonl')
+      expect(sessionId).not.toBe('missing-session')
+      expect(warnings).toEqual([])
+    } finally {
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+    }
+  })
+
+  test('propagates fresh-session creation failures after rehydration fails', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const originalOpen = SessionManager.open
+    const originalCreate = SessionManager.create
+    const createFailure = codedError('ENOSPC', 'private create failure')
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw codedError('ENOENT', 'private open failure')
+      },
+      writable: true,
+    })
+    Object.defineProperty(SessionManager, 'create', {
+      configurable: true,
+      value: () => {
+        throw createFailure
+      },
+      writable: true,
+    })
+    try {
+      const { factory } = makeRehydrateHarness(tmp, null)
+      await expect(rehydrateChannelSession(factory, 'missing-session', 'missing.jsonl')).rejects.toBe(createFailure)
+    } finally {
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+      Object.defineProperty(SessionManager, 'create', {
+        configurable: true,
+        value: originalCreate,
+        writable: true,
+      })
+    }
+  })
+
+  test('sanitizes fallback warnings', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'channel-session-factory-'))
+    const sessionId = 'private-session-identifier'
+    const sessionFile = 'private-session-file.jsonl'
+    const privateDetail = 'private-path-and-error-detail'
+    writePersistedSession(join(tmp, 'sessions'), sessionFile, sessionId)
+    const originalCap = capJsonlFileInPlace
+    const originalOpen = SessionManager.open
+    capJsonlFileInPlace = () => {
+      throw codedError('EIO', privateDetail)
+    }
+    Object.defineProperty(SessionManager, 'open', {
+      configurable: true,
+      value: () => {
+        throw codedError('EIO', privateDetail)
+      },
+      writable: true,
+    })
+    try {
+      const { factory, warnings } = makeRehydrateHarness(tmp)
+      await rehydrateChannelSession(factory, sessionId, sessionFile)
+      expect(warnings).toEqual([
+        '[channels] rehydrate-cap unavailable; continuing with open',
+        '[channels] persisted session rehydrate failed; creating new',
+      ])
+      expect(warnings.join('\n')).not.toContain(sessionId)
+      expect(warnings.join('\n')).not.toContain(sessionFile)
+      expect(warnings.join('\n')).not.toContain(privateDetail)
+    } finally {
+      capJsonlFileInPlace = originalCap
+      Object.defineProperty(SessionManager, 'open', {
+        configurable: true,
+        value: originalOpen,
+        writable: true,
+      })
+    }
   })
 })

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -89,6 +89,21 @@ function isValidSessionFileBasename(name: string): boolean {
   return name.endsWith('.jsonl')
 }
 
+function errorChainHasCode(error: unknown, expectedCode: string): boolean {
+  const seen = new Set<object>()
+  let current = error
+  while (typeof current === 'object' && current !== null && !seen.has(current)) {
+    seen.add(current)
+    try {
+      if ('code' in current && current.code === expectedCode) return true
+      current = 'cause' in current ? current.cause : undefined
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
 // The production wiring for channel-routed sessions. Channel inbounds arrive
 // at the router, the router calls this factory to get an AgentSession, and
 // the agent uses `channel_send` to reply. If `channelRouter` is missing here
@@ -181,41 +196,46 @@ function tryReopenOrCreate(
   logger: FactoryLogger,
 ): SessionManager {
   if (existingSessionFile === undefined) {
-    logger.warn(
-      `[channels] session ${existingSessionId} has no sessionFile (v2 mapping not yet migrated); creating new`,
-    )
+    logger.warn('[channels] persisted session has no session file; creating new')
     return SessionManager.create(cwd, sessionDir)
   }
   if (!isValidSessionFileBasename(existingSessionFile)) {
-    logger.warn(
-      `[channels] session ${existingSessionId} has invalid sessionFile (${JSON.stringify(existingSessionFile)}); creating new`,
-    )
+    logger.warn('[channels] persisted session file is invalid; creating new')
     return SessionManager.create(cwd, sessionDir)
   }
   const path = join(sessionDir, existingSessionFile)
+  let missingDuringCap = false
   if (capOptions !== null) {
     try {
       const stats = capJsonlFileInPlace(path, capOptions)
       if (stats.entriesMutated > 0) {
         logger.info(
-          `[channels] rehydrate-cap ${existingSessionFile}: entriesMutated=${stats.entriesMutated} imagesReplaced=${stats.imagesReplaced} textsTruncated=${stats.textsTruncated} bytesElided=${stats.bytesElided}`,
+          `[channels] rehydrate-cap complete: entriesMutated=${stats.entriesMutated} imagesReplaced=${stats.imagesReplaced} textsTruncated=${stats.textsTruncated} bytesElided=${stats.bytesElided}`,
         )
       }
     } catch (err) {
       // Capping is best-effort: if the rewrite fails, fall through to the
       // regular open path so the session still rehydrates uncapped rather
-      // than being killed by a transient FS error.
-      const reason = err instanceof Error ? err.message : String(err)
-      logger.warn(`[channels] rehydrate-cap failed for ${existingSessionFile}: ${reason}; continuing with open`)
+      // than being killed by a transient FS error. Missing files are expected
+      // during concurrent cleanup; open either creates a fresh transcript or
+      // reaches the fallback below.
+      if (errorChainHasCode(err, 'ENOENT')) {
+        missingDuringCap = true
+      } else {
+        logger.warn('[channels] rehydrate-cap unavailable; continuing with open')
+      }
     }
   }
   try {
-    return SessionManager.open(path)
+    const sessionManager = SessionManager.open(path)
+    if (sessionManager.getSessionId() !== existingSessionId && !missingDuringCap) {
+      logger.warn('[channels] persisted session was replaced during rehydrate')
+    }
+    return sessionManager
   } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err)
-    logger.warn(
-      `[channels] could not rehydrate session ${existingSessionId} from ${existingSessionFile}: ${reason}; creating new`,
-    )
+    if (!errorChainHasCode(err, 'ENOENT')) {
+      logger.warn('[channels] persisted session rehydrate failed; creating new')
+    }
     return SessionManager.create(cwd, sessionDir)
   }
 }


### PR DESCRIPTION
## Background

Channel routing persists a transcript basename so an inbound after restart can reopen the exact `${ISO_TIMESTAMP}_${UUID}.jsonl` file. Before open, the tool-result-cap plugin may rewrite oversized historical results so a poisoned transcript can recover without manual surgery. If rehydration still fails, the factory creates a fresh session rather than making one damaged transcript take the whole channel offline.

Those were deliberate availability choices. The basename is necessary because the timestamped filename cannot be derived from the session ID, and best-effort fresh-session fallback is the product behavior that keeps a channel replyable. The missing boundary was diagnostic: both cap and open catches stringified arbitrary errors, exposing session IDs, filenames, paths, and raw storage messages while still failing to distinguish expected cleanup races from real corruption.

## Fresh-session fallback is product behavior; opaque logging was not

A persisted session can fail in three materially different ways:

- the file disappeared during concurrent cleanup;
- storage/open failed unexpectedly, for example through permissions or I/O;
- `SessionManager.open` accepted malformed JSONL but silently rewrote it as a replacement session.

The third case is important because it does not throw. A catch-only implementation reports nothing even though the persisted history was replaced. The earlier mocked-open regression could not exercise that dependency behavior.

This PR preserves the expected session ID before open and compares it with the returned manager. A real malformed JSONL test, using the unmocked `SessionManager.open`, proves that a silent replacement emits one fixed warning. The warning contains no persisted ID, basename, path, malformed payload, or raw exception text.

## Classify the operation that failed, not a preflight snapshot

Missing-file detection walks structured `code` values through the error `cause` chain. It is cycle-safe and guards property access, so wrappers cannot hide `ENOENT` and hostile cause objects cannot hang classification.

The two stages then keep their existing control flow with tighter disclosure semantics:

1. cap-stage `ENOENT` records that the transcript was observed missing and continues quietly;
2. other cap failures emit a sanitized category and continue to open;
3. open-stage nested `ENOENT` creates fresh quietly;
4. a returned manager with a different session ID warns only when the cap stage did not already establish expected absence;
5. other open failures emit a sanitized category and create fresh.

Carrying the cap-stage missing classification avoids an `existsSync`/`stat` preflight that would add another TOCTOU window. It also prevents the dependency's normal missing-file replacement from being mislabeled as corruption, while an existing malformed file still produces the replacement warning.

The alternatives either lose an invariant or add scope: message matching is platform-dependent and retains raw text; swallowing every error hides storage regressions; throwing on unexpected errors reverses channel availability; deleting the mapping changes persistence semantics; a filesystem preflight cannot guarantee the file still exists at open.

## Summary

- Classify nested error codes without logging arbitrary error content.
- Treat missing-file cap and open races as quiet self-healing paths.
- Detect successful-but-replaced persisted sessions by comparing session IDs.
- Cover malformed JSONL with the real `SessionManager.open` behavior.
- Preserve best-effort fresh-session fallback and existing mapping state.

## Side effects and disclosure boundary

Logs intentionally lose exact filenames and raw messages. They retain only actionable categories: invalid mapping, cap unavailable, persisted session replaced, or rehydrate failed. Expected missing files become quiet; non-missing failures and silent corruption remain observable.

No routing, persistence schema, or mapping mutation changes. Cap failure still continues to open, open failure still creates fresh, and fresh-session creation failures still propagate. The classifier terminates on cyclic causes and fails closed to the generic unexpected category when properties cannot be inspected safely.

## What this does NOT do

- Does not delete or migrate channel mappings.
- Does not add filesystem preflight probes.
- Does not make transcript rehydration mandatory for channel availability.
- Does not log raw causes, transcript identifiers, or paths.
- Does not change cap limits or rewrite policy.

## Review notes

Review `errorChainHasCode` as both a security and liveness boundary, then follow `tryReopenOrCreate` across cap, open, and fresh creation. The key distinction is that a replacement ID is unexpected unless cap already observed `ENOENT`. The malformed-file regression must keep the real `SessionManager.open`; substituting a throwing mock no longer covers the silent-rewrite failure.

## Verification

- Rebased onto `d43da137` (`0.48.9`).
- Focused channel session factory suite: 20 pass, 0 fail.
- `bun run typecheck`: pass.
- `bun run lint`: 0 errors (70 pre-existing warnings).
- `bun run format`: clean.
- GitHub CI: Linux, Windows, and oversubscribed flake guard pass.
