### PR TITLE
Recover missed Instagram messages after outages

### DIFF
--- a/docs/content/docs/reference/instagram.mdx
+++ b/docs/content/docs/reference/instagram.mdx
@@ -101,6 +101,7 @@ Use the `instagram` platform token in role match rules. Instagram is scoped by i
 - **No surfaced mentions or replies**: there is no native @-mention or per-message reply metadata, so group engagement is alias-driven while DMs engage every message. No threading is exposed.
 - **2FA / checkpoint not supported**: login fails hard if the account requires a second factor or a challenge.
 - **Provisional registration**: chats not yet surfaced by the chat list are registered provisionally as `@instagram-group` (the stricter bucket) on first message, until the next refresh can reclassify them.
+- **Bounded outage recovery**: the adapter keeps durable per-chat message IDs and backfills missed messages after polling gaps or restarts. Instagram's SDK exposes no history cursor, so recovery is limited to the 100 most recent chats and 200 most recent messages per chat; TypeClaw logs a warning when either window is full.
 
 ## Config
 

--- a/src/channels/adapters/instagram-continuity-store.test.ts
+++ b/src/channels/adapters/instagram-continuity-store.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { instagramContinuityPath, loadInstagramContinuityStore } from './instagram-continuity-store'
+
+const SILENT = { warn: () => {}, error: () => {} }
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'instagram-continuity-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('InstagramContinuityStore', () => {
+  test('persists seeded and delivered message ids across reloads', async () => {
+    const first = await loadInstagramContinuityStore(agentDir, SILENT)
+    await first.seedThread('account-1', 'thread-1', ['M1', 'M2'])
+    await first.markMessage('account-1', 'thread-1', 'M3')
+
+    const reloaded = await loadInstagramContinuityStore(agentDir, SILENT)
+
+    expect(reloaded.knowsThread('account-1', 'thread-1')).toBe(true)
+    expect(reloaded.hasMessage('account-1', 'thread-1', 'M1')).toBe(true)
+    expect(reloaded.hasMessage('account-1', 'thread-1', 'M3')).toBe(true)
+    expect(reloaded.hasMessage('account-2', 'thread-1', 'M3')).toBe(false)
+  })
+
+  test('keeps only the newest bounded set of ids', async () => {
+    const store = await loadInstagramContinuityStore(agentDir, SILENT)
+    const ids = Array.from({ length: 501 }, (_, index) => `M${index}`)
+
+    await store.seedThread('account-1', 'thread-1', ids)
+
+    expect(store.hasMessage('account-1', 'thread-1', 'M0')).toBe(false)
+    expect(store.hasMessage('account-1', 'thread-1', 'M500')).toBe(true)
+  })
+
+  test('ignores a corrupted file and starts fresh', async () => {
+    const path = instagramContinuityPath(agentDir)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, '{ invalid json', 'utf8')
+
+    const store = await loadInstagramContinuityStore(agentDir, SILENT)
+
+    expect(store.knowsThread('account-1', 'thread-1')).toBe(false)
+  })
+
+  test('rolls back and rethrows when persistence fails', async () => {
+    await writeFile(join(agentDir, 'channels'), 'not a directory', 'utf8')
+    const store = await loadInstagramContinuityStore(agentDir, SILENT)
+
+    await expect(store.markMessage('account-1', 'thread-1', 'M1')).rejects.toThrow()
+
+    expect(store.knowsThread('account-1', 'thread-1')).toBe(false)
+  })
+})

--- a/src/channels/adapters/instagram-continuity-store.ts
+++ b/src/channels/adapters/instagram-continuity-store.ts
@@ -1,0 +1,141 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import { describeError } from '../describe-error'
+
+const FILE_VERSION = 1
+const MAX_MESSAGE_IDS_PER_THREAD = 500
+
+type ThreadState = {
+  accountId: string
+  threadId: string
+  messageIds: string[]
+}
+
+type FileV1 = {
+  version: 1
+  threads: ThreadState[]
+}
+
+export type InstagramContinuityLogger = {
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type InstagramContinuityStore = {
+  knowsThread: (accountId: string, threadId: string) => boolean
+  hasMessage: (accountId: string, threadId: string, messageId: string) => boolean
+  seedThread: (accountId: string, threadId: string, messageIds: readonly string[]) => Promise<void>
+  markMessage: (accountId: string, threadId: string, messageId: string) => Promise<void>
+}
+
+export function instagramContinuityPath(agentDir: string): string {
+  return join(agentDir, 'channels', 'instagram-continuity.json')
+}
+
+export async function loadInstagramContinuityStore(
+  agentDir: string,
+  logger: InstagramContinuityLogger,
+): Promise<InstagramContinuityStore> {
+  const path = instagramContinuityPath(agentDir)
+  const threads = new Map<string, string[]>()
+  for (const state of await readStates(path, logger)) {
+    threads.set(threadKey(state.accountId, state.threadId), state.messageIds.slice(-MAX_MESSAGE_IDS_PER_THREAD))
+  }
+
+  const flush = async (): Promise<void> => {
+    const states: ThreadState[] = []
+    for (const [key, messageIds] of threads) {
+      const [accountId, threadId] = parseThreadKey(key)
+      states.push({ accountId, threadId, messageIds })
+    }
+    const payload: FileV1 = { version: FILE_VERSION, threads: states }
+    await mkdir(dirname(path), { recursive: true })
+    const tmp = `${path}.tmp`
+    await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+    await rename(tmp, path)
+  }
+
+  const saveIds = async (accountId: string, threadId: string, messageIds: readonly string[]): Promise<void> => {
+    const key = threadKey(accountId, threadId)
+    const previous = threads.get(key)
+    const next = Array.from(new Set(messageIds)).slice(-MAX_MESSAGE_IDS_PER_THREAD)
+    threads.set(key, next)
+    try {
+      await flush()
+    } catch (err) {
+      if (previous === undefined) threads.delete(key)
+      else threads.set(key, previous)
+      throw err
+    }
+  }
+
+  return {
+    knowsThread(accountId, threadId): boolean {
+      return threads.has(threadKey(accountId, threadId))
+    },
+    hasMessage(accountId, threadId, messageId): boolean {
+      return threads.get(threadKey(accountId, threadId))?.includes(messageId) ?? false
+    },
+    async seedThread(accountId, threadId, messageIds): Promise<void> {
+      await saveIds(accountId, threadId, messageIds)
+    },
+    async markMessage(accountId, threadId, messageId): Promise<void> {
+      const current = threads.get(threadKey(accountId, threadId)) ?? []
+      if (current.includes(messageId)) return
+      await saveIds(accountId, threadId, [...current, messageId])
+    },
+  }
+}
+
+function threadKey(accountId: string, threadId: string): string {
+  return `${accountId}\u0000${threadId}`
+}
+
+function parseThreadKey(key: string): [string, string] {
+  const separator = key.indexOf('\u0000')
+  return [key.slice(0, separator), key.slice(separator + 1)]
+}
+
+async function readStates(path: string, logger: InstagramContinuityLogger): Promise<ThreadState[]> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    return []
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    logger.error(`[instagram] ${path} corrupted: ${describeError(err)}; starting fresh`)
+    return []
+  }
+  if (!isObject(parsed)) {
+    logger.warn(`[instagram] ${path} not an object; ignored`)
+    return []
+  }
+  if (parsed.version !== FILE_VERSION) {
+    logger.warn(
+      `[instagram] ${path} version ${String(parsed.version)} not supported (expected ${FILE_VERSION}); ignored`,
+    )
+    return []
+  }
+  if (!Array.isArray(parsed.threads)) return []
+  return parsed.threads.filter(isThreadState)
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isThreadState(value: unknown): value is ThreadState {
+  if (!isObject(value)) return false
+  return (
+    typeof value.accountId === 'string' &&
+    typeof value.threadId === 'string' &&
+    Array.isArray(value.messageIds) &&
+    value.messageIds.every((id) => typeof id === 'string')
+  )
+}

--- a/src/channels/adapters/instagram.test.ts
+++ b/src/channels/adapters/instagram.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import type { InstagramChatSummary, InstagramMessageSummary } from 'agent-messenger/instagram'
 
@@ -17,6 +20,17 @@ import {
 } from './instagram'
 
 const SILENT = { info: () => {}, warn: () => {}, error: () => {} }
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function tempAgentDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'instagram-recovery-'))
+  tempDirs.push(dir)
+  return dir
+}
 
 class FakeListener implements InstagramListenerShape {
   connected?: (payload: ConnectedPayload) => void
@@ -255,7 +269,341 @@ describe('createInstagramAdapter lifecycle', () => {
     expect(client.loginCalls).toEqual([{ credentials: undefined, accountId: 'ig-account' }])
     await adapter.stop()
   })
+
+  test('recovers every unseen message in chronological order after restart', async () => {
+    const agentDir = await tempAgentDir()
+    const listener = new FakeListener()
+    const firstRouter = makeRouterStub(() => {})
+    const first = createInstagramAdapter({
+      agentDir,
+      router: firstRouter,
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient({ getMessages: async () => [msg()] }),
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await first.start()
+    await first.stop()
+
+    const routed: InboundMessage[] = []
+    const second = createInstagramAdapter({
+      agentDir,
+      router: makeRouterStub((message) => routed.push(message)),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient({
+        getMessages: async () => [
+          msg(),
+          msg({ id: 'M2', timestamp: '2025-01-02T00:00:01.000Z', text: 'second' }),
+          msg({ id: 'M3', timestamp: '2025-01-02T00:00:02.000Z', text: 'third' }),
+        ],
+      }),
+      listenerCtorResolver: listenerResolver(new FakeListener()),
+    })
+    await second.start()
+
+    expect(routed.map((message) => message.externalMessageId)).toEqual(['M2', 'M3'])
+    await second.stop()
+  })
+
+  test('routes messages that arrive during bootstrap before checkpointing them', async () => {
+    const listener = new FakeListener()
+    const historyFetchEntered = deferred<void>()
+    const historyReady = deferred<void>()
+    const events: string[] = []
+    let history = [msg({ id: 'M-old', timestamp: '2025-01-01T00:00:00.000Z' })]
+    const store = await memoryContinuityStore({
+      onMark: (messageId) => events.push(`mark:${messageId}`),
+    })
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub((message) => events.push(`route:${message.externalMessageId}`)),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      now: () => Date.parse('2025-01-02T00:00:00.000Z'),
+      client: fakeClient({
+        getMessages: async () => {
+          historyFetchEntered.resolve()
+          await historyReady.promise
+          return history
+        },
+      }),
+      continuityStore: store,
+      listenerCtorResolver: listenerResolver(listener),
+    })
+
+    const starting = adapter.start()
+    await historyFetchEntered.promise
+    history = [...history, msg({ id: 'M-new', timestamp: '2025-01-02T00:00:01.000Z' })]
+    historyReady.resolve()
+    await starting
+
+    expect(events).toEqual(['route:M-new', 'mark:M-new'])
+    await adapter.stop()
+  })
+
+  test('backfills a polling burst without routing the newest message twice', async () => {
+    const agentDir = await tempAgentDir()
+    const listener = new FakeListener()
+    let history = [msg()]
+    let historyCalls = 0
+    const routed: InboundMessage[] = []
+    const adapter = createInstagramAdapter({
+      agentDir,
+      router: makeRouterStub((message) => routed.push(message)),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient({
+        getMessages: async () => {
+          historyCalls++
+          return history
+        },
+      }),
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await adapter.start()
+    listener.connected?.({ userId: 'U_self', transport: 'polling' })
+    await waitFor(() => historyCalls === 2)
+    history = [
+      msg(),
+      msg({ id: 'M2', timestamp: '2025-01-02T00:00:01.000Z', text: 'second' }),
+      msg({ id: 'M3', timestamp: '2025-01-02T00:00:02.000Z', text: 'third' }),
+    ]
+
+    listener.message?.(history[2]!)
+    listener.connected?.({ userId: 'U_self', transport: 'realtime' })
+    await waitFor(() => routed.length === 2)
+
+    expect(routed.map((message) => message.externalMessageId)).toEqual(['M2', 'M3'])
+    await adapter.stop()
+  })
+
+  test('does not let a failed earlier message get overtaken during recovery', async () => {
+    const agentDir = await tempAgentDir()
+    const first = createInstagramAdapter({
+      agentDir,
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient({ getMessages: async () => [msg()] }),
+      listenerCtorResolver: listenerResolver(new FakeListener()),
+    })
+    await first.start()
+    await first.stop()
+
+    const listener = new FakeListener()
+    const attempts: string[] = []
+    let failM2 = true
+    const history = [
+      msg(),
+      msg({ id: 'M2', timestamp: '2025-01-02T00:00:01.000Z' }),
+      msg({ id: 'M3', timestamp: '2025-01-02T00:00:02.000Z' }),
+    ]
+    const adapter = createInstagramAdapter({
+      agentDir,
+      router: makeRouterStub((message) => {
+        attempts.push(message.externalMessageId)
+        if (message.externalMessageId === 'M2' && failM2) throw new Error('route failed')
+      }),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient({ getMessages: async () => history }),
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await adapter.start()
+    expect(attempts).toEqual(['M2'])
+
+    failM2 = false
+    listener.message?.(history[2]!)
+    await waitFor(() => attempts.length === 3)
+
+    expect(attempts).toEqual(['M2', 'M2', 'M3'])
+    await adapter.stop()
+  })
+
+  test('retries failed bootstrap seeding without replaying existing history', async () => {
+    const listener = new FakeListener()
+    const routed: InboundMessage[] = []
+    let seedCalls = 0
+    let seeded = false
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub((message) => routed.push(message)),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient({ getMessages: async () => [msg(), msg({ id: 'M2' })] }),
+      continuityStore: {
+        knowsThread: () => seeded,
+        hasMessage: () => seeded,
+        seedThread: async () => {
+          seedCalls++
+          if (seedCalls === 1) throw new Error('disk full')
+          seeded = true
+        },
+        markMessage: async () => {},
+      },
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await adapter.start()
+    listener.connected?.({ userId: 'U_self', transport: 'polling' })
+    await waitFor(() => seedCalls === 2)
+
+    expect(routed).toEqual([])
+    await adapter.stop()
+  })
+
+  test('does not replay bootstrap history when seeding still fails on a polling event', async () => {
+    const listener = new FakeListener()
+    const routed: InboundMessage[] = []
+    let seedCalls = 0
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub((message) => routed.push(message)),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient({ getMessages: async () => [msg(), msg({ id: 'M2' })] }),
+      continuityStore: {
+        knowsThread: () => false,
+        hasMessage: () => false,
+        seedThread: async () => {
+          seedCalls++
+          throw new Error('disk full')
+        },
+        markMessage: async () => {},
+      },
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await adapter.start()
+
+    listener.connected?.({ userId: 'U_self', transport: 'realtime' })
+    listener.message?.(msg({ id: 'M2' }))
+    await waitFor(() => seedCalls >= 3)
+
+    expect(routed).toEqual([])
+    await adapter.stop()
+  })
+
+  test('recovers only post-start messages when a dormant chat first becomes visible', async () => {
+    const listener = new FakeListener()
+    const routed: InboundMessage[] = []
+    const history = [
+      msg({ id: 'M-old', thread_id: 'T2', timestamp: '2025-01-01T00:00:00.000Z' }),
+      msg({ id: 'M-new-1', thread_id: 'T2', timestamp: '2025-01-02T00:00:01.000Z' }),
+      msg({ id: 'M-new-2', thread_id: 'T2', timestamp: '2025-01-02T00:00:02.000Z' }),
+    ]
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub((message) => routed.push(message)),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      now: () => Date.parse('2025-01-02T00:00:00.000Z'),
+      client: fakeClient({
+        listChats: async () => [chat()],
+        getMessages: async (threadId) =>
+          threadId === 'T2' ? history : [msg({ timestamp: '2025-01-01T00:00:00.000Z' })],
+      }),
+      continuityStore: await memoryContinuityStore(),
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await adapter.start()
+
+    listener.connected?.({ userId: 'U_self', transport: 'realtime' })
+    listener.message?.(history[2]!)
+    await waitFor(() => routed.length === 2)
+
+    expect(routed.map((message) => message.externalMessageId)).toEqual(['M-new-1', 'M-new-2'])
+    await adapter.stop()
+  })
+
+  test('warns once when recovery windows are saturated', async () => {
+    const listener = new FakeListener()
+    const warnings: string[] = []
+    let listChatsCalls = 0
+    let saturatedHistoryCalls = 0
+    const chats = Array.from({ length: 100 }, (_, index) => chat({ id: `T${index}` }))
+    const messages = Array.from({ length: 200 }, (_, index) => msg({ id: `M${index}`, thread_id: 'T0' }))
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
+      client: fakeClient({
+        listChats: async () => {
+          listChatsCalls++
+          return chats
+        },
+        getMessages: async (threadId) => {
+          if (threadId !== 'T0') return []
+          saturatedHistoryCalls++
+          return messages
+        },
+      }),
+      continuityStore: await memoryContinuityStore(),
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await adapter.start()
+    listener.connected?.({ userId: 'U_self', transport: 'realtime' })
+    await waitFor(() => listChatsCalls >= 3 && saturatedHistoryCalls >= 2)
+
+    expect(warnings.filter((message) => message.includes('recovery chat list reached'))).toHaveLength(1)
+    expect(warnings.filter((message) => message.includes('recovery history reached'))).toHaveLength(1)
+    await adapter.stop()
+  })
+
+  test('ignores listener messages emitted after stop', async () => {
+    const listener = new FakeListener()
+    const routed: InboundMessage[] = []
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub((message) => routed.push(message)),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient(),
+      listenerCtorResolver: listenerResolver(listener),
+    })
+    await adapter.start()
+    await adapter.stop()
+
+    listener.message?.(msg())
+    await Bun.sleep(10)
+
+    expect(routed).toEqual([])
+  })
 })
+
+function listenerResolver(
+  listener: FakeListener,
+): NonNullable<Parameters<typeof createInstagramAdapter>[0]['listenerCtorResolver']> {
+  return () => ({
+    ctor: class {
+      constructor() {
+        return listener
+      }
+    } as never,
+    transport: 'hybrid',
+  })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+async function memoryContinuityStore(options: { onMark?: (messageId: string) => void } = {}) {
+  const threads = new Map<string, Set<string>>()
+  return {
+    knowsThread: (accountId: string, threadId: string) => threads.has(`${accountId}:${threadId}`),
+    hasMessage: (accountId: string, threadId: string, messageId: string) =>
+      threads.get(`${accountId}:${threadId}`)?.has(messageId) ?? false,
+    seedThread: async (accountId: string, threadId: string, messageIds: readonly string[]) => {
+      threads.set(`${accountId}:${threadId}`, new Set(messageIds))
+    },
+    markMessage: async (accountId: string, threadId: string, messageId: string) => {
+      options.onMark?.(messageId)
+      const key = `${accountId}:${threadId}`
+      const ids = threads.get(key) ?? new Set<string>()
+      ids.add(messageId)
+      threads.set(key, ids)
+    },
+  }
+}
 
 function makeRouterStub(onRoute: (m: InboundMessage) => void) {
   const registered = { outbound: false, history: false, nameResolver: false }

--- a/src/channels/adapters/instagram.ts
+++ b/src/channels/adapters/instagram.ts
@@ -22,6 +22,7 @@ import type {
 import { describeError } from '../describe-error'
 import { createInstagramChannelResolver } from './instagram-channel-resolver'
 import { classifyInbound } from './instagram-classify'
+import { loadInstagramContinuityStore, type InstagramContinuityStore } from './instagram-continuity-store'
 import { toInstagramPlainText } from './instagram-format'
 
 export interface InstagramClientShape {
@@ -89,6 +90,7 @@ const consoleLogger: InstagramAdapterLogger = {
 }
 
 export type InstagramAdapterOptions = {
+  agentDir?: string
   router: ChannelRouter
   configRef: () => ChannelAdapterConfig
   logger?: InstagramAdapterLogger
@@ -97,6 +99,7 @@ export type InstagramAdapterOptions = {
   client?: InstagramClientShape
   clientFactory?: (credManager?: InstagramCredentialManager) => InstagramClientShape
   listenerCtorResolver?: () => { ctor: InstagramListenerCtor; transport: 'hybrid' | 'polling' }
+  continuityStore?: InstagramContinuityStore
   now?: () => number
 }
 
@@ -107,6 +110,7 @@ export type InstagramAdapter = {
 }
 
 export const INSTAGRAM_HISTORY_LIMIT_MAX = 200
+const INSTAGRAM_RECOVERY_CHAT_LIMIT = 100
 
 export function createOutboundCallback(deps: {
   client: Pick<InstagramClientShape, 'sendMessage'>
@@ -177,6 +181,13 @@ export function createInstagramAdapter(options: InstagramAdapterOptions): Instag
   let started = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
+  let continuityStore: InstagramContinuityStore | null = options.continuityStore ?? null
+  let activeTransport: 'realtime' | 'polling' = 'polling'
+  let inboundQueue = Promise.resolve()
+  let adapterStartedAt = 0
+  const bootstrapBaselines = new Map<string, readonly string[]>()
+  const recoveryLimitWarnedThreads = new Set<string>()
+  let recoveryChatLimitWarned = false
 
   const channelResolver = createInstagramChannelResolver({ client, logger })
 
@@ -190,7 +201,7 @@ export function createInstagramAdapter(options: InstagramAdapterOptions): Instag
   const historyCallback = createInstagramHistoryCallback({ client, logger, selfUserIdRef: () => selfUserId })
   const outboundCallback = createOutboundCallback({ client, logger, formatChannelTag })
 
-  const processInbound = async (message: InstagramMessageSummary): Promise<void> => {
+  const processInbound = async (message: InstagramMessageSummary): Promise<boolean> => {
     inflightInbounds++
     try {
       if (channelResolver.lookupChat(message.thread_id) === null) {
@@ -216,15 +227,17 @@ export function createInstagramAdapter(options: InstagramAdapterOptions): Instag
       })
       if (verdict.kind === 'drop') {
         logger.info(`[instagram] dropped message_id=${message.id} reason=${verdict.reason}`)
-        return
+        return true
       }
 
       logger.info(
         `[instagram] routed message_id=${message.id} ${inboundTag} mention=${verdict.payload.isBotMention} dm=${verdict.payload.isDm}`,
       )
       await options.router.route(verdict.payload)
+      return true
     } catch (err) {
       logger.error(`[instagram] handleInbound failed: ${describeError(err)}`)
+      return false
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -235,10 +248,117 @@ export function createInstagramAdapter(options: InstagramAdapterOptions): Instag
     }
   }
 
+  const markDelivered = async (message: InstagramMessageSummary): Promise<void> => {
+    if (continuityStore === null || selfUserId === null) return
+    await continuityStore.markMessage(selfUserId, message.thread_id, message.id)
+  }
+
+  const deliverUnseen = async (message: InstagramMessageSummary): Promise<boolean> => {
+    if (
+      continuityStore !== null &&
+      selfUserId !== null &&
+      continuityStore.hasMessage(selfUserId, message.thread_id, message.id)
+    ) {
+      return true
+    }
+    if (!(await processInbound(message))) return false
+    // Checkpoint only after the router accepts the message. A crash can replay
+    // once, but persisting first would silently lose a message when routing fails.
+    await markDelivered(message)
+    return true
+  }
+
+  const fetchRecoveryMessages = async (threadId: string): Promise<InstagramMessageSummary[]> => {
+    const messages = await client.getMessages(threadId, INSTAGRAM_HISTORY_LIMIT_MAX)
+    if (messages.length === INSTAGRAM_HISTORY_LIMIT_MAX && !recoveryLimitWarnedThreads.has(threadId)) {
+      recoveryLimitWarnedThreads.add(threadId)
+      logger.warn(
+        `[instagram] recovery history reached limit=${INSTAGRAM_HISTORY_LIMIT_MAX} chat=${threadId}; older unseen messages cannot be recovered without upstream pagination`,
+      )
+    }
+    return messages.toSorted((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp))
+  }
+
+  const establishUnknownThread = async (
+    threadId: string,
+    messages: readonly InstagramMessageSummary[],
+  ): Promise<void> => {
+    if (continuityStore === null || selfUserId === null) return
+    const bootstrapIds = bootstrapBaselines.get(threadId)
+    const baselineIds = bootstrapIds ?? messages.filter(isBeforeAdapterStart).map((message) => message.id)
+    await continuityStore.seedThread(selfUserId, threadId, baselineIds)
+    bootstrapBaselines.delete(threadId)
+  }
+
+  const reconcileThread = async (threadId: string): Promise<boolean> => {
+    if (continuityStore === null || selfUserId === null) return true
+    const messages = await fetchRecoveryMessages(threadId)
+    if (!continuityStore.knowsThread(selfUserId, threadId)) await establishUnknownThread(threadId, messages)
+    for (const message of messages) {
+      if (!(await deliverUnseen(message))) return false
+    }
+    return true
+  }
+
+  const reconcileAll = async (): Promise<void> => {
+    const chats = await client.listChats(INSTAGRAM_RECOVERY_CHAT_LIMIT)
+    warnIfChatLimitReached(chats.length)
+    for (const chat of chats) {
+      try {
+        await reconcileThread(chat.id)
+      } catch (err) {
+        logger.error(`[instagram] recovery failed chat=${chat.id}: ${describeError(err)}`)
+      }
+    }
+  }
+
+  const seedBootstrap = async (): Promise<void> => {
+    const chats = await client.listChats(INSTAGRAM_RECOVERY_CHAT_LIMIT)
+    warnIfChatLimitReached(chats.length)
+    for (const chat of chats) {
+      try {
+        if (continuityStore === null || selfUserId === null || continuityStore.knowsThread(selfUserId, chat.id)) {
+          await reconcileThread(chat.id)
+          continue
+        }
+        const messages = await fetchRecoveryMessages(chat.id)
+        const baselineIds = messages.filter(isBeforeAdapterStart).map((message) => message.id)
+        bootstrapBaselines.set(chat.id, baselineIds)
+        await continuityStore.seedThread(selfUserId, chat.id, baselineIds)
+        bootstrapBaselines.delete(chat.id)
+        for (const message of messages) {
+          if (!(await deliverUnseen(message))) break
+        }
+      } catch (err) {
+        logger.error(`[instagram] bootstrap failed chat=${chat.id}: ${describeError(err)}`)
+      }
+    }
+  }
+
+  const warnIfChatLimitReached = (chatCount: number): void => {
+    if (chatCount !== INSTAGRAM_RECOVERY_CHAT_LIMIT || recoveryChatLimitWarned) return
+    recoveryChatLimitWarned = true
+    logger.warn(
+      `[instagram] recovery chat list reached limit=${INSTAGRAM_RECOVERY_CHAT_LIMIT}; older chats cannot be recovered without upstream pagination`,
+    )
+  }
+
+  const isBeforeAdapterStart = (message: InstagramMessageSummary): boolean => {
+    const timestamp = Date.parse(message.timestamp)
+    return Number.isNaN(timestamp) || timestamp < adapterStartedAt
+  }
+
+  const enqueueInbound = (task: () => Promise<void>): void => {
+    inboundQueue = inboundQueue.then(task).catch((err: unknown) => {
+      logger.error(`[instagram] recovery failed: ${describeError(err)}`)
+    })
+  }
+
   return {
     async start(): Promise<void> {
       if (started) return
       started = true
+      adapterStartedAt = (options.now ?? Date.now)()
 
       try {
         const credentialStore = options.credentialsStore ?? null
@@ -269,28 +389,52 @@ export function createInstagramAdapter(options: InstagramAdapterOptions): Instag
         throw err
       }
 
+      if (continuityStore === null && options.agentDir !== undefined) {
+        continuityStore = await loadInstagramContinuityStore(options.agentDir, logger)
+      }
+
       try {
         await channelResolver.refresh()
       } catch (err) {
         logger.warn(`[instagram] initial chat list fetch failed: ${describeError(err)}`)
       }
 
+      try {
+        await seedBootstrap()
+      } catch (err) {
+        logger.warn(`[instagram] initial recovery failed: ${describeError(err)}`)
+      }
+
       const resolved = (options.listenerCtorResolver ?? resolveInstagramListenerCtor)()
       listener = new resolved.ctor(client, { pollInterval: 5_000 })
       logger.info(`[instagram] listener transport=${resolved.transport}`)
       listener.on('connected', ({ userId, transport = 'polling' }) => {
+        if (!started) return
         connected = true
+        activeTransport = transport
         logger.info(`[instagram] connected (user_id=${userId}, transport=${transport})`)
+        enqueueInbound(reconcileAll)
       })
       listener.on('disconnected', () => {
+        if (!started) return
         connected = false
         logger.warn('[instagram] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
+        if (!started) return
         logger.error(`[instagram] listener error: ${describeError(err)}`)
       })
       listener.on('message', (message) => {
-        void processInbound(message)
+        if (!started) return
+        const transport = activeTransport
+        enqueueInbound(async () => {
+          const unknownThread =
+            continuityStore !== null &&
+            selfUserId !== null &&
+            !continuityStore.knowsThread(selfUserId, message.thread_id)
+          if ((transport === 'polling' || unknownThread) && !(await reconcileThread(message.thread_id))) return
+          await deliverUnseen(message)
+        })
       })
 
       try {
@@ -318,12 +462,13 @@ export function createInstagramAdapter(options: InstagramAdapterOptions): Instag
       options.router.unregisterOutbound('instagram', outboundCallback)
       options.router.unregisterChannelNameResolver('instagram', channelResolver.resolve)
       options.router.unregisterHistory('instagram', historyCallback)
+      listener?.stop()
+      await inboundQueue
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)
         })
       }
-      listener?.stop()
       listener = null
       selfUserId = null
       connected = false

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -161,6 +161,29 @@ const writeSlackSecrets = async (dir: string): Promise<void> => {
   )
 }
 
+const writeInstagramSecrets = async (dir: string): Promise<void> => {
+  await writeFile(
+    join(dir, 'secrets.json'),
+    JSON.stringify({
+      version: 2,
+      providers: {},
+      channels: {
+        instagram: {
+          currentAccount: 'ig-account',
+          accounts: {
+            'ig-account': {
+              account_id: 'ig-account',
+              username: 'test-user',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      },
+    }),
+  )
+}
+
 function recordingLogger(): {
   info: (msg: string) => void
   warn: (msg: string) => void
@@ -1221,6 +1244,30 @@ describe('channel manager — restartAdapter serialization', () => {
     await mgr.start()
 
     expect(constructed).toBe(true)
+    await mgr.stop()
+  })
+})
+
+describe('channel manager — instagram adapter lifecycle', () => {
+  test('passes agentDir to the instagram adapter continuity store', async () => {
+    cfg.instagram = enabledAdapterCfg()
+    await writeInstagramSecrets(agentDir)
+    const fake = makeFakeAdapter()
+    let capturedAgentDir: string | undefined
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      secretsProvider: createFileSecretsProvider(join(agentDir, 'secrets.json')),
+      createInstagramAdapter: (options) => {
+        capturedAgentDir = options.agentDir
+        return fake
+      },
+    })
+
+    await mgr.start()
+
+    expect(capturedAgentDir).toBe(agentDir)
+    expect(fake.startCalls).toBe(1)
     await mgr.stop()
   })
 })

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -362,6 +362,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       )
       if (credentialsStore === null) return null
       return createInstagram({
+        agentDir: options.agentDir,
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,


### PR DESCRIPTION
## Background

The Instagram adapter's realtime/polling listener had no continuity tracking: on a poll gap, SDK reconnect, or process restart, it simply resumed listening for new events with no reconciliation against what happened during the gap. Instagram's polling transport in particular delivers only the messages present at each poll tick, so a message that arrived and was superseded before the next tick was never seen at all. There was no durable record of which messages a thread had already delivered, so recovery after any outage was silently skipped.

## Summary

### Durable per-account/thread continuity ledger

`instagram-continuity-store.ts` persists per-account, per-thread seen message IDs to `channels/instagram-continuity.json` (capped at 500 IDs per thread, oldest evicted first), written atomically via a temp file + rename so a crash mid-write can't corrupt the ledger.

### Chronological reconciliation for polling/realtime unknown threads

`reconcileThread` fetches a thread's recent history, sorts it chronologically, and delivers any message not yet in the ledger, in order, before returning to live listening. This runs on every realtime reconnect (`reconcileAll`, across the recent chat list) and inline whenever an inbound message arrives over the `polling` transport or from a thread the ledger doesn't yet know about — the two cases where a gap could have been missed.

### Startup baselines and a timestamp watermark against history floods

On first start, `seedBootstrap` seeds a baseline for any chat not already in the ledger using messages older than the adapter's start timestamp, so bringing up a fresh or long-idle account does not attempt to redeliver its entire history — only messages from adapter startup forward are ever recovered.

### Ordered at-least-once retry semantics

`deliverUnseen` checkpoints a message into the ledger (`markMessage`) only after `router.route` has accepted it, never before. A crash between delivery and checkpoint can replay a message once on the next reconciliation; persisting first would risk silently losing a message if routing then failed. `enqueueInbound` serializes reconciliation sweeps and live listener events through a single per-adapter task queue so the two can't interleave and double-deliver or skip an entry.

### Production agentDir wiring

`createChannelManager` now passes `agentDir` through to `createInstagram`, so the continuity store persists to the real per-agent directory at runtime instead of only being reachable via test injection.

### Explicit upstream bounds, warnings, and docs

Instagram's SDK exposes no history pagination cursor, so recovery is hard-bounded to the 100 most recent chats (`listChats`) and the 200 most recent messages per chat (`getMessages`) — `INSTAGRAM_HISTORY_LIMIT_MAX` was already the adapter's existing history ceiling. The adapter now logs a one-time warning when either bound is hit (per chat for messages, once globally for the chat list), and the reference doc documents the bound explicitly instead of implying open-ended recovery.

## What this does NOT do

- Does not add pagination beyond the SDK's fixed windows. 100 chats / 200 messages per chat is the hard ceiling until Instagram's SDK exposes a history cursor.
- Does not change realtime/polling transport selection, credential handling, or message classification.
- Does not claim unlimited recovery — a chat or message beyond the bound is unrecoverable and only logged, never silently retried indefinitely.

## Review notes

The load-bearing invariant is checkpoint-after-accept: `deliverUnseen` must call `markMessage` only once `processInbound` returns `true`. Verify no path can persist a message ID ahead of a successful `router.route`, since that would silently drop a message on a routing failure. Also verify `enqueueInbound`'s single-promise-chain queue actually serializes a reconnect's `reconcileAll` sweep against concurrent listener `message` events — a race there could double-deliver or skip a message.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only)
- `bun run format:check` — clean
- Focused suite (Instagram adapter + continuity store + manager) — 81 pass
- `bun run test` — 13,399 pass, 32 skip, 0 fail (after rebase)

Closes #1411
