### PR TITLE
Cover the bwrap file-mask contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,6 +246,11 @@ jobs:
       packages: write
 
     steps:
+      # Needed for scripts/verify-mask-fd-sandbox.sh below. The base image
+      # carries no repo source, so the sandbox smoke test ships as a script
+      # this job checks out and runs against the freshly published image.
+      - uses: actions/checkout@v4
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: actions/download-artifact@v4
@@ -319,6 +324,30 @@ jobs:
           docker pull --platform linux/amd64 "$IMAGE"
           docker pull --platform linux/arm64 "$IMAGE"
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:latest"
+
+      - name: Verify the sandbox file-mask contract against the shipped bwrap
+        # `bubblewrap` is installed unpinned, so the sandboxer can change
+        # behaviour on any base-image rebuild with no typeclaw commit. That is
+        # exactly how 0.48.8 shipped a total model-bash outage: bwrap 0.12.0
+        # started rejecting the reused --ro-bind-data fd that <= 0.11.0 had
+        # tolerated, and every sandboxed command — down to `echo` — died.
+        #
+        # The bwrap-gated unit test cannot catch this: `ubuntu-latest` has no
+        # bwrap, and even where one exists it is not the build that ships. So
+        # exercise the real mask argv inside the image we just published.
+        # `release` needs: this job, so a failure here blocks the irreversible
+        # npm publish rather than stranding users on a dead bash surface.
+        #
+        # The platform is passed explicitly and derived from the runner: the
+        # step above pulls BOTH architectures under this one tag, and on the
+        # classic image store that leaves the tag pointing at whichever it
+        # pulled last (arm64). Running that unqualified here would exec a
+        # foreign-arch binary with no QEMU registered and fail the release on
+        # exec format instead of on bwrap.
+        env:
+          VERSION: ${{ needs.checks.outputs.version }}
+          PLATFORM: linux/${{ runner.arch == 'ARM64' && 'arm64' || 'amd64' }}
+        run: scripts/verify-mask-fd-sandbox.sh "${REGISTRY_IMAGE}:${VERSION}" "${PLATFORM}"
 
   # ─────────────────────────── release ───────────────────────────
   # The irreversible publish path, gated on a verified multi-arch base image.

--- a/scripts/verify-mask-fd-sandbox.sh
+++ b/scripts/verify-mask-fd-sandbox.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Acceptance check for the --ro-bind-data file-mask contract (appendMasks in
+# src/sandbox/build.ts). Not a unit test: it needs the bubblewrap that actually
+# ships in the base image, which the macOS dev host cannot provide and which
+# `ubuntu-latest` does not match — so the bwrap-gated unit test silently skips
+# on every CI runner we have.
+#
+# Why it exists: bwrap copies a --ro-bind-data operand out of its fd and then
+# close()s it, so each mask needs its OWN fd. Sharing one appeared to work on
+# bubblewrap <= 0.11.0 (the next mkstemp reclaimed the just-freed slot and
+# copied the empty temp file onto itself) and hard-fails on 0.12.0 with
+# "Can't write data to file <dest>: Bad file descriptor" — which aborts the
+# WHOLE bwrap invocation, not just the mask, taking down every sandboxed bash
+# call down to `echo`. That shipped in 0.48.8.
+#
+# `bubblewrap` is installed unpinned (BASELINE_APT_PACKAGES), so this behaviour
+# can change under us on any base-image rebuild with no typeclaw commit. Wired
+# into release.yml's merge-base job, which runs before the irreversible npm
+# publish, so a bwrap that rejects our rendered command blocks the release.
+#
+# Asserts only the property we depend on — N masks over N distinct fds succeed
+# and every target reads back empty. It deliberately does NOT assert that a
+# SHARED fd fails: that pins upstream behaviour we neither control nor need.
+#
+# Usage: scripts/verify-mask-fd-sandbox.sh [image] [platform]
+#   image    defaults to ghcr.io/typeclaw/typeclaw-base:<version-from-package.json>
+#   platform e.g. linux/amd64; defaults to the daemon's native platform
+set -euo pipefail
+
+IMAGE="${1:-}"
+PLATFORM="${2:-}"
+if [ -z "$IMAGE" ]; then
+  version="$(node -p "require('./package.json').version" 2>/dev/null || echo latest)"
+  IMAGE="ghcr.io/typeclaw/typeclaw-base:${version}"
+fi
+
+# Mirrors CANONICAL_AGENT_SECRET_FILES + CANONICAL_AGENT_RUNTIME_PRIVATE_FILES.
+# The count is what matters here (one fd per mask); keep in sync if that grows.
+runner='
+set -u
+d=/tmp/maskcheck
+mkdir -p "$d"
+for f in env secrets.json auth.json incidents.json; do printf CANARY > "$d/$f"; done
+
+# The argv shape mirrors buildArgv()/appendMasks() in src/sandbox/build.ts:
+# masks render after the broad parent bind, and the rendered commandString
+# self-opens one /dev/null fd per masked file. Keep in sync if that changes.
+set +e
+out="$(bwrap --unshare-all \
+      --new-session --die-with-parent --clearenv \
+      --setenv PATH /usr/local/bin:/usr/bin:/bin --setenv HOME /tmp --setenv LANG C.UTF-8 \
+      --ro-bind /usr /usr --ro-bind /etc /etc --dev /dev --tmpfs /tmp \
+      --ro-bind-try /bin /bin --ro-bind-try /sbin /sbin --ro-bind-try /lib /lib --ro-bind-try /lib64 /lib64 \
+      --bind "$d" "$d" \
+      --ro-bind-data 3 "$d/env" \
+      --ro-bind-data 4 "$d/secrets.json" \
+      --ro-bind-data 5 "$d/auth.json" \
+      --ro-bind-data 6 "$d/incidents.json" \
+      bash -c "cat $d/env $d/secrets.json $d/auth.json $d/incidents.json" \
+      3</dev/null 4</dev/null 5</dev/null 6</dev/null 2>/tmp/maskcheck.err)"
+rc=$?
+set -e
+
+echo "bwrap: $(bwrap --version)"
+if [ $rc -ne 0 ]; then
+  echo "MASK_BWRAP_FAILED rc=$rc"
+  cat /tmp/maskcheck.err
+  exit 1
+fi
+if [ -n "$out" ]; then
+  echo "MASK_LEAKED: masked files were readable: [$out]"
+  exit 1
+fi
+echo "MASK_CONTRACT_OK: 4 masks over 4 distinct fds, all empty"
+'
+
+echo "Image: $IMAGE${PLATFORM:+ ($PLATFORM)}"
+
+# --pull=always plus an explicit platform, because the caller may have pulled
+# several architectures under this one tag. The classic Docker image store maps
+# a tag to exactly ONE image, so a preceding `docker pull --platform linux/amd64`
+# followed by `--platform linux/arm64` leaves the tag on whichever came LAST.
+# An unqualified `docker run` would then execute a foreign-arch image — and with
+# no QEMU registered that dies on exec format, failing the release for a reason
+# that has nothing to do with bwrap. Re-resolving the tag here keeps the check
+# honest on both the classic and containerd image stores.
+run_args=(--rm --pull=always --security-opt seccomp=unconfined)
+if [ -n "$PLATFORM" ]; then
+  run_args+=(--platform "$PLATFORM")
+fi
+
+docker run "${run_args[@]}" "$IMAGE" bash -c "$runner"

--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { buildSandboxedCommand } from './build'
+import { CANONICAL_AGENT_SECRET_FILES } from './canonical-secrets'
 import { SandboxPolicyError } from './errors'
 import type { SandboxPolicy } from './policy'
+import { CANONICAL_AGENT_RUNTIME_PRIVATE_FILES } from './runtime-private'
 
 function argvOf(command: string, policy?: SandboxPolicy): string[] {
   return buildSandboxedCommand(command, policy).argv
@@ -16,6 +18,10 @@ function argvOf(command: string, policy?: SandboxPolicy): string[] {
 function valueAfter(argv: string[], flag: string): string | undefined {
   const i = argv.indexOf(flag)
   return i === -1 ? undefined : argv[i + 1]
+}
+
+function maskRedirectFdsOf(commandString: string): string[] {
+  return [...commandString.matchAll(/(\d+)<\/dev\/null/g)].map((match) => match[1] as string)
 }
 
 function maskFdsOf(argv: string[]): [string, string][] {
@@ -305,6 +311,35 @@ describe('buildSandboxedCommand masks', () => {
   test('does NOT append the mask-fd redirect when only dirs are masked', () => {
     const { commandString } = buildSandboxedCommand('true', { masks: { dirs: ['/agent/workspace'] } })
     expect(commandString).not.toContain('3</dev/null')
+  })
+
+  // The fd numbering and the redirect list are produced by two separate
+  // expressions; if they ever drift apart, bwrap reads an fd the shell never
+  // opened and every sandboxed command dies EBADF. Pin them as one invariant
+  // at several mask counts rather than at one hard-coded arity.
+  test.each([1, 2, 3, 4, 8])('opens exactly the mask fds it binds, for %p masked file(s)', (count) => {
+    const files = Array.from({ length: count }, (_, i) => `/agent/secret-${i}`)
+
+    const { argv, commandString } = buildSandboxedCommand('true', { masks: { files } })
+    const opFds = maskFdsOf(argv).map(([fd]) => fd)
+
+    expect(opFds).toHaveLength(count)
+    expect(new Set(opFds).size).toBe(count)
+    expect(maskRedirectFdsOf(commandString)).toEqual(opFds)
+  })
+
+  // Guards the arity the runtime actually ships: adding a canonical secret
+  // file must not silently reintroduce a shared fd.
+  test('assigns a distinct fd to every canonical file the runtime masks', () => {
+    const files = [...CANONICAL_AGENT_SECRET_FILES, ...CANONICAL_AGENT_RUNTIME_PRIVATE_FILES].map((file) =>
+      join('/agent', file),
+    )
+
+    const { argv, commandString } = buildSandboxedCommand('true', { masks: { files } })
+    const opFds = maskFdsOf(argv).map(([fd]) => fd)
+
+    expect(new Set(opFds).size).toBe(files.length)
+    expect(maskRedirectFdsOf(commandString)).toEqual(opFds)
   })
 
   test('renders all masks AFTER the broad parent bind so the last op wins', () => {


### PR DESCRIPTION
## Background

PR #1423 fixed a sandbox bug where `src/sandbox/build.ts` reused one file descriptor across all four `--ro-bind-data` secret masks. bwrap consumes a `--ro-bind-data` operand fd and then `close()`s it, so the second mask hit `Bad file descriptor` and aborted the entire bwrap invocation — every sandboxed bash call, down to `echo`, failed. It shipped in 0.48.8 and is fixed in 0.48.9. This PR adds the coverage that would have caught it, closing two gaps that let it ship green.

**Gap 1 — the unit assertions pinned one hard-coded three-mask arity.** Two ways remained to reintroduce the bug: a different mask count, and the fd list drifting out of step with the redirect list. The second is the dangerous one, because the argv fds and the `<fd></dev/null` redirects are produced by two separate expressions — binding fd 4 while opening only fd 3 puts bwrap back on a descriptor the shell never opened.

**Gap 2 — nothing we run can observe the sandboxer we actually ship.** `bubblewrap` is in `BASELINE_APT_PACKAGES` unpinned, so its behavior can change on any base-image rebuild with no typeclaw commit. That is precisely what happened: bwrap 0.12.0 began rejecting the reused fd that 0.11.0 tolerated. Confirmed empirically against the published base images — `typeclaw-base:0.48.7` ships bubblewrap 0.11.0, `typeclaw-base:0.48.8` ships 0.12.0; both are Debian 13, so no base-OS change was involved. The bwrap-gated unit test cannot catch this: CI runs bare `ubuntu-latest` with no bwrap, so it silently skips, and even where a bwrap exists it is not the build that ships.

## Summary

- `src/sandbox/build.test.ts` — replace the single hard-coded three-mask assertion with `test.each([1, 2, 3, 4, 8])` asserting the real invariant at several arities: every `--ro-bind-data` fd is unique, and the set of bound fds equals the set of opened redirects exactly. Add a case driven by the canonical mask list the runtime actually ships (`CANONICAL_AGENT_SECRET_FILES` + `CANONICAL_AGENT_RUNTIME_PRIVATE_FILES`), so adding a fifth secret file cannot silently share a descriptor.
- `scripts/verify-mask-fd-sandbox.sh` — a new acceptance harness, in the shape of the existing `verify-procbind-sandbox.sh` / `verify-realproc-sandbox.sh` scripts (operator-runnable, takes an image argument, defaults to the version in `package.json`). Renders the real mask argv against a live container and asserts N masks over N distinct fds succeed with every target reading back empty.
- `.github/workflows/release.yml` — wire the script into the `merge-base` job, which already pulls the freshly published image, and add `actions/checkout@v4` to that job since the base image carries no repo source. Because `release` has `needs: [checks, merge-base]`, a bwrap that rejects our rendered mask argv now blocks the irreversible npm publish instead of stranding every agent on a dead bash surface.

Verified against two injected regressions on the unit side: (a) a shared fd everywhere, (b) argv fds distinct but only fd 3 redirected. Case (b) passes the pre-existing assertions and fails the new ones — that is the added coverage.

## What this does NOT do

- Does not assert that a shared fd fails. The script checks only the property we depend on — N masks over N distinct fds succeed and read back empty — deliberately not pinning upstream failure behavior we neither control nor need, which would block releases on a benign upstream change.
- Does not pin `bubblewrap` in the base image. Detecting drift at release time was preferred over freezing a security-relevant sandboxer that should keep receiving distro CVE fixes. Worth a separate discussion.

## Review notes

The load-bearing property in both the unit tests and the shell script is the same: the fd set bound by `--ro-bind-data` ops must equal the fd set opened by `<fd></dev/null` redirects, with no duplicates. Verify `maskFdsOf`/`maskRedirectFdsOf` in the test file actually parse the argv and command string the way `buildSandboxedCommand` renders them, and that the canonical-file test case tracks `CANONICAL_AGENT_SECRET_FILES`/`CANONICAL_AGENT_RUNTIME_PRIVATE_FILES` rather than a copy of the file list.

## Verification

- Script passes against published `typeclaw-base:0.48.7` (bubblewrap 0.11.0) and `typeclaw-base:0.48.9` (0.12.0).
- Both failure directions proven: forcing a shared fd reproduces `bwrap: Can't write data to file .../secrets.json: Bad file descriptor` and exits 1; deleting the mask ops surfaces the planted canaries and exits 1.
- `bun run test` — 13,371 pass, 32 skip, 0 fail.
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` — clean.
- `release.yml` re-parsed as YAML to confirm step ordering and that `release` still has `needs: [checks, merge-base]`.
- `shellcheck` on the new script reports only SC2016 (info), identical to what both existing `verify-*-sandbox.sh` scripts report; the repo uses no shellcheck disable directives.