### PR TITLE
hostd: refresh registration at launch boundary

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -130,6 +130,7 @@ describe('buildHostdRestart', () => {
   test('forwards the daemon-supplied currentHostDaemon into start()', async () => {
     const starts: RestartOptions[] = []
     const register = async (): Promise<{ ok: true }> => ({ ok: true })
+    const deregister = async (): Promise<void> => {}
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {
       validateConfig: () => ({ ok: true }),
       loadConfigSync: () => configSchema.parse({ port: 61234 }),
@@ -142,11 +143,11 @@ describe('buildHostdRestart', () => {
     const result = await restart({
       containerName: 'agent',
       cwd: '/agent-dir',
-      currentHostDaemon: { httpPort: 8974, register },
+      currentHostDaemon: { httpPort: 8974, register, deregister },
     })
 
     expect(result.ok).toBe(true)
-    expect(starts[0]?.currentHostDaemon).toEqual({ httpPort: 8974, register })
+    expect(starts[0]?.currentHostDaemon).toEqual({ httpPort: 8974, register, deregister })
   })
 
   test('omits currentHostDaemon when the daemon does not supply one', async () => {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -3258,8 +3258,87 @@ describe('start (composition)', () => {
     }
   })
 
-  test('currentHostDaemon registers in-process and injects the hostd env triple without any socket RPC', async () => {
-    // given: a daemon-owned restart supplies its own httpPort + in-process registrar
+  test.each(['build', 'models'] as const)(
+    'refreshes hostd only after build and model provisioning when %s finishes first',
+    async (firstToFinish) => {
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: '^0.1.0' })
+      await writeTypeclawConfig(root)
+      const docker = fakeDockerExec({ imageExists: false, container: { exists: false } })
+      const buildGate = Promise.withResolvers<void>()
+      const buildStarted = Promise.withResolvers<void>()
+      const modelsGate = Promise.withResolvers<void>()
+      const buildFinished = Promise.withResolvers<void>()
+      const modelsStarted = Promise.withResolvers<void>()
+      const initialRegistration = Promise.withResolvers<void>()
+      const modelsFinished = Promise.withResolvers<void>()
+      const events: string[] = []
+      const registrations: HostDaemonRegisterPayload[] = []
+      const exec: DockerExec = async (args, options) => {
+        if (isBuildCall(args)) {
+          events.push('build-started')
+          buildStarted.resolve()
+          await buildGate.promise
+          events.push('build-finished')
+          buildFinished.resolve()
+        }
+        if (args[0] === 'run') events.push('docker-run')
+        return await docker.exec(args, options)
+      }
+
+      const startPromise = start({
+        cwd: root,
+        preferredHostPort: 8973,
+        exec,
+        allocatePort: deterministicAllocator,
+        cliEntry: '/placeholder/cli.ts',
+        reuseCurrentHostDaemon: true,
+        currentHostDaemon: {
+          httpPort: 49999,
+          register: async (payload) => {
+            registrations.push(payload)
+            events.push(registrations.length === 1 ? 'registration-before-work' : 'registration-at-launch')
+            if (registrations.length === 1) initialRegistration.resolve()
+            return { ok: true }
+          },
+          deregister: async () => {},
+        },
+        ensureDeps: noEnsureDeps,
+        ensureModels: async () => {
+          events.push('models-started')
+          modelsStarted.resolve()
+          await modelsGate.promise
+          events.push('models-ready')
+          modelsFinished.resolve()
+        },
+        verifyRunning: async () => ({ ok: true }),
+        archiveLogs: noArchiveLogs,
+        provisionGithubCliStore: noGithubCliProvision,
+        autoUpgrade: noAutoUpgrade,
+      })
+
+      await Promise.all([buildStarted.promise, modelsStarted.promise, initialRegistration.promise])
+      expect(registrations).toHaveLength(1)
+      const firstGate = firstToFinish === 'build' ? buildGate : modelsGate
+      const firstFinished = firstToFinish === 'build' ? buildFinished : modelsFinished
+      const secondGate = firstToFinish === 'build' ? modelsGate : buildGate
+      firstGate.resolve()
+      await firstFinished.promise
+      for (let pending = 0; pending < 5; pending += 1) await Promise.resolve()
+      expect(registrations).toHaveLength(1)
+
+      secondGate.resolve()
+      const result = await startPromise
+      expect(result.ok).toBe(true)
+      const launchRefresh = events.indexOf('registration-at-launch')
+      expect(launchRefresh).toBeGreaterThan(events.indexOf('build-finished'))
+      expect(launchRefresh).toBeGreaterThan(events.indexOf('models-ready'))
+      expect(events.slice(launchRefresh)).toEqual(['registration-at-launch', 'docker-run'])
+      expect(registrations).toHaveLength(2)
+    },
+  )
+
+  test('uses only replacement hostd tokens in the final docker run', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeTypeclawConfig(root)
@@ -3271,7 +3350,7 @@ describe('start (composition)', () => {
       preferredHostPort: 8973,
       exec,
       allocatePort: deterministicAllocator,
-      cliEntry: '/nonexistent/cli.ts',
+      cliEntry: '/placeholder/cli.ts',
       reuseCurrentHostDaemon: true,
       currentHostDaemon: {
         httpPort: 49999,
@@ -3279,83 +3358,142 @@ describe('start (composition)', () => {
           registered.push(payload)
           return { ok: true }
         },
+        deregister: async () => {},
       },
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
     if (!result.ok) return
-    expect(result.hostd.state).toBe('registered')
-    // then: the container is registered in-process (not over a socket)
-    expect(registered).toHaveLength(1)
-    expect(registered[0]).toMatchObject({ containerName: basename(root), cwd: root, wsHostPort: 8973 })
-    // then: the env triple points at the daemon's own http port
-    expect(result.plan.runArgs).toContain('TYPECLAW_HOSTD_URL=http://host.docker.internal:49999')
-    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_TOKEN=${registered[0]!.restartToken}`)
-    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_BROKER_TOKEN=${registered[0]!.brokerToken}`)
+    expect(registered).toHaveLength(2)
+    const [staleRegistration, launchRegistration] = registered
+    expect(launchRegistration).toBeDefined()
+    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_TOKEN=${launchRegistration!.restartToken}`)
+    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_BROKER_TOKEN=${launchRegistration!.brokerToken}`)
+    expect(result.plan.runArgs).not.toContain(`TYPECLAW_HOSTD_TOKEN=${staleRegistration!.restartToken}`)
+    expect(result.plan.runArgs).not.toContain(`TYPECLAW_HOSTD_BROKER_TOKEN=${staleRegistration!.brokerToken}`)
   })
 
-  test('currentHostDaemon register failure still boots the container (degraded, never dead)', async () => {
-    // given: in-process registration fails — the daemon-owned restart must not strand the agent
+  test('aborts before docker run and rolls back the initial registration when launch refresh setup fails', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeTypeclawConfig(root)
-    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    const docker = fakeDockerExec({ imageExists: false, container: { exists: false } })
+    const exec: DockerExec = async (args, options) => {
+      // Corrupt config only after the initial plan reaches its build step, so
+      // this targets launch-boundary replanning rather than initial setup.
+      if (isBuildCall(args)) await writeFile(join(root, 'typeclaw.json'), '{ not-json')
+      return await docker.exec(args, options)
+    }
+    const deregistrations: string[] = []
+    let registrations = 0
 
     const result = await start({
       cwd: root,
       preferredHostPort: 8973,
       exec,
       allocatePort: deterministicAllocator,
-      cliEntry: '/nonexistent/cli.ts',
-      reuseCurrentHostDaemon: true,
-      currentHostDaemon: {
-        httpPort: 49999,
-        register: async () => ({ ok: false, reason: 'daemon stopping' }),
-      },
-      ensureDeps: noEnsureDeps,
-      ...bypassVerify,
-    })
-
-    // then: the container still launches, but without the hostd env triple
-    expect(result.ok).toBe(true)
-    if (!result.ok) return
-    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'daemon stopping' })
-    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
-    expect(result.plan.runArgs.find((a) => a.startsWith('TYPECLAW_HOSTD_URL='))).toBeUndefined()
-  })
-
-  test('a throwing in-process registrar degrades to a booting container, never aborts the restart', async () => {
-    // given: the in-process registrar rejects (e.g. a throw from the shared registration path)
-    await writeDockerfile(root)
-    await writePackageJson(root, { typeclaw: '^0.1.0' })
-    await writeTypeclawConfig(root)
-    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
-
-    const result = await start({
-      cwd: root,
-      preferredHostPort: 8973,
-      exec,
-      allocatePort: deterministicAllocator,
-      cliEntry: '/nonexistent/cli.ts',
+      cliEntry: '/placeholder/cli.ts',
       reuseCurrentHostDaemon: true,
       currentHostDaemon: {
         httpPort: 49999,
         register: async () => {
-          throw new Error('registry write failed')
+          registrations += 1
+          return { ok: true }
+        },
+        deregister: async (containerName) => {
+          deregistrations.push(containerName)
+        },
+      },
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
+      ensureModels: noEnsureModels,
+      verifyRunning: async () => ({ ok: true }),
+      archiveLogs: noArchiveLogs,
+      provisionGithubCliStore: noGithubCliProvision,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(registrations).toBe(1)
+    expect(deregistrations).toEqual([basename(root)])
+    expect(docker.calls.some((call) => call.args[0] === 'run')).toBe(false)
+  })
+
+  test('launches without hostd control when the launch refresh is unavailable', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    let registrations = 0
+    const deregistrations: string[] = []
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      cliEntry: '/placeholder/cli.ts',
+      reuseCurrentHostDaemon: true,
+      currentHostDaemon: {
+        httpPort: 49999,
+        register: async () => {
+          registrations += 1
+          return registrations === 1 ? { ok: true } : { ok: false, reason: 'registration-unavailable' }
+        },
+        deregister: async (containerName) => {
+          deregistrations.push(containerName)
         },
       },
       ensureDeps: noEnsureDeps,
       ...bypassVerify,
     })
 
-    // then: the throw is normalized to a degraded boot, not an aborted start
     expect(result.ok).toBe(true)
     if (!result.ok) return
-    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registry write failed' })
-    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
-    expect(result.plan.runArgs.find((a) => a.startsWith('TYPECLAW_HOSTD_URL='))).toBeUndefined()
+    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registration-unavailable' })
+    expect(calls.find((call) => call.args[0] === 'run')).toBeDefined()
+    expect(result.plan.runArgs.some((arg) => arg.includes('TYPECLAW_HOSTD_'))).toBe(false)
+    expect(deregistrations).toEqual([basename(root)])
+  })
+
+  test('launches without hostd control when the in-process registrar throws at the launch boundary', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    let registrations = 0
+    const deregistrations: string[] = []
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      cliEntry: '/placeholder/cli.ts',
+      reuseCurrentHostDaemon: true,
+      currentHostDaemon: {
+        httpPort: 49999,
+        register: async () => {
+          registrations += 1
+          if (registrations === 1) return { ok: true }
+          throw new Error('registration-unavailable')
+        },
+        deregister: async (containerName) => {
+          deregistrations.push(containerName)
+        },
+      },
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registration-unavailable' })
+    expect(calls.find((call) => call.args[0] === 'run')).toBeDefined()
+    expect(result.plan.runArgs.some((arg) => arg.includes('TYPECLAW_HOSTD_'))).toBe(false)
+    expect(deregistrations).toEqual([basename(root)])
   })
 
   test('forceBuild=false skips build entirely when image already exists', async () => {
@@ -4525,6 +4663,67 @@ describe('start (port allocation)', () => {
     expect(runCalls[0]!.args).toContain('127.0.0.1:8973:8973')
     expect(runCalls[1]!.args).toContain('127.0.0.1:49160:8973')
     if (result.ok) expect(result.hostPort).toBe(49160)
+  })
+
+  test('cleans the prior registration when the port-retry registration is unavailable', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+    const calls: { args: string[] }[] = []
+    let runAttempts = 0
+    const exec: DockerExec = async (args) => {
+      calls.push({ args })
+      if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
+      if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'No such container' }
+      if (args[0] === 'run') {
+        runAttempts += 1
+        if (runAttempts === 1) {
+          return { exitCode: 1, stdout: '', stderr: 'docker: Bind for :::8973 failed: port is already allocated' }
+        }
+        return { exitCode: 0, stdout: 'fake-id\n', stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    const ports = [8973, 49160]
+    const allocatePort = async (): Promise<number> => ports.shift() ?? 0
+    const deregistrations: string[] = []
+    let registrations = 0
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort,
+      cliEntry: '/placeholder/cli.ts',
+      reuseCurrentHostDaemon: true,
+      currentHostDaemon: {
+        httpPort: 49999,
+        register: async () => {
+          registrations += 1
+          return registrations < 3 ? { ok: true } : { ok: false, reason: 'registration-unavailable' }
+        },
+        deregister: async (containerName) => {
+          deregistrations.push(containerName)
+        },
+      },
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(registrations).toBe(3)
+    expect(deregistrations).toEqual([basename(root)])
+    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registration-unavailable' })
+    expect(result.hostPort).toBe(49160)
+    expect(result.plan.runArgs.some((arg) => arg.includes('TYPECLAW_HOSTD_'))).toBe(false)
+    expect(runAttempts).toBe(2)
+    const runCalls = calls.filter((call) => call.args[0] === 'run')
+    expect(runCalls).toHaveLength(2)
+    expect(runCalls[0]!.args).toContain('127.0.0.1:8973:8973')
+    expect(runCalls[1]!.args).toContain('127.0.0.1:49160:8973')
+    expect(runCalls[1]!.args.some((arg) => arg.includes('TYPECLAW_HOSTD_'))).toBe(false)
   })
 
   test('does NOT retry when docker fails for a non-port reason (e.g. permission denied)', async () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -119,13 +119,14 @@ export type HostDaemonRegisterPayload = {
 }
 
 // Injected only on the daemon-owned restart path (reuseCurrentHostDaemon).
-// The daemon registers the container in-process and reports its own HTTP port,
-// so the restart skips the `http-info`/`register` self-RPCs — those round-trips
-// can time out under IPC congestion and silently drop the TYPECLAW_HOSTD_* env
-// triple, booting a container whose hostd-bridged adapters can't construct.
+// The daemon updates the container registration in-process and reports its own
+// HTTP port, so restart lifecycle changes skip socket self-RPCs — those
+// round-trips can time out under IPC congestion and silently drop the
+// TYPECLAW_HOSTD_* env triple or leave stale broker state behind.
 export type CurrentHostDaemon = {
   httpPort: number
   register: (payload: HostDaemonRegisterPayload) => Promise<{ ok: true } | { ok: false; reason: string }>
+  deregister: (containerName: string) => Promise<void>
 }
 
 export type StartOptions = {
@@ -140,9 +141,10 @@ export type StartOptions = {
   // Hostd's supervisor restart callback already runs inside the daemon process.
   // Reusing that daemon avoids a self-shutdown when disk source has drifted.
   reuseCurrentHostDaemon?: boolean
-  // Set by hostd's supervisor restart wrapper. When present, registration goes
-  // through the daemon in-process (no socket round-trips), so the env triple is
-  // injected from known-good values even under IPC congestion. See type docs.
+  // Set by hostd's supervisor restart wrapper. When present, registration
+  // lifecycle changes go through the daemon in-process (no socket round-trips),
+  // so known-good control values and rollback survive IPC congestion.
+  // See type docs.
   currentHostDaemon?: CurrentHostDaemon
   ensureDeps?: (cwd: string, opts?: { force?: boolean }) => Promise<EnsureDepsResult>
   // Test seam for host embedding model provisioning. Production callers use
@@ -575,6 +577,44 @@ async function runStart({
       }
     }
 
+    // The build and model provisioning above can outlive a hostd registration.
+    // Refresh both the registry entry and the launch plan at the run boundary:
+    // a broker restart may have invalidated the initial control tokens while
+    // those pre-run steps were in flight. Keep that early registration because
+    // it remains the cleanup target for build/model failures.
+    const initialHostd = hostd
+    try {
+      if (cliEntry) {
+        const refreshedHostd = await registerWithDaemon({
+          cwd,
+          containerName,
+          cliEntry,
+          hostPort,
+          reuseCurrentHostDaemon,
+          currentHostDaemon,
+        })
+        if (refreshedHostd.state !== 'registered') {
+          await cleanupHostDaemonRegistration(containerName, initialHostd)
+        }
+        hostd = refreshedHostd
+        hostdControl = refreshedHostd.state === 'registered' ? refreshedHostd.control : undefined
+        plan = await planStart({
+          cwd,
+          hostPort,
+          imageExists: true,
+          forceBuild: false,
+          hostdControl,
+          publishHost,
+          tuiToken,
+          platform,
+          hostIdentity,
+        })
+      }
+    } catch (error) {
+      await cleanupHostDaemonRegistration(containerName, hostd.state === 'registered' ? hostd : initialHostd)
+      return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+    }
+
     let run = await execRunWithConflictRetry(exec, plan.runArgs, cwd, containerName, archiveBeforeRemove)
 
     // TOCTOU: another process may have grabbed the port between our probe and
@@ -616,7 +656,8 @@ async function runStart({
       }
       hostPort = await allocatePort(0)
       if (cliEntry) {
-        hostd = await registerWithDaemon({
+        const previousHostd = hostd
+        const retriedHostd = await registerWithDaemon({
           cwd,
           containerName,
           cliEntry,
@@ -624,7 +665,11 @@ async function runStart({
           reuseCurrentHostDaemon,
           currentHostDaemon,
         })
-        hostdControl = hostd.state === 'registered' ? hostd.control : undefined
+        if (retriedHostd.state !== 'registered') {
+          await cleanupHostDaemonRegistration(containerName, previousHostd)
+        }
+        hostd = retriedHostd
+        hostdControl = retriedHostd.state === 'registered' ? retriedHostd.control : undefined
       }
       plan = await planStart({
         cwd,
@@ -1448,6 +1493,7 @@ async function registerWithDaemon({
     return {
       state: 'registered',
       control: { url: `http://${CONTAINER_HOSTD_HOST}:${currentHostDaemon.httpPort}`, token, brokerToken },
+      deregister: (registeredContainerName) => currentHostDaemon.deregister(registeredContainerName),
     }
   }
 
@@ -1458,6 +1504,9 @@ async function registerWithDaemon({
   return {
     state: 'registered',
     control: { url: `http://${CONTAINER_HOSTD_HOST}:${prepared.httpPort}`, token, brokerToken },
+    deregister: async (registeredContainerName) => {
+      await sendToDaemon({ kind: 'deregister', containerName: registeredContainerName })
+    },
   }
 }
 
@@ -1492,7 +1541,7 @@ async function useCurrentHostDaemon(): Promise<{ ok: true; httpPort: number } | 
 }
 
 type PreparedHostDaemonStatus =
-  | { state: 'registered'; control: HostDaemonControl }
+  | { state: 'registered'; control: HostDaemonControl; deregister: (containerName: string) => Promise<void> }
   | { state: 'unavailable'; reason: string }
   | { state: 'disabled' }
 
@@ -1503,7 +1552,7 @@ function stripHostDaemonControl(status: PreparedHostDaemonStatus): HostDaemonSta
 
 async function cleanupHostDaemonRegistration(containerName: string, status: PreparedHostDaemonStatus): Promise<void> {
   if (status.state !== 'registered') return
-  await sendToDaemon({ kind: 'deregister', containerName }).catch(() => {})
+  await status.deregister(containerName).catch(() => {})
 }
 
 // process.env.TZ is honored first because users who explicitly set it (e.g.

--- a/src/hostd/current-host-daemon.test.ts
+++ b/src/hostd/current-host-daemon.test.ts
@@ -8,7 +8,11 @@ describe('createCurrentHostDaemonHolder', () => {
   test('ready() resolves with the value once set, even when awaited before set', async () => {
     // given: a caller awaits ready() before the daemon has booted
     const holder = createCurrentHostDaemonHolder()
-    const value: CurrentHostDaemon = { httpPort: 8974, register: async () => ({ ok: true }) }
+    const value: CurrentHostDaemon = {
+      httpPort: 8974,
+      register: async () => ({ ok: true }),
+      deregister: async () => {},
+    }
     const pending = holder.ready()
 
     // when: the daemon populates the holder after boot
@@ -20,7 +24,11 @@ describe('createCurrentHostDaemonHolder', () => {
 
   test('ready() resolves immediately when set has already happened', async () => {
     const holder = createCurrentHostDaemonHolder()
-    const value: CurrentHostDaemon = { httpPort: 49999, register: async () => ({ ok: true }) }
+    const value: CurrentHostDaemon = {
+      httpPort: 49999,
+      register: async () => ({ ok: true }),
+      deregister: async () => {},
+    }
     holder.set(value)
 
     expect(await holder.ready()).toBe(value)

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -244,6 +244,72 @@ describe('startDaemon', () => {
     expect((list.result as ListResult).registrations.map((r) => r.containerName)).toContain('coder')
   })
 
+  test('GC gives a re-registration a full renewed miss budget after partial misses', async () => {
+    let phase: 'partial' | 'renewed' = 'partial'
+    let partialProbes = 0
+    let partialProbeStarted = false
+    let renewedProbes = 0
+    const releasePartialProbe = deferred()
+    const exec: DockerExec = async (args) => {
+      if (args[0] !== 'ps') return { exitCode: 1, stdout: '', stderr: 'unknown command' }
+      if (phase === 'partial') {
+        partialProbes += 1
+        if (partialProbes === 1) return { exitCode: 0, stdout: '', stderr: '' }
+        partialProbeStarted = true
+        await releasePartialProbe.promise
+      } else {
+        renewedProbes += 1
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    daemon = await startDaemon({ exec, gcIntervalMs: 20, gcMissesToDeregister: 3 })
+    await send({ kind: 'register', containerName: 'coder', cwd: '/old' })
+
+    await waitFor(() => partialProbeStarted)
+    phase = 'renewed'
+    expect((await send({ kind: 'register', containerName: 'coder', cwd: '/renewed' })).ok).toBe(true)
+    releasePartialProbe.resolve()
+
+    await waitFor(() => renewedProbes >= 2)
+    const beforeFinalMiss = await send({ kind: 'list' })
+    expect(beforeFinalMiss.ok).toBe(true)
+    if (!beforeFinalMiss.ok) return
+    expect((beforeFinalMiss.result as ListResult).registrations).toEqual([{ containerName: 'coder', cwd: '/renewed' }])
+
+    await waitFor(async () => {
+      const list = await send({ kind: 'list' })
+      return renewedProbes >= 3 && list.ok && (list.result as ListResult).registrations.length === 0
+    })
+  })
+
+  test('GC ignores a threshold probe that raced a re-registration', async () => {
+    const probeStarted = deferred()
+    const releaseProbe = deferred()
+    const exec: DockerExec = async (args) => {
+      if (args[0] !== 'ps') return { exitCode: 1, stdout: '', stderr: 'unknown command' }
+      probeStarted.resolve()
+      await releaseProbe.promise
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+    daemon = await startDaemon({ exec, gcIntervalMs: 20, gcMissesToDeregister: 1 })
+    await send({ kind: 'register', containerName: 'coder', cwd: '/old' })
+
+    await probeStarted.promise
+    expect((await send({ kind: 'register', containerName: 'coder', cwd: '/renewed' })).ok).toBe(true)
+    releaseProbe.resolve()
+
+    await waitFor(async () => {
+      const list = await send({ kind: 'list' })
+      return (
+        list.ok && (list.result as ListResult).registrations.some((registration) => registration.cwd === '/renewed')
+      )
+    })
+    const list = await send({ kind: 'list' })
+    expect(list.ok).toBe(true)
+    if (!list.ok) return
+    expect((list.result as ListResult).registrations).toEqual([{ containerName: 'coder', cwd: '/renewed' }])
+  })
+
   test('GC tolerates docker ps failures (status=unknown does not count as gone)', async () => {
     let psFails = 0
     const exec: DockerExec = async (args) => {
@@ -336,7 +402,7 @@ describe('startDaemon', () => {
     expect(restartCalls[0]?.currentHostDaemon?.httpPort).toBeGreaterThan(0)
   })
 
-  test('populates the currentHostDaemon holder with an in-process registrar once booted', async () => {
+  test('populates the currentHostDaemon holder with in-process registration lifecycle callbacks', async () => {
     const holder = createCurrentHostDaemonHolder()
     daemon = await startDaemon({
       exec: fakeExec(),
@@ -344,7 +410,7 @@ describe('startDaemon', () => {
       currentHostDaemonHolder: holder,
     })
 
-    // then: the holder is populated and its registrar records a registration in-process
+    // then: the holder's callbacks mutate registration state in-process
     const current = await holder.ready()
     expect(current.httpPort).toBeGreaterThan(0)
     const reply = await current.register({
@@ -357,6 +423,9 @@ describe('startDaemon', () => {
     })
     expect(reply).toEqual({ ok: true })
     expect(daemon.registered()).toContain('coder')
+
+    await current.deregister('coder')
+    expect(daemon.registered()).not.toContain('coder')
   })
 
   test('restart RPC forwards build:true to the supervisor', async () => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -323,6 +323,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   const cwds = new Map<string, string>()
   const restartTokens = new Map<string, string>()
   const brokerTokens = new Map<string, string>()
+  const registrationGenerations = new Map<string, number>()
+  let nextRegistrationGeneration = 0
   const perContainerSerial = new Map<string, Promise<unknown>>()
   const gcMisses = new Map<string, number>()
   let stopped = false
@@ -398,6 +400,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       brokerTokens.delete(containerName)
       cwds.delete(containerName)
       restartTokens.delete(containerName)
+      registrationGenerations.delete(containerName)
       gcMisses.delete(containerName)
       if (opts.portbroker)
         await withCleanupTimeout(opts.portbroker.stop(containerName, 'fatal-auth'), cleanupStepTimeoutMs)
@@ -410,6 +413,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
 
   const applyRegistration = async (payload: RegisterPayload): Promise<void> => {
     const alreadyRegistered = cwds.has(payload.containerName)
+    registrationGenerations.set(payload.containerName, ++nextRegistrationGeneration)
+    gcMisses.delete(payload.containerName)
     cwds.set(payload.containerName, payload.cwd)
     if (payload.restartToken) restartTokens.set(payload.containerName, payload.restartToken)
     else restartTokens.delete(payload.containerName)
@@ -471,6 +476,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       const hadCwd = cwds.delete(req.containerName)
       restartTokens.delete(req.containerName)
       brokerTokens.delete(req.containerName)
+      registrationGenerations.delete(req.containerName)
       gcMisses.delete(req.containerName)
       if (opts.portbroker)
         await withCleanupTimeout(opts.portbroker.stop(req.containerName, 'deregistered'), cleanupStepTimeoutMs)
@@ -500,15 +506,20 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     return { ok: true, result }
   }
 
-  // Lets the supervisor's restart re-register the child in-process instead of
-  // over the socket. Awaits restore for the same no-mutation-before-restore
-  // invariant the socket dispatcher enforces before handleRegister.
+  // Lets the supervisor's restart update child registration lifecycle
+  // in-process instead of over the socket. Both callbacks await restore for
+  // the same no-mutation-before-restore invariant as the socket dispatcher.
   const registerCurrentChild = async (
     payload: HostDaemonRegisterPayload,
   ): Promise<{ ok: true } | { ok: false; reason: string }> => {
     await awaitRestored()
     const reply = await registerContainer(payload)
     return reply.ok ? { ok: true } : { ok: false, reason: reply.reason }
+  }
+
+  const deregisterCurrentChild = async (containerName: string): Promise<void> => {
+    await awaitRestored()
+    await handleDeregister({ containerName })
   }
 
   // Auth: only restart containers that registered with this daemon. The
@@ -531,7 +542,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       containerName: req.containerName,
       cwd,
       build: req.build,
-      currentHostDaemon: { httpPort, register: registerCurrentChild },
+      currentHostDaemon: { httpPort, register: registerCurrentChild, deregister: deregisterCurrentChild },
     })
     if (!ack.ok) return ack
     const result: RestartResult = { containerName: req.containerName, scheduled: true }
@@ -790,7 +801,11 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
   httpPort = httpServer.port ?? 0
   log({ kind: 'daemon-http-listening', host: httpHostname, port: httpPort })
-  opts.currentHostDaemonHolder?.set({ httpPort, register: registerCurrentChild })
+  opts.currentHostDaemonHolder?.set({
+    httpPort,
+    register: registerCurrentChild,
+    deregister: deregisterCurrentChild,
+  })
 
   const sockets = new Set<NetSocket>()
   const listener = createServer((socket) => {
@@ -812,28 +827,36 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
 
   const runGc = async (): Promise<void> => {
     for (const name of Array.from(cwds.keys())) {
+      const generation = registrationGenerations.get(name)
+      if (generation === undefined) continue
       const status = await probeContainerAlive(name)
-      if (status === 'alive') {
-        gcMisses.delete(name)
-        continue
-      }
-      if (status === 'unknown') continue
-      const misses = (gcMisses.get(name) ?? 0) + 1
-      if (misses < gcMissesToDeregister) {
-        gcMisses.set(name, misses)
-        continue
-      }
-      gcMisses.delete(name)
       void runSerially(name, async () => {
+        // A probe is only authoritative for the registration it observed before
+        // awaiting Docker. Re-registration installs a new generation before any
+        // later async registration work, so stale probes cannot spend its miss
+        // budget or remove it.
+        if (registrationGenerations.get(name) !== generation) return
+        if (status === 'alive') {
+          gcMisses.delete(name)
+          return
+        }
+        if (status === 'unknown') return
+        const misses = (gcMisses.get(name) ?? 0) + 1
+        if (misses < gcMissesToDeregister) {
+          gcMisses.set(name, misses)
+          return
+        }
+        gcMisses.delete(name)
         const hadCwd = cwds.delete(name)
         restartTokens.delete(name)
+        brokerTokens.delete(name)
+        registrationGenerations.delete(name)
         if (opts.portbroker) await withCleanupTimeout(opts.portbroker.stop(name, 'deregistered'), cleanupStepTimeoutMs)
         if (opts.kakaoRenewal) await withCleanupTimeout(opts.kakaoRenewal.stop(name), cleanupStepTimeoutMs)
         if (opts.webexRenewal) await withCleanupTimeout(opts.webexRenewal.stop(name), cleanupStepTimeoutMs)
         if (opts.teamsRenewal) await withCleanupTimeout(opts.teamsRenewal.stop(name), cleanupStepTimeoutMs)
         await removeRegistrationFile(name)
         if (hadCwd) log({ kind: 'deregister', containerName: name, reason: 'gone' })
-        return { ok: true }
       })
     }
   }


### PR DESCRIPTION
## Background

`typeclaw start` registers the future container with hostd before it builds the image and provisions the embedding model. That ordering was not accidental: registration needs the final host port and forwarding policy, while `planStart` needs the returned control URL, restart token, and broker token to render the container environment. The same registration is also the rollback target when preparation fails.

The problem appears on the starts where that early work matters most. A first build, forced rebuild, dependency change, or empty model cache can keep the process in preparation for longer than hostd's stale-registration window. During that time the container legitimately does not exist, so hostd's normal GC can exhaust its absence budget and remove the registration. The eventual `docker run` then carries credentials minted from an entry that no longer exists.

Warm starts usually hide this. Cold starts can produce a running container whose restart, renewal, and port-forward control was detached before launch.

## The early registration was doing real work — it just lived too long

The lifecycle combined two individually reasonable policies with incompatible clocks:

1. start registered early enough to obtain launch credentials and a cleanup handle;
2. Docker build and model provisioning intentionally overlapped to reduce cold-start latency;
3. hostd correctly collected registrations for repeatedly absent containers;
4. no step reconciled the registry with the launch plan after the unbounded preparation phase.

This is not fixed by extending the timeout. Cold preparation has no useful upper bound, while weakening GC retains genuinely stale entries. A heartbeat or lease would add a timer protocol, crash recovery, and suspension behavior. Moving the first registration after preparation would require splitting the planner and discard the existing rollback target.

The natural synchronization point already exists: after every potentially long preparation step and immediately before `docker run`.

## A fresh token was not yet a fresh lifetime

The first launch-boundary implementation re-registered and replanned together, which corrected the token/argv mismatch but exposed two deeper lifecycle gaps during review.

First, `applyRegistration` replaced the cwd and tokens without clearing accumulated `gcMisses`. Worse, `runGc` made its Docker probe outside the per-container serial queue and later deleted whatever registration occupied that name. A refresh after partial misses inherited the old budget, and a threshold probe already in flight could delete the newly refreshed entry immediately after it minted launch tokens.

Hostd now gives every successfully persisted registration a daemon-unique generation and resets its miss budget. GC captures that generation before probing, then performs every alive/gone miss mutation and threshold deletion inside `runSerially`. The queued operation first verifies that the current generation is the one it observed. A stale probe can therefore neither spend the refreshed entry's miss budget nor clear/delete its state. Fatal-auth, requested deregistration, and GC removal delete the current generation alongside the other registration maps.

Second, the later port-bind TOCTOU retry can require one more registration for a new host port. The old code assigned the retry result directly. If that registration returned `unavailable`, the prior live registration and its cleanup callback were lost even though the retry plan correctly dropped hostd control. The retry now retains the previous status until the result is known: an unavailable replacement explicitly cleans the prior entry before local state is replaced; a successful replacement is kept and is not accidentally deregistered.

## The launch boundary remains the stable reconciliation point

The complete sequence is now:

1. register early for port policy, planning, and preparation rollback;
2. complete image build and model provisioning;
3. re-register at the launch boundary, receiving a fresh generation and full GC miss budget;
4. rebuild only the launch plan with `imageExists: true` and `forceBuild: false`;
5. if Docker reports a port-bind race, retain the current cleanup target until registration for the new port succeeds or is proven unavailable;
6. launch with registry state and argv produced from the same registration.

Re-registering the same container remains the existing serialized replacement operation; no parallel registry primitive is introduced. Re-registering without replanning would leave stale tokens in Docker argv. Replanning without re-registering cannot restore a collected entry. Deleting on an unguarded stale probe would recreate the original race regardless of where refresh occurs.

`PreparedHostDaemonStatus` also carries the exact deregistration callback that created the registration. Rollback does not rediscover a potentially different daemon through process-global `TYPECLAW_HOME` state.

## Summary

- Refresh hostd registration and launch argv together immediately before `docker run`.
- Give each registration a fresh GC generation and full miss budget.
- Reject stale Docker probe results inside the per-container serial queue.
- Preserve and clean the prior registration when port-retry registration becomes unavailable.
- Rebuild retry plans without hostd control only after the old entry is removed.
- Bind every rollback to the daemon instance that accepted the registration.

## Side effects and failure semantics

A cold launch performs two bounded register calls, plus one more only if Docker proves the selected port was lost to a race. Each successful call replaces the same container entry, rotates control tokens, installs a new generation, and resets the absence budget. The second and retry plans are pinned to the already-built image; tests assert no duplicate build and final argv containing only the applicable registration's control values.

If launch refresh is unavailable, start removes the initial registration and preserves the existing degraded behavior by replanning without hostd control. If a port-retry registration is unavailable, it likewise removes the preceding live registration before launching without control. If refresh or replanning throws, start aborts before Docker run and cleans the registration that is actually live.

Generation state is in-memory and intentionally absent from the persistence format: it protects probes within one daemon lifetime, while a daemon restart rebuilds registrations before normal handlers proceed. The monotonically increasing counter prevents a stale probe from matching a later deregister/re-register cycle under the same container name.

## What this does NOT do

- Does not change hostd GC intervals, miss thresholds, or registration persistence.
- Does not add heartbeats, polling retries, or a lease protocol.
- Does not serialize model provisioning behind Docker build.
- Does not make hostd mandatory for container startup.
- Does not retry Docker run more than the existing single port-conflict retry.

## Review notes

Trace the invariant across both files: **the current hostd generation, its control tokens, the final `plan.runArgs`, and the cleanup callback must describe the same registration**.

In `src/hostd/daemon.ts`, verify every GC effect is generation-checked inside `runSerially`, re-registration clears misses, and all removal paths delete generation state. In `src/container/start.ts`, inspect both launch refresh and port-bind retry: failed replacement must clean the prior registration before discarding its callback, while successful replacement must not be cleaned through the old status.

## Verification

- Rebased onto `d43da137` (`0.48.9`).
- Focused hostd/start suite: 269 pass, 0 fail.
- Renewed-budget regression repeated 20 times: 20 pass, 0 fail.
- Stale threshold-probe regression repeated 20 times: 20 pass, 0 fail.
- `bun run typecheck`: pass.
- `bun run lint`: 0 errors (70 pre-existing warnings).
- `bun run format`: clean.
- GitHub CI: Linux, Windows, and oversubscribed flake guard pass on `4feec2a9`.
