### PR TITLE
Keep compose start/restart output on the clack board

### DIFF
--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -306,8 +306,11 @@ export const composeCommand = defineCommand({
 // Single clack spinner with a multi-line message body, one line per agent.
 // Concurrent clack spinners can't coexist: each one's render loop writes
 // cursor.to(0) + erase.down() to process.stdout, so they trample each other.
-// Multi-line redraw is safe — clack counts newlines in the previous message
-// and walks the cursor up before erasing (see @clack/prompts spinner.ts).
+// Multi-line redraw is safe while this board owns the terminal — clack counts
+// newlines in the previous message and walks the cursor up before erasing (see
+// @clack/prompts spinner.ts). Compose start/restart therefore capture process
+// output instead of letting child progress or warnings invalidate clack's
+// cursor position.
 type Board = {
   add: (s: ReturnType<typeof spinner>, name: string, state: string) => void
   set: (s: ReturnType<typeof spinner>, name: string, state: string) => void
@@ -356,7 +359,7 @@ function makeBoard(header: string): Board {
 }
 
 function formatStartDone<T extends { alreadyRunning?: boolean; hostPort: number }>(result: AgentResult<T>): string {
-  if (!result.ok) return `${c.red('✖')} ${c.red('failed:')} ${result.reason}`
+  if (!result.ok) return appendWarnings(`${c.red('✖')} ${c.red('failed:')} ${result.reason}`, result.warnings)
   const verb = result.data.alreadyRunning ? 'already running' : 'started'
   const head = `${c.green('✔')} ${verb} on host port ${c.cyan(String(result.data.hostPort))}`
   return appendWarnings(head, result.warnings)
@@ -369,7 +372,7 @@ function formatStopDone<T extends { running: boolean }>(result: AgentResult<T>):
 }
 
 function formatRestartDone<T extends { start: { hostPort: number } }>(result: AgentResult<T>): string {
-  if (!result.ok) return `${c.red('✖')} ${c.red('failed:')} ${result.reason}`
+  if (!result.ok) return appendWarnings(`${c.red('✖')} ${c.red('failed:')} ${result.reason}`, result.warnings)
   const head = `${c.green('✔')} restarted on host port ${c.cyan(String(result.data.start.hostPort))}`
   return appendWarnings(head, result.warnings)
 }

--- a/src/compose/restart.test.ts
+++ b/src/compose/restart.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { Controller, RestartOptions } from '@/container'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { composeRestart, type ComposeRestartEvent } from './restart'
@@ -23,6 +24,12 @@ async function makeInvalidAgent(parent: string, name: string): Promise<void> {
   const dir = join(parent, name)
   await mkdir(dir, { recursive: true })
   await writeFile(join(dir, 'typeclaw.json'), 'this is not json\n')
+}
+
+async function makeValidAgent(parent: string, name: string): Promise<void> {
+  const dir = join(parent, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'typeclaw.json'), '{}\n')
 }
 
 describe('composeRestart events', () => {
@@ -117,5 +124,25 @@ describe('composeRestart events', () => {
     await makeInvalidAgent(root, 'alpha')
     const { results } = await composeRestart({ rootCwd: root, preferredHostPort: 8973 })
     expect(results).toHaveLength(1)
+  })
+
+  test('keeps inherited build output away from the live compose board', async () => {
+    await makeValidAgent(root, 'alpha')
+    let restartOptions: RestartOptions | undefined
+    const restart: Controller['restart'] = async (options) => {
+      restartOptions = options
+      options.onWarning?.('captured warning')
+      return { ok: false, reason: 'simulated failure' }
+    }
+
+    const { results } = await composeRestart({ rootCwd: root, preferredHostPort: 8973 }, { restart })
+
+    expect(restartOptions?.streamOutput).toBe(false)
+    expect(results[0]).toEqual({
+      name: 'alpha',
+      ok: false,
+      reason: 'simulated failure',
+      warnings: ['captured warning'],
+    })
   })
 })

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -1,5 +1,5 @@
 import { validateConfig } from '@/config'
-import { resolveController } from '@/container'
+import { type Controller, resolveController } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 import type { AgentResult, StartSuccess } from './start'
@@ -20,25 +20,32 @@ export type ComposeRestartOptions = {
   onProgress?: (event: ComposeRestartEvent) => void
 }
 
+export type ComposeRestartDeps = {
+  restart?: Controller['restart']
+}
+
 export type ComposeRestartResult = {
   agents: AgentEntry[]
   results: AgentResult<RestartData>[]
 }
 
-export async function composeRestart({
-  rootCwd,
-  preferredHostPort,
-  forceBuild = false,
-  cliEntry,
-  onProgress,
-}: ComposeRestartOptions): Promise<ComposeRestartResult> {
+export async function composeRestart(
+  { rootCwd, preferredHostPort, forceBuild = false, cliEntry, onProgress }: ComposeRestartOptions,
+  { restart = (options) => resolveController().restart(options) }: ComposeRestartDeps = {},
+): Promise<ComposeRestartResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<RestartData>> => {
       onProgress?.({ kind: 'agent-start', name: agent.name })
-      const result = await runOne(agent.name, agent.cwd, preferredHostPort, forceBuild, cliEntry, () => {
-        onProgress?.({ kind: 'agent-stopped', name: agent.name })
-      })
+      const result = await runOne(
+        agent.name,
+        agent.cwd,
+        preferredHostPort,
+        forceBuild,
+        cliEntry,
+        () => onProgress?.({ kind: 'agent-stopped', name: agent.name }),
+        restart,
+      )
       onProgress?.({ kind: 'agent-done', name: agent.name, result })
       return result
     }),
@@ -53,26 +60,29 @@ async function runOne(
   forceBuild: boolean,
   cliEntry: string | undefined,
   onStopped: () => void,
+  restart: Controller['restart'],
 ): Promise<AgentResult<RestartData>> {
   const validated = validateConfig(cwd)
   if (!validated.ok) return { name, ok: false, reason: validated.reason }
+  const warnings = [...(validated.warnings ?? [])]
   try {
-    const controller = resolveController()
-    const restarted = await controller.restart({
+    const restarted = await restart({
       cwd,
       preferredHostPort,
       forceBuild,
       cliEntry,
       onStopped,
+      streamOutput: false,
+      onWarning: (warning) => warnings.push(warning),
     })
-    if (!restarted.ok) return { name, ok: false, reason: restarted.reason }
+    if (!restarted.ok) return { name, ok: false, reason: restarted.reason, warnings }
     return {
       name,
       ok: true,
       data: { stop: restarted.stop, start: restarted.start },
-      warnings: validated.warnings,
+      warnings,
     }
   } catch (error) {
-    return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+    return { name, ok: false, reason: error instanceof Error ? error.message : String(error), warnings }
   }
 }

--- a/src/compose/start.test.ts
+++ b/src/compose/start.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { Controller, StartOptions } from '@/container'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { composeStart, type ComposeStartEvent } from './start'
@@ -25,6 +26,12 @@ async function makeInvalidAgent(parent: string, name: string): Promise<void> {
   const dir = join(parent, name)
   await mkdir(dir, { recursive: true })
   await writeFile(join(dir, 'typeclaw.json'), 'this is not json\n')
+}
+
+async function makeValidAgent(parent: string, name: string): Promise<void> {
+  const dir = join(parent, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'typeclaw.json'), '{}\n')
 }
 
 describe('composeStart events', () => {
@@ -97,5 +104,25 @@ describe('composeStart events', () => {
     await makeInvalidAgent(root, 'alpha')
     const { results } = await composeStart({ rootCwd: root, preferredHostPort: 8973 })
     expect(results).toHaveLength(1)
+  })
+
+  test('keeps inherited build output away from the live compose board', async () => {
+    await makeValidAgent(root, 'alpha')
+    let startOptions: StartOptions | undefined
+    const start: Controller['start'] = async (options) => {
+      startOptions = options
+      options.onWarning?.('captured warning')
+      return { ok: false, reason: 'simulated failure' }
+    }
+
+    const { results } = await composeStart({ rootCwd: root, preferredHostPort: 8973 }, { start })
+
+    expect(startOptions?.streamOutput).toBe(false)
+    expect(results[0]).toEqual({
+      name: 'alpha',
+      ok: false,
+      reason: 'simulated failure',
+      warnings: ['captured warning'],
+    })
   })
 })

--- a/src/compose/start.ts
+++ b/src/compose/start.ts
@@ -1,11 +1,11 @@
 import { validateConfig } from '@/config'
-import { resolveController, type StartResult } from '@/container'
+import { type Controller, resolveController, type StartResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 
 export type AgentResult<T> =
   | { name: string; ok: true; data: T; warnings?: string[] }
-  | { name: string; ok: false; reason: string }
+  | { name: string; ok: false; reason: string; warnings?: string[] }
 
 export type StartSuccess = Extract<StartResult, { ok: true }>
 
@@ -21,23 +21,24 @@ export type ComposeStartOptions = {
   onProgress?: (event: ComposeStartEvent) => void
 }
 
+export type ComposeStartDeps = {
+  start?: Controller['start']
+}
+
 export type ComposeStartResult = {
   agents: AgentEntry[]
   results: AgentResult<StartSuccess>[]
 }
 
-export async function composeStart({
-  rootCwd,
-  preferredHostPort,
-  forceBuild = false,
-  cliEntry,
-  onProgress,
-}: ComposeStartOptions): Promise<ComposeStartResult> {
+export async function composeStart(
+  { rootCwd, preferredHostPort, forceBuild = false, cliEntry, onProgress }: ComposeStartOptions,
+  { start = (options) => resolveController().start(options) }: ComposeStartDeps = {},
+): Promise<ComposeStartResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<StartSuccess>> => {
       onProgress?.({ kind: 'agent-start', name: agent.name })
-      const result = await runOne(agent.name, agent.cwd, preferredHostPort, forceBuild, cliEntry)
+      const result = await runOne(agent.name, agent.cwd, preferredHostPort, forceBuild, cliEntry, start)
       onProgress?.({ kind: 'agent-done', name: agent.name, result })
       return result
     }),
@@ -51,14 +52,23 @@ async function runOne(
   preferredHostPort: number,
   forceBuild: boolean,
   cliEntry: string | undefined,
+  start: Controller['start'],
 ): Promise<AgentResult<StartSuccess>> {
   const validated = validateConfig(cwd)
   if (!validated.ok) return { name, ok: false, reason: validated.reason }
+  const warnings = [...(validated.warnings ?? [])]
   try {
-    const data = await resolveController().start({ cwd, preferredHostPort, forceBuild, cliEntry })
-    if (!data.ok) return { name, ok: false, reason: data.reason }
-    return { name, ok: true, data, warnings: validated.warnings }
+    const data = await start({
+      cwd,
+      preferredHostPort,
+      forceBuild,
+      cliEntry,
+      streamOutput: false,
+      onWarning: (warning) => warnings.push(warning),
+    })
+    if (!data.ok) return { name, ok: false, reason: data.reason, warnings }
+    return { name, ok: true, data, warnings }
   } catch (error) {
-    return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
+    return { name, ok: false, reason: error instanceof Error ? error.message : String(error), warnings }
   }
 }

--- a/src/container/restart.ts
+++ b/src/container/restart.ts
@@ -6,6 +6,8 @@ export type RestartOptions = {
   cwd: string
   preferredHostPort: number
   forceBuild?: boolean
+  streamOutput?: boolean
+  onWarning?: (warning: string) => void
   cliEntry?: string
   reuseCurrentHostDaemon?: boolean
   currentHostDaemon?: CurrentHostDaemon
@@ -44,6 +46,8 @@ async function restartWithLease(
     cwd: options.cwd,
     preferredHostPort: options.preferredHostPort,
     forceBuild: options.forceBuild,
+    streamOutput: options.streamOutput,
+    onWarning: options.onWarning,
     cliEntry: options.cliEntry,
     reuseCurrentHostDaemon: options.reuseCurrentHostDaemon,
     currentHostDaemon: options.currentHostDaemon,

--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -20,6 +20,7 @@ import {
   isContainerNameConflict,
   isMissingDockerCredentialHelper,
   parseContainerInspectOutput,
+  readCapturedStream,
   resolveDockerBinary,
   sanitizeDockerConfigJson,
   sanitizeDockerStderr,
@@ -811,5 +812,32 @@ describe('spawnInheritTeeStderr', () => {
     expect(killed).toBe(true)
     expect(await exited).toBe(137)
     expect(stderr.locked).toBe(false)
+  })
+})
+
+describe('readCapturedStream', () => {
+  test('drains the stream while retaining only the requested tail', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('first-'))
+        controller.enqueue(new TextEncoder().encode('second'))
+        controller.close()
+      },
+    })
+
+    expect(await readCapturedStream(stream, 6)).toBe('second')
+    expect(stream.locked).toBe(false)
+  })
+
+  test('drains discarded output without retaining it', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('verbose build output'))
+        controller.close()
+      },
+    })
+
+    expect(await readCapturedStream(stream, 0)).toBe('')
+    expect(stream.locked).toBe(false)
   })
 })

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -20,6 +20,10 @@ export type DockerExecOptions = {
   // stay visible to the user while start() still inspects stderr to detect the
   // missing-credential-helper failure and decide whether to retry.
   captureStderr?: boolean
+  // Piped commands normally retain complete output. Long-running callers can
+  // still drain without retaining stdout and keep only stderr's diagnostic tail.
+  captureStdout?: boolean
+  maxCapturedStderrBytes?: number
 }
 
 export type DockerExec = (args: string[], options?: DockerExecOptions) => Promise<DockerExecResult>
@@ -83,9 +87,9 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
       signal: options?.signal,
       env,
     })
-    const exitCode = await proc.exited
-    const stdout = await new Response(proc.stdout).text()
-    const stderr = await new Response(proc.stderr).text()
+    const stdoutPromise = readCapturedStream(proc.stdout, options?.captureStdout === false ? 0 : undefined)
+    const stderrPromise = readCapturedStream(proc.stderr, options?.maxCapturedStderrBytes)
+    const [exitCode, stdout, stderr] = await Promise.all([proc.exited, stdoutPromise, stderrPromise])
     return { exitCode, stdout, stderr }
   } catch (error) {
     if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
@@ -93,6 +97,29 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
     }
     throw error
   }
+}
+
+export async function readCapturedStream(stream: ReadableStream<Uint8Array>, maxBytes?: number): Promise<string> {
+  if (maxBytes === undefined) return await new Response(stream).text()
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) throw new RangeError('maxBytes must be a non-negative integer')
+
+  const reader = stream.getReader()
+  let tail = Buffer.alloc(0)
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (maxBytes === 0) continue
+      const chunk = Buffer.from(value)
+      tail =
+        chunk.length >= maxBytes
+          ? chunk.subarray(chunk.length - maxBytes)
+          : Buffer.concat([tail, chunk]).subarray(-maxBytes)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return tail.toString('utf8')
 }
 
 // Streams a docker child's stdout straight to the parent terminal while teeing

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1542,6 +1542,10 @@ type RecordedCall = {
   args: string[]
   dockerfileSnapshot: string | null
   env?: Record<string, string | undefined>
+  inheritStdio?: boolean
+  captureStderr?: boolean
+  captureStdout?: boolean
+  maxCapturedStderrBytes?: number
   // Snapshot, taken at call time, of whether the build's DOCKER_CONFIG dir has a
   // `contexts/` subdir. Lets a test assert the sanitized config deep-copied the
   // docker context state BEFORE runImageBuild's finally removes the temp dir.
@@ -1578,6 +1582,8 @@ function fakeDockerExec(scenario: {
   dockerPlatformName?: string
   buildxAvailable?: boolean
   buildxBuildFails?: boolean
+  buildFails?: boolean
+  buildStderr?: string
   // Simulate a broken credential helper: build calls fail with the helper-not-
   // found stderr UNTIL the call is made with DOCKER_CONFIG set in its env (the
   // sanitized-config retry), at which point the build succeeds.
@@ -1603,7 +1609,16 @@ function fakeDockerExec(scenario: {
     }
     const dockerConfig = options?.env?.DOCKER_CONFIG
     const dockerConfigHasContexts = dockerConfig === undefined ? undefined : existsSync(join(dockerConfig, 'contexts'))
-    calls.push({ args, dockerfileSnapshot, env: options?.env, dockerConfigHasContexts })
+    calls.push({
+      args,
+      dockerfileSnapshot,
+      env: options?.env,
+      inheritStdio: options?.inheritStdio,
+      captureStderr: options?.captureStderr,
+      captureStdout: options?.captureStdout,
+      maxCapturedStderrBytes: options?.maxCapturedStderrBytes,
+      dockerConfigHasContexts,
+    })
 
     if (args[0] === 'image' && args[1] === 'inspect') {
       return { exitCode: scenario.imageExists ? 0 : 1, stdout: '', stderr: '' }
@@ -1681,6 +1696,9 @@ function fakeDockerExec(scenario: {
       return { exitCode: 0, stdout: '', stderr: '' }
     }
     if (isBuildCall(args)) {
+      if (scenario.buildFails) {
+        return { exitCode: 1, stdout: '', stderr: scenario.buildStderr ?? 'build exploded' }
+      }
       // Simulate "buildx plugin present but the build fails" (e.g. no usable
       // builder). The legacy `docker build` retry still succeeds.
       if (scenario.buildxBuildFails && args[0] === 'buildx') {
@@ -2054,6 +2072,36 @@ describe('start (composition)', () => {
     }
   })
 
+  test('returns warnings instead of writing them while a parent renderer owns the terminal', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    const stderr = spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const warnings: string[] = []
+
+    try {
+      const result = await start({
+        cwd: root,
+        preferredHostPort: 8973,
+        streamOutput: false,
+        onWarning: (warning) => warnings.push(warning),
+        exec,
+        allocatePort: deterministicAllocator,
+        ensureDeps: noEnsureDeps,
+        autoUpgrade: noAutoUpgrade,
+        ...bypassVerify,
+        provisionGithubCliStore: () => ({ ok: false, reason: 'sensitive-command-output' }),
+      })
+
+      expect(result.ok).toBe(true)
+      expect(warnings).toEqual([expect.stringContaining('Could not refresh GitHub CLI credentials')])
+      expect(warnings.join('')).not.toContain('sensitive-command-output')
+      expect(stderr).not.toHaveBeenCalled()
+    } finally {
+      stderr.mockRestore()
+    }
+  })
+
   test('passes the canonical agent root and configured writable mount roots to GitHub CLI refresh', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
@@ -2279,6 +2327,97 @@ describe('start (composition)', () => {
     expect(buildCall?.args).toContain('--load')
     expect(buildCall?.dockerfileSnapshot).toContain('# syntax=docker/dockerfile:1.7')
     expect(buildCall?.dockerfileSnapshot).toContain('--mount=type=cache')
+    expect(buildCall?.inheritStdio).toBe(true)
+    expect(buildCall?.captureStderr).toBe(true)
+  })
+
+  test('captures build output when streaming is disabled by a live parent renderer', async () => {
+    await writeFile(join(root, 'Dockerfile'), 'FROM stale\n# no git\n')
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({
+      imageExists: false,
+      container: { exists: false },
+      buildxAvailable: true,
+      buildxBuildFails: true,
+    })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      streamOutput: false,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    const buildCalls = calls.filter((call) => isBuildCall(call.args))
+    expect(buildCalls).toHaveLength(2)
+    for (const buildCall of buildCalls) {
+      expect(buildCall.inheritStdio).toBeUndefined()
+      expect(buildCall.captureStderr).toBeUndefined()
+      expect(buildCall.captureStdout).toBe(false)
+      expect(buildCall.maxCapturedStderrBytes).toBe(32 * 1024)
+    }
+  })
+
+  test('returns a safe recovery command when a live parent renderer suppresses build output', async () => {
+    await writeFile(join(root, 'Dockerfile'), 'FROM stale\n# no git\n')
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({
+      imageExists: false,
+      container: { exists: false },
+      buildxAvailable: true,
+      buildFails: true,
+      buildStderr: 'docker: Error response from daemon: unavailable\n',
+    })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      streamOutput: false,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
+      ...bypassVerify,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        'docker build failed (exit code 1). Run `typeclaw start --build` from this agent directory to view the full build output.',
+    })
+  })
+
+  test('does not expose captured build output in the compose failure reason', async () => {
+    await writeFile(join(root, 'Dockerfile'), 'FROM stale\n# no git\n')
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({
+      imageExists: false,
+      container: { exists: false },
+      buildxAvailable: true,
+      buildFails: true,
+      buildStderr: '\x1b[31msensitive-build-output\x1b[0m\r',
+    })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      streamOutput: false,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.reason).not.toContain('sensitive-build-output')
+    expect(result.reason).toContain('typeclaw start --build')
   })
 
   test('without buildx, falls back to legacy `docker build` against a BuildKit-stripped Dockerfile so start still succeeds', async () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -132,6 +132,10 @@ export type StartOptions = {
   cwd: string
   preferredHostPort: number
   forceBuild?: boolean
+  // A parent live renderer must be the terminal's only cursor owner. Compose
+  // disables process output so child progress and warnings cannot corrupt it.
+  streamOutput?: boolean
+  onWarning?: (warning: string) => void
   exec?: DockerExec
   // Test seam: allows tests to inject a deterministic port allocator. In
   // production we go through the real kernel via `findFreePort`.
@@ -242,6 +246,8 @@ async function runStart({
   cwd,
   preferredHostPort,
   forceBuild = false,
+  streamOutput = true,
+  onWarning,
   exec = defaultDockerExec,
   allocatePort = findFreePort,
   cliEntry,
@@ -327,7 +333,11 @@ async function runStart({
     }
 
     const githubCliDeniedRoots = resolveGithubCliDeniedRoots(cwd, await loadTypeclawConfig(cwd))
-    await refreshGithubCliStore(cwd, githubCliDeniedRoots, provisionGithubCliStoreForAgent)
+    const githubCliWarning = await refreshGithubCliStore(cwd, githubCliDeniedRoots, provisionGithubCliStoreForAgent)
+    if (githubCliWarning !== null) {
+      if (streamOutput) process.stderr.write(githubCliWarning)
+      else onWarning?.(githubCliWarning.trim())
+    }
 
     if (agentMessengerPolicy.migrate) {
       const agentMessengerMigration = await migrateAgentMessengerConfigDir(cwd)
@@ -551,16 +561,23 @@ async function runStart({
 
     let built = false
     if (plan.needsBuild) {
-      const buildOk = await runImageBuild({
+      const buildResult = await runImageBuild({
         exec,
         cwd,
         imageTag: plan.imageTag,
         buildContext: plan.buildContext,
         hasBuildx,
+        streamOutput,
       })
-      if (!buildOk) {
+      if (!buildResult.ok) {
         await cleanupHostDaemonRegistration(containerName, hostd)
-        return { ok: false, reason: 'docker build failed' }
+        const retryDetail = buildResult.credentialHelperRetried
+          ? ' The build was also retried without the configured Docker credential helper.'
+          : ''
+        const detail = streamOutput
+          ? ''
+          : ` (exit code ${buildResult.exitCode}). Run \`typeclaw start --build\` from this agent directory to view the full build output.${retryDetail}`
+        return { ok: false, reason: `docker build failed${detail}` }
       }
       built = true
     }
@@ -674,19 +691,19 @@ async function refreshGithubCliStore(
   agentDir: string,
   deniedRoots: readonly string[],
   provision: (options: ProvisionGithubCliStoreOptions) => GithubCliProvisionResult | Promise<GithubCliProvisionResult>,
-): Promise<void> {
+): Promise<string | null> {
   let refreshed = false
   try {
     refreshed = (await provision({ agentDir, deniedRoots })).ok
   } catch {
     refreshed = false
   }
-  if (refreshed) return
+  if (refreshed) return null
 
-  process.stderr.write(
+  return (
     'typeclaw: warning: Could not refresh GitHub CLI credentials from the host. ' +
-      'Keeping the previously persisted credential store. Run `gh auth login --hostname github.com` on the host, ' +
-      'then restart TypeClaw.\n',
+    'Keeping the previously persisted credential store. Run `gh auth login --hostname github.com` on the host, ' +
+    'then restart TypeClaw.\n'
   )
 }
 
@@ -1042,8 +1059,9 @@ async function runImageBuild(args: {
   imageTag: string
   buildContext: string
   hasBuildx: boolean
-}): Promise<boolean> {
-  const { exec, cwd, imageTag, buildContext, hasBuildx } = args
+  streamOutput: boolean
+}): Promise<{ ok: true } | { ok: false; exitCode: number; credentialHelperRetried: boolean }> {
+  const { exec, cwd, imageTag, buildContext, hasBuildx, streamOutput } = args
   const buildArgv = (frontend: 'buildx' | 'legacy'): string[] =>
     frontend === 'buildx'
       ? ['buildx', 'build', '--load', '-t', imageTag, buildContext]
@@ -1051,12 +1069,17 @@ async function runImageBuild(args: {
 
   let sanitizedConfig: SanitizedDockerConfig | null = null
   const attempt = async (frontend: 'buildx' | 'legacy'): Promise<DockerExecResult> =>
-    exec(buildArgv(frontend), { cwd, inheritStdio: true, captureStderr: true, env: sanitizedConfig?.env })
+    exec(buildArgv(frontend), {
+      cwd,
+      ...(streamOutput ? { inheritStdio: true, captureStderr: true } : {}),
+      ...(streamOutput ? {} : { captureStdout: false, maxCapturedStderrBytes: 32 * 1024 }),
+      env: sanitizedConfig?.env,
+    })
 
   try {
     let frontend: 'buildx' | 'legacy' = hasBuildx ? 'buildx' : 'legacy'
     let result = await attempt(frontend)
-    if (result.exitCode === 0) return true
+    if (result.exitCode === 0) return { ok: true }
 
     // Same-frontend retry: a broken credential helper aborts the pull before
     // the builder ever matters, so strip it and retry the identical build.
@@ -1064,7 +1087,7 @@ async function runImageBuild(args: {
       sanitizedConfig = await createSanitizedDockerConfig()
       if (sanitizedConfig) {
         result = await attempt(frontend)
-        if (result.exitCode === 0) return true
+        if (result.exitCode === 0) return { ok: true }
       }
     }
 
@@ -1075,23 +1098,23 @@ async function runImageBuild(args: {
       await refreshDockerfile(cwd, { buildKit: false })
       frontend = 'legacy'
       result = await attempt(frontend)
-      if (result.exitCode === 0) return true
+      if (result.exitCode === 0) return { ok: true }
       if (sanitizedConfig === null && isMissingDockerCredentialHelper(result.stderr)) {
         sanitizedConfig = await createSanitizedDockerConfig()
         if (sanitizedConfig) {
           result = await attempt(frontend)
-          if (result.exitCode === 0) return true
+          if (result.exitCode === 0) return { ok: true }
         }
       }
     }
 
-    if (sanitizedConfig !== null) {
-      process.stderr.write(
+    if (sanitizedConfig !== null && streamOutput) {
+      const guidance =
         'typeclaw: docker build still failed after retrying public image pulls without the configured ' +
-          'credential helper. Your ~/.docker/config.json credsStore/credHelpers may be broken.\n',
-      )
+        'credential helper. Your ~/.docker/config.json credsStore/credHelpers may be broken.'
+      process.stderr.write(`${guidance}\n`)
     }
-    return false
+    return { ok: false, exitCode: result.exitCode, credentialHelperRetried: sanitizedConfig !== null }
   } finally {
     await sanitizedConfig?.cleanup()
   }


### PR DESCRIPTION
## Background

`typeclaw compose start`/`restart` render a single multi-line clack spinner (the "board") tracking every agent's progress. Clack's spinner redraw works by counting newlines in its own previous message and walking the cursor up before erasing — it assumes it is the terminal's only writer.

`container/start.ts`'s Docker build step used `inheritStdio: true`, letting BuildKit's own progress output stream straight to the terminal. BuildKit's progress output goes to both stdout and stderr, and both streams share the same terminal cursor as clack's stdout — BuildKit has no concept of clack's cursor bookkeeping, so the two writers stomped on each other: BuildKit's progress lines desynced the board's line count, and the board's next redraw erased or overwrote the wrong region. Warnings collected during start/restart (GitHub CLI credential refresh failures, config validation warnings) were similarly either written directly to the terminal or dropped, bypassing the board entirely.

## Summary

### Give compose exclusive ownership of terminal output

`start.ts` and `restart.ts` (`container/`) take a new `streamOutput` option (default `true` for the single-agent CLI path, `false` for compose). When `false`, the Docker build step captures stdout/stderr instead of inheriting the terminal, so BuildKit progress never touches the board's cursor. `compose/start.ts` and `compose/restart.ts` now pass `streamOutput: false` when calling into the container controller.

### Drain captured output concurrently instead of sequentially

`container/shared.ts`'s `defaultDockerExec` previously awaited `proc.exited`, then read stdout, then read stderr — each read starting only after the prior one finished. For a long-running build this delays completion and needlessly holds the full stdout in memory. `readCapturedStream()` now drains both streams concurrently via `Promise.all`, and accepts a `maxBytes` bound so a capturing caller can keep only stderr's diagnostic tail (32 KiB) instead of retaining the entire build log.

### Give a failed build actionable guidance instead of a silent code

When `streamOutput` is `false` and a build fails, the caller has no build log to look at. `runImageBuild` now returns the exit code and whether the credential-helper retry fired, and `start.ts` turns that into a failure reason like `docker build failed (exit code N)`, followed by guidance to run `typeclaw start --build` from the agent directory to view the full build output — instead of a bare `docker build failed`.

### Propagate warnings instead of dropping or printing them mid-board

`refreshGithubCliStore`'s credential-refresh warning used to always go straight to `process.stderr`. It now returns the warning string; `start.ts` writes it to stderr only when `streamOutput` is true, and otherwise forwards it through the new `onWarning` callback. `compose/start.ts` and `compose/restart.ts` collect everything from `onWarning` (plus `validateConfig`'s existing warnings) into the per-agent `warnings` array already rendered by the board, including on the failure path — `AgentResult`'s `ok: false` variant gained an optional `warnings` field so a failed agent's warnings aren't silently lost. `cli/compose.ts`'s `formatStartDone`/`formatRestartDone` now attach warnings to the failure line too, not just the success line.

## What this does NOT do

- Does not change single-agent `typeclaw start`/`restart` behavior — `streamOutput` defaults to `true` there, so build output still streams straight to the terminal as before.
- Does not change what counts as a warning or how `validateConfig` produces them — this only ensures warnings already being generated reach the board instead of bypassing it.
- Does not touch `container/stop.ts`'s absent-container classification or any other unrelated container/sandbox code.

## Review notes

The load-bearing invariant is that nothing writes to `process.stdout`/`process.stderr` on the container start/build path while the compose board owns the terminal. Verify every `streamOutput` branch in `container/start.ts` and `container/restart.ts` correctly routes to capture-and-callback instead of inherit-and-write when compose is the caller, and that `readCapturedStream`'s concurrent drain still returns the correct exit code/stdout/stderr triple under `Promise.all`.

## Verification

- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run typecheck` — clean
- `bun run test` — 13,373 pass, 32 skip, 0 fail