### PR TITLE
Preserve Telegram messages across restarts

### DIFF
--- a/src/channels/adapters/telegram-bot-lifecycle.test.ts
+++ b/src/channels/adapters/telegram-bot-lifecycle.test.ts
@@ -3,18 +3,13 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type {
-  TelegramBotClient,
-  TelegramBotListener,
-  TelegramBotListenerEventMap,
-  TelegramBotUser,
-  TelegramMessage,
-} from 'agent-messenger/telegrambot'
+import type { TelegramBotClient, TelegramBotUser, TelegramMessage } from 'agent-messenger/telegrambot'
 
 import { createChannelRouter } from '@/channels/router'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
 
 import { createTelegramBotAdapter, type TelegramBotAdapterLogger } from './telegram-bot'
+import type { TelegramBotPollingListenerEventMap } from './telegram-bot-listener'
 
 const BOT_USER: TelegramBotUser = { id: 999, is_bot: true, first_name: 'TypeClaw', username: 'typeclaw_bot' }
 
@@ -41,12 +36,13 @@ function silentLogger(): TelegramBotAdapterLogger & { errors: string[]; warns: s
   }
 }
 
-type ListenerEvent = keyof TelegramBotListenerEventMap
+type ListenerEvent = keyof TelegramBotPollingListenerEventMap
 
 class FakeListener {
   started = false
   stopped = 0
   startCalls = 0
+  stopGate: Promise<void> | null = null
   startBehavior: 'emit-connected' | 'silent-fail' | 'error-event' | 'throw' | 'wait-for-connected-call' =
     'emit-connected'
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -82,14 +78,20 @@ class FakeListener {
     // 'wait-for-connected-call' — caller will trigger the event manually
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.stopped++
     this.started = false
+    await this.stopGate
   }
 
-  emit<K extends ListenerEvent>(event: K, ...args: TelegramBotListenerEventMap[K]): void {
+  emit<K extends ListenerEvent>(event: K, ...args: TelegramBotPollingListenerEventMap[K]): void {
     const list = this.handlers.get(event) ?? []
     for (const h of list) h(...args)
+  }
+
+  async emitAsync<K extends ListenerEvent>(event: K, ...args: TelegramBotPollingListenerEventMap[K]): Promise<void> {
+    const list = this.handlers.get(event) ?? []
+    for (const h of list) await h(...args)
   }
 }
 
@@ -153,11 +155,12 @@ describe('createTelegramBotAdapter — startup correctness', () => {
 
     const adapter = createTelegramBotAdapter({
       router,
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger,
       createClient: () => fakeClient as unknown as TelegramBotClient,
-      createListener: () => fakeListener as unknown as TelegramBotListener,
+      createListener: () => fakeListener,
     })
 
     let thrown: unknown = null
@@ -187,11 +190,12 @@ describe('createTelegramBotAdapter — startup correctness', () => {
 
     const adapter = createTelegramBotAdapter({
       router: makeRouter(),
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger,
       createClient: () => fakeClient as unknown as TelegramBotClient,
-      createListener: () => fakeListener as unknown as TelegramBotListener,
+      createListener: () => fakeListener,
     })
 
     let thrown: unknown = null
@@ -214,17 +218,50 @@ describe('createTelegramBotAdapter — startup correctness', () => {
 
     const adapter = createTelegramBotAdapter({
       router,
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger: silentLogger(),
       createClient: () => fakeClient as unknown as TelegramBotClient,
-      createListener: () => fakeListener as unknown as TelegramBotListener,
+      createListener: () => fakeListener,
     })
 
     await expect(adapter.start()).rejects.toThrow('listener.start threw')
     expect(adapter.isConnected()).toBe(false)
     const sendResult = await router.send({ adapter: 'telegram-bot', workspace: 'telegram', chat: '-100123', text: 'x' })
     expect(sendResult.ok).toBe(false)
+  })
+
+  test('startup rollback waits for listener shutdown to drain', async () => {
+    const fakeClient = new FakeClient()
+    const fakeListener = new FakeListener()
+    fakeListener.startBehavior = 'throw'
+    const stopGate = deferred<void>()
+    fakeListener.stopGate = stopGate.promise
+    const adapter = createTelegramBotAdapter({
+      router: makeRouter(),
+      agentDir,
+      configRef: () => adapterCfg,
+      token: 'tok',
+      logger: silentLogger(),
+      createClient: () => fakeClient as unknown as TelegramBotClient,
+      createListener: () => fakeListener,
+    })
+    let settled = false
+    const startPromise = adapter.start().then(
+      () => null,
+      (error: unknown) => error,
+    )
+    void startPromise.finally(() => {
+      settled = true
+    })
+
+    await Bun.sleep(10)
+    expect(fakeListener.stopped).toBe(1)
+    expect(settled).toBe(false)
+
+    stopGate.resolve()
+    expect(await startPromise).toEqual(new Error('listener.start threw'))
   })
 
   test('throws on getMe() failure WITHOUT constructing the listener (preflight bails early)', async () => {
@@ -235,13 +272,14 @@ describe('createTelegramBotAdapter — startup correctness', () => {
 
     const adapter = createTelegramBotAdapter({
       router: makeRouter(),
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger: silentLogger(),
       createClient: () => fakeClient as unknown as TelegramBotClient,
       createListener: () => {
         listenerConstructed = true
-        return fakeListener as unknown as TelegramBotListener
+        return fakeListener
       },
     })
 
@@ -257,11 +295,12 @@ describe('createTelegramBotAdapter — startup correctness', () => {
 
     const adapter = createTelegramBotAdapter({
       router,
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger: silentLogger(),
       createClient: () => fakeClient as unknown as TelegramBotClient,
-      createListener: () => fakeListener as unknown as TelegramBotListener,
+      createListener: () => fakeListener,
     })
 
     await adapter.start()
@@ -269,6 +308,74 @@ describe('createTelegramBotAdapter — startup correctness', () => {
     expect(adapter.isConnected()).toBe(true)
     expect(fakeClient.getMeCalls).toBe(1)
     expect(fakeListener.startCalls).toBe(1)
+  })
+
+  test('reflects transient listener disconnect and recovery in adapter liveness', async () => {
+    const fakeClient = new FakeClient()
+    const fakeListener = new FakeListener()
+    const adapter = createTelegramBotAdapter({
+      router: makeRouter(),
+      agentDir,
+      configRef: () => adapterCfg,
+      token: 'tok',
+      logger: silentLogger(),
+      createClient: () => fakeClient as unknown as TelegramBotClient,
+      createListener: () => fakeListener,
+    })
+
+    await adapter.start()
+    fakeListener.emit('disconnected')
+    expect(adapter.isConnected()).toBe(false)
+
+    fakeListener.emit('connected', { user: BOT_USER })
+    expect(adapter.isConnected()).toBe(true)
+    await adapter.stop()
+  })
+
+  test('post-connect terminal listener failure makes adapter liveness false', async () => {
+    const fakeClient = new FakeClient()
+    const fakeListener = new FakeListener()
+    const adapter = createTelegramBotAdapter({
+      router: makeRouter(),
+      agentDir,
+      configRef: () => adapterCfg,
+      token: 'tok',
+      logger: silentLogger(),
+      createClient: () => fakeClient as unknown as TelegramBotClient,
+      createListener: () => fakeListener,
+    })
+
+    await adapter.start()
+    fakeListener.emit('error', new Error('route handler failed'))
+    fakeListener.emit('disconnected')
+
+    expect(adapter.isConnected()).toBe(false)
+    await adapter.stop()
+  })
+
+  test('router rejection propagates while intentional classification drops resolve', async () => {
+    const fakeClient = new FakeClient()
+    const fakeListener = new FakeListener()
+    const router = makeRouter()
+    router.route = async () => {
+      throw new Error('route failed')
+    }
+    const adapter = createTelegramBotAdapter({
+      router,
+      agentDir,
+      configRef: () => adapterCfg,
+      token: 'tok',
+      logger: silentLogger(),
+      createClient: () => fakeClient as unknown as TelegramBotClient,
+      createListener: () => fakeListener,
+    })
+    await adapter.start()
+
+    await expect(
+      fakeListener.emitAsync('message', inboundMessage({ id: 1, is_bot: false, first_name: 'Alice' })),
+    ).rejects.toThrow('route failed')
+    await expect(fakeListener.emitAsync('message', inboundMessage(BOT_USER))).resolves.toBeUndefined()
+    await adapter.stop()
   })
 })
 
@@ -300,11 +407,12 @@ describe('createTelegramBotAdapter — shutdown race', () => {
 
     const adapter = createTelegramBotAdapter({
       router,
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger: silentLogger(),
       createClient: () => fakeClient as unknown as TelegramBotClient,
-      createListener: () => fakeListener as unknown as TelegramBotListener,
+      createListener: () => fakeListener,
     })
 
     await adapter.start()
@@ -354,11 +462,12 @@ describe('createTelegramBotAdapter — shutdown race', () => {
 
     const adapter = createTelegramBotAdapter({
       router,
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger: silentLogger(),
       createClient: () => fakeClient as unknown as TelegramBotClient,
-      createListener: () => fakeListener as unknown as TelegramBotListener,
+      createListener: () => fakeListener,
     })
 
     await adapter.start()
@@ -373,11 +482,12 @@ describe('createTelegramBotAdapter — shutdown race', () => {
 
     const adapter = createTelegramBotAdapter({
       router: makeRouter(),
+      agentDir,
       configRef: () => adapterCfg,
       token: 'tok',
       logger: silentLogger(),
       createClient: () => fakeClient as unknown as TelegramBotClient,
-      createListener: () => fakeListener as unknown as TelegramBotListener,
+      createListener: () => fakeListener,
     })
 
     await adapter.start()
@@ -385,4 +495,53 @@ describe('createTelegramBotAdapter — shutdown race', () => {
     await adapter.stop()
     expect(fakeListener.stopped).toBe(1)
   })
+
+  test('adapter stop waits for listener drain before resolving', async () => {
+    const fakeClient = new FakeClient()
+    const fakeListener = new FakeListener()
+    const stopGate = deferred<void>()
+    fakeListener.stopGate = stopGate.promise
+    const adapter = createTelegramBotAdapter({
+      router: makeRouter(),
+      agentDir,
+      configRef: () => adapterCfg,
+      token: 'tok',
+      logger: silentLogger(),
+      createClient: () => fakeClient as unknown as TelegramBotClient,
+      createListener: () => fakeListener,
+    })
+    await adapter.start()
+    let settled = false
+    const stopPromise = adapter.stop().then(() => {
+      settled = true
+    })
+
+    await Bun.sleep(10)
+    expect(fakeListener.stopped).toBe(1)
+    expect(settled).toBe(false)
+
+    stopGate.resolve()
+    await stopPromise
+    expect(settled).toBe(true)
+  })
 })
+
+function inboundMessage(from: TelegramBotUser): TelegramMessage {
+  return {
+    message_id: 17,
+    date: 1_700_000_000,
+    chat: { id: -100123, type: 'supergroup', title: 'Eng' },
+    from,
+    text: 'hello @typeclaw_bot',
+  }
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/src/channels/adapters/telegram-bot-listener.test.ts
+++ b/src/channels/adapters/telegram-bot-listener.test.ts
@@ -1,0 +1,637 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { TelegramBotError } from 'agent-messenger/telegrambot'
+import type { GetUpdatesOptions, TelegramBotUser, TelegramUpdate } from 'agent-messenger/telegrambot'
+
+import {
+  createTelegramBotPollingListener,
+  telegramBotCursorPath,
+  type TelegramBotCursorState,
+  type TelegramBotCursorStore,
+  type TelegramBotPollingListenerOptions,
+} from './telegram-bot-listener'
+
+const BOT_USER: TelegramBotUser = { id: 999, is_bot: true, first_name: 'TypeClaw', username: 'typeclaw_bot' }
+const BOT_ID = BOT_USER.id
+
+class FakePollingClient {
+  readonly deleteWebhookCalls: Array<{ drop_pending_updates?: boolean } | undefined> = []
+  readonly getUpdatesCalls: GetUpdatesOptions[] = []
+  deleteWebhookImpl: (options?: { drop_pending_updates?: boolean }) => Promise<boolean> = async () => true
+  getUpdatesImpl: (options: GetUpdatesOptions, signal?: AbortSignal) => Promise<TelegramUpdate[]> = (
+    _options,
+    signal,
+  ) => waitForAbort(signal)
+
+  async deleteWebhook(options?: { drop_pending_updates?: boolean }): Promise<boolean> {
+    this.deleteWebhookCalls.push(options)
+    return this.deleteWebhookImpl(options)
+  }
+
+  async getUpdates(options: GetUpdatesOptions = {}, signal?: AbortSignal): Promise<TelegramUpdate[]> {
+    this.getUpdatesCalls.push(options)
+    return this.getUpdatesImpl(options, signal)
+  }
+}
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-telegram-cursor-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('Telegram bot polling cursor', () => {
+  test('cold boot drops pending updates once, then offset 0 is durable initialized state', async () => {
+    const firstClient = new FakePollingClient()
+    firstClient.deleteWebhookImpl = async () => {
+      const state = JSON.parse(await readFile(telegramBotCursorPath(agentDir, BOT_ID), 'utf8')) as unknown
+      expect(state).toEqual({ version: 1, status: 'initializing' })
+      return true
+    }
+    const first = createListener(firstClient)
+
+    await first.start()
+    await waitUntil(() => firstClient.getUpdatesCalls.length === 1)
+
+    expect(firstClient.deleteWebhookCalls).toEqual([{ drop_pending_updates: true }])
+    expect(firstClient.getUpdatesCalls[0]?.offset).toBe(0)
+    const cursorPath = telegramBotCursorPath(agentDir, BOT_ID)
+    expect(cursorPath).toContain(String(BOT_ID))
+    expect(await readFile(cursorPath, 'utf8')).not.toContain('test-token')
+    expect(JSON.parse(await readFile(cursorPath, 'utf8'))).toEqual({ version: 1, status: 'ready', offset: 0 })
+    await first.stop()
+
+    const restartedClient = new FakePollingClient()
+    const restarted = createListener(restartedClient)
+    await restarted.start()
+    await waitUntil(() => restartedClient.getUpdatesCalls.length === 1)
+
+    expect(restartedClient.deleteWebhookCalls).toEqual([{ drop_pending_updates: false }])
+    expect(restartedClient.getUpdatesCalls[0]?.offset).toBe(0)
+    await restarted.stop()
+  })
+
+  test('an initializing marker recovers without another destructive drop', async () => {
+    const path = telegramBotCursorPath(agentDir, BOT_ID)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, JSON.stringify({ version: 1, status: 'initializing' }), 'utf8')
+    const client = new FakePollingClient()
+    const listener = createListener(client)
+
+    await listener.start()
+    await waitUntil(() => client.getUpdatesCalls.length === 1)
+
+    expect(client.deleteWebhookCalls).toEqual([{ drop_pending_updates: false }])
+    expect(client.getUpdatesCalls[0]?.offset).toBe(0)
+    expect(JSON.parse(await readFile(path, 'utf8'))).toEqual({ version: 1, status: 'ready', offset: 0 })
+    await listener.stop()
+  })
+
+  test('a failed first destructive drop leaves initializing state so restart will not drop again', async () => {
+    const firstClient = new FakePollingClient()
+    firstClient.deleteWebhookImpl = async () => {
+      throw new Error('network failed')
+    }
+
+    await expect(createListener(firstClient).start()).rejects.toThrow('network failed')
+    expect(JSON.parse(await readFile(telegramBotCursorPath(agentDir, BOT_ID), 'utf8'))).toEqual({
+      version: 1,
+      status: 'initializing',
+    })
+
+    const restartedClient = new FakePollingClient()
+    const restarted = createListener(restartedClient)
+    await restarted.start()
+    await waitUntil(() => restartedClient.getUpdatesCalls.length === 1)
+    expect(restartedClient.deleteWebhookCalls).toEqual([{ drop_pending_updates: false }])
+    await restarted.stop()
+  })
+
+  test('same authenticated bot id keeps the cursor across adapter token rotation', async () => {
+    const store = new MemoryCursorStore({ version: 1, status: 'ready', offset: 73 })
+    const firstClient = new FakePollingClient()
+    const first = createListener(firstClient, { cursorStore: store })
+    await first.start()
+    await waitUntil(() => firstClient.getUpdatesCalls.length === 1)
+    await first.stop()
+
+    const rotatedClient = new FakePollingClient()
+    const rotated = createListener(rotatedClient, {
+      cursorStore: store,
+      botUser: { ...BOT_USER, username: 'renamed_bot' },
+    })
+    await rotated.start()
+    await waitUntil(() => rotatedClient.getUpdatesCalls.length === 1)
+
+    expect(firstClient.getUpdatesCalls[0]?.offset).toBe(73)
+    expect(rotatedClient.getUpdatesCalls[0]?.offset).toBe(73)
+    await rotated.stop()
+  })
+
+  test('advances the durable cursor only after the supported handler finishes', async () => {
+    const client = new FakePollingClient()
+    const handlerStarted = deferred<void>()
+    const handlerFinished = deferred<void>()
+    let poll = 0
+    client.getUpdatesImpl = async (_options, signal) => {
+      poll++
+      if (poll === 1) return [{ update_id: 41, message: telegramMessage(7) }]
+      return waitForAbort(signal)
+    }
+    const listener = createListener(client)
+    listener.on('message', async () => {
+      handlerStarted.resolve()
+      await handlerFinished.promise
+    })
+
+    await listener.start()
+    await handlerStarted.promise
+    expect(client.getUpdatesCalls.map((call) => call.offset)).toEqual([0])
+
+    handlerFinished.resolve()
+    await waitUntil(() => client.getUpdatesCalls.length === 2)
+    expect(client.getUpdatesCalls.map((call) => call.offset)).toEqual([0, 42])
+    await listener.stop()
+
+    const restartedClient = new FakePollingClient()
+    const restarted = createListener(restartedClient)
+    await restarted.start()
+    await waitUntil(() => restartedClient.getUpdatesCalls.length === 1)
+    expect(restartedClient.getUpdatesCalls[0]?.offset).toBe(42)
+    expect(restartedClient.deleteWebhookCalls).toEqual([{ drop_pending_updates: false }])
+    await restarted.stop()
+  })
+
+  test('corrupt or unsupported cursor state fails closed without dropping backlog', async () => {
+    const path = telegramBotCursorPath(agentDir, BOT_ID)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, JSON.stringify({ version: 99, offset: 123 }), 'utf8')
+    const client = new FakePollingClient()
+    const listener = createListener(client)
+
+    await expect(listener.start()).rejects.toThrow('unsupported')
+    await expect(listener.start()).rejects.toThrow(path)
+    await expect(listener.start()).rejects.toThrow('pending updates')
+    expect(client.deleteWebhookCalls).toHaveLength(0)
+    expect(client.getUpdatesCalls).toHaveLength(0)
+  })
+
+  test('malformed cursor state fails closed without contacting Telegram', async () => {
+    const path = telegramBotCursorPath(agentDir, BOT_ID)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, '{not-json', 'utf8')
+    const client = new FakePollingClient()
+
+    await expect(createListener(client).start()).rejects.toThrow('corrupt')
+    expect(client.deleteWebhookCalls).toHaveLength(0)
+    expect(client.getUpdatesCalls).toHaveLength(0)
+  })
+
+  test('sends allowed updates only on the first successful poll', async () => {
+    const client = new FakePollingClient()
+    let poll = 0
+    client.getUpdatesImpl = async (_options, signal) => {
+      poll++
+      if (poll === 1) return []
+      return waitForAbort(signal)
+    }
+    const listener = createListener(client)
+
+    await listener.start()
+    await waitUntil(() => client.getUpdatesCalls.length === 2)
+
+    expect(client.getUpdatesCalls[0]).toMatchObject({
+      offset: 0,
+      limit: 100,
+      timeout: 30,
+      allowed_updates: ['message', 'channel_post'],
+    })
+    expect(client.getUpdatesCalls[1]?.allowed_updates).toBeUndefined()
+    await listener.stop()
+  })
+
+  test('stops polling on fatal Telegram authorization errors', async () => {
+    const store = new MemoryCursorStore({ version: 1, status: 'ready', offset: 0 })
+    const client = new FakePollingClient()
+    client.getUpdatesImpl = async () => {
+      throw new TelegramBotError('Unauthorized', 'unauthorized')
+    }
+    const fatal = deferred<Error>()
+    let disconnected = 0
+    const listener = createListener(client, { cursorStore: store })
+    listener.on('error', (error) => fatal.resolve(error))
+    listener.on('disconnected', () => {
+      disconnected++
+    })
+
+    await listener.start()
+    expect(await fatal.promise).toBeInstanceOf(TelegramBotError)
+    await Bun.sleep(10)
+
+    expect(client.getUpdatesCalls).toHaveLength(1)
+    expect(disconnected).toBe(1)
+    await listener.stop()
+  })
+
+  test('transient polling failure disconnects, then successful polling reconnects', async () => {
+    const store = new MemoryCursorStore({ version: 1, status: 'ready', offset: 0 })
+    const client = new FakePollingClient()
+    let poll = 0
+    client.getUpdatesImpl = async (_options, signal) => {
+      poll++
+      if (poll === 1) throw new Error('temporary network failure')
+      if (poll === 2) return []
+      return waitForAbort(signal)
+    }
+    const events: string[] = []
+    const listener = createListener(client, { cursorStore: store, backoff: async () => {} })
+    listener.on('connected', () => {
+      events.push('connected')
+    })
+    listener.on('disconnected', () => {
+      events.push('disconnected')
+    })
+
+    await listener.start()
+    await waitUntil(() => client.getUpdatesCalls.length === 3)
+
+    expect(events).toEqual(['connected', 'disconnected', 'connected'])
+    await listener.stop()
+  })
+
+  test('handler rejection runs siblings, terminates safely, and leaves the cursor unadvanced', async () => {
+    const store = new MemoryCursorStore({ version: 1, status: 'ready', offset: 0 })
+    const client = new FakePollingClient()
+    client.getUpdatesImpl = async () => [{ update_id: 12, message: telegramMessage(12) }]
+    const events: string[] = []
+    const terminal = deferred<void>()
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const listener = createListener(client, { cursorStore: store })
+      listener.on('message', async () => {
+        events.push('message:first')
+        throw new Error('route failed')
+      })
+      listener.on('message', () => {
+        events.push('message:second')
+      })
+      listener.on('error', async () => {
+        events.push('error:first')
+        throw new Error('error observer failed')
+      })
+      listener.on('error', () => {
+        events.push('error:second')
+      })
+      listener.on('disconnected', async () => {
+        events.push('disconnected:first')
+        throw new Error('disconnect observer failed')
+      })
+      listener.on('disconnected', () => {
+        events.push('disconnected:second')
+        terminal.resolve()
+      })
+
+      await listener.start()
+      await terminal.promise
+      await Bun.sleep(10)
+
+      expect(events).toEqual([
+        'message:first',
+        'message:second',
+        'error:first',
+        'error:second',
+        'disconnected:first',
+        'disconnected:second',
+      ])
+      expect(store.state).toEqual({ version: 1, status: 'ready', offset: 0 })
+      expect(client.getUpdatesCalls).toHaveLength(1)
+      expect(unhandled).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+
+  test('cursor write failure terminates without polling an uncommitted higher offset', async () => {
+    const store = new MemoryCursorStore({ version: 1, status: 'ready', offset: 0 })
+    store.failWrites = 1
+    const client = new FakePollingClient()
+    client.getUpdatesImpl = async (_options, signal) => {
+      if (client.getUpdatesCalls.length === 1) return [{ update_id: 41, message: telegramMessage(41) }]
+      return waitForAbort(signal)
+    }
+    let dispatched = 0
+    const errors: string[] = []
+    const disconnected = deferred<void>()
+    const listener = createListener(client, { cursorStore: store })
+    listener.on('message', () => {
+      dispatched++
+    })
+    listener.on('error', (error) => {
+      errors.push(error.message)
+    })
+    listener.on('disconnected', () => disconnected.resolve())
+
+    await listener.start()
+    await disconnected.promise
+    await Bun.sleep(10)
+
+    expect(client.getUpdatesCalls.map((call) => call.offset)).toEqual([0])
+    expect(dispatched).toBe(1)
+    expect(store.state).toEqual({ version: 1, status: 'ready', offset: 0 })
+    expect(
+      errors.some((message) => message.includes('checkpoint failed') && message.includes('not acknowledged')),
+    ).toBe(true)
+    await listener.stop()
+  })
+
+  test('stop interrupts dedicated backoff after a polling failure', async () => {
+    const store = new MemoryCursorStore({ version: 1, status: 'ready', offset: 0 })
+    const client = new FakePollingClient()
+    client.getUpdatesImpl = async () => {
+      throw new Error('temporary network failure')
+    }
+    const backoffStarted = deferred<AbortSignal>()
+    const backoffStopped = deferred<void>()
+    const listener = createListener(client, {
+      cursorStore: store,
+      backoff: async (_delay, signal) => {
+        backoffStarted.resolve(signal)
+        if (signal.aborted) return
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        backoffStopped.resolve()
+      },
+    })
+
+    await listener.start()
+    const signal = await backoffStarted.promise
+    await listener.stop()
+    await backoffStopped.promise
+
+    expect(signal.aborted).toBe(true)
+    expect(client.getUpdatesCalls).toHaveLength(1)
+  })
+
+  test('stop is bounded when the SDK request ignores abort and late results never dispatch', async () => {
+    const client = new FakePollingClient()
+    const pollResult = deferred<TelegramUpdate[]>()
+    let pollSignal: AbortSignal | undefined
+    client.getUpdatesImpl = (_options, signal) => {
+      pollSignal = signal
+      return pollResult.promise
+    }
+    const listener = createListener(client)
+    let dispatched = 0
+    listener.on('message', async () => {
+      dispatched++
+    })
+
+    await listener.start()
+    await waitUntil(() => client.getUpdatesCalls.length === 1)
+    const stopPromise = listener.stop()
+    expect(pollSignal?.aborted).toBe(true)
+    const stoppedWithinBound = await Promise.race([stopPromise.then(() => true), Bun.sleep(50).then(() => false)])
+    expect(stoppedWithinBound).toBe(true)
+
+    pollResult.resolve([{ update_id: 88, message: telegramMessage(8) }])
+    await Bun.sleep(10)
+
+    expect(dispatched).toBe(0)
+
+    const restartedClient = new FakePollingClient()
+    const restarted = createListener(restartedClient)
+    await restarted.start()
+    await waitUntil(() => restartedClient.getUpdatesCalls.length === 1)
+    expect(restartedClient.getUpdatesCalls[0]?.offset).toBe(0)
+    expect(restartedClient.deleteWebhookCalls).toEqual([{ drop_pending_updates: false }])
+    await restarted.stop()
+  })
+
+  test('late SDK rejection after abort is retained without unhandled or listener error leakage', async () => {
+    const client = new FakePollingClient()
+    const pollResult = deferred<TelegramUpdate[]>()
+    client.getUpdatesImpl = () => pollResult.promise
+    const listener = createListener(client)
+    const unhandled: unknown[] = []
+    const listenerErrors: Error[] = []
+    let dispatched = 0
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    listener.on('error', (error) => {
+      listenerErrors.push(error)
+    })
+    listener.on('message', () => {
+      dispatched++
+    })
+    try {
+      await listener.start()
+      await waitUntil(() => client.getUpdatesCalls.length === 1)
+      await listener.stop()
+
+      pollResult.reject(new Error('late SDK retry failed'))
+      await Bun.sleep(10)
+
+      expect(unhandled).toEqual([])
+      expect(listenerErrors).toEqual([])
+      expect(dispatched).toBe(0)
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+
+  test('stop during a handler prevents its later completion from checkpointing', async () => {
+    const client = new FakePollingClient()
+    const handlerStarted = deferred<void>()
+    const handlerFinished = deferred<void>()
+    client.getUpdatesImpl = async () => [{ update_id: 55, message: telegramMessage(9) }]
+    const listener = createListener(client)
+    listener.on('message', async () => {
+      handlerStarted.resolve()
+      await handlerFinished.promise
+    })
+
+    await listener.start()
+    await handlerStarted.promise
+    const stopPromise = listener.stop()
+    handlerFinished.resolve()
+    await stopPromise
+    await Bun.sleep(10)
+
+    const restartedClient = new FakePollingClient()
+    const restarted = createListener(restartedClient)
+    await restarted.start()
+    await waitUntil(() => restartedClient.getUpdatesCalls.length === 1)
+    expect(restartedClient.getUpdatesCalls[0]?.offset).toBe(0)
+    await restarted.stop()
+  })
+
+  test('reentrant stop lets the carrying dispatch checkpoint before drain completes', async () => {
+    const store = new MemoryCursorStore({ version: 1, status: 'ready', offset: 0 })
+    const client = new FakePollingClient()
+    client.getUpdatesImpl = async () => [{ update_id: 55, message: telegramMessage(55) }]
+    const listener = createListener(client, { cursorStore: store })
+    let stopPromise: Promise<void> | null = null
+    listener.on('message', () => {
+      stopPromise = listener.stop({ finishCurrentDispatch: true })
+    })
+
+    await listener.start()
+    await waitUntil(() => store.readyOffset() === 56)
+    await stopPromise
+
+    expect(store.state).toEqual({ version: 1, status: 'ready', offset: 56 })
+    expect(client.getUpdatesCalls.map((call) => call.offset)).toEqual([0])
+  })
+
+  test('stop drains an old checkpoint write before a replacement listener can start', async () => {
+    const store = new BlockingCheckpointStore({ version: 1, status: 'ready', offset: 0 }, 10)
+    const oldClient = new FakePollingClient()
+    let oldPoll = 0
+    oldClient.getUpdatesImpl = async (_options, signal) => {
+      oldPoll++
+      if (oldPoll === 1) return [{ update_id: 9, message: telegramMessage(9) }]
+      return waitForAbort(signal)
+    }
+    const oldListener = createListener(oldClient, { cursorStore: store })
+    oldListener.on('message', () => {})
+    await oldListener.start()
+    await store.blocked.promise
+
+    const replacementClient = new FakePollingClient()
+    let replacementPoll = 0
+    replacementClient.getUpdatesImpl = async (_options, signal) => {
+      replacementPoll++
+      if (replacementPoll === 1) return [{ update_id: 99, message: telegramMessage(99) }]
+      return waitForAbort(signal)
+    }
+    const replacement = createListener(replacementClient, { cursorStore: store })
+    replacement.on('message', () => {})
+    let stopResolved = false
+    const restart = (async () => {
+      await oldListener.stop()
+      stopResolved = true
+      await replacement.start()
+    })()
+
+    await Bun.sleep(10)
+    expect(stopResolved).toBe(false)
+    expect(replacementClient.getUpdatesCalls).toHaveLength(0)
+
+    store.release.resolve()
+    await restart
+    await waitUntil(() => replacementClient.getUpdatesCalls.length === 2 && store.readyOffset() === 100)
+
+    expect(replacementClient.getUpdatesCalls[0]?.offset).toBe(10)
+    expect(store.state).toEqual({ version: 1, status: 'ready', offset: 100 })
+    await replacement.stop()
+  })
+})
+
+function createListener(client: FakePollingClient, overrides: Partial<TelegramBotPollingListenerOptions> = {}) {
+  return createTelegramBotPollingListener(client, {
+    agentDir,
+    botUser: BOT_USER,
+    timeoutSeconds: 30,
+    limit: 100,
+    allowedUpdates: ['message', 'channel_post'],
+    ...overrides,
+  })
+}
+
+function telegramMessage(messageId: number) {
+  return {
+    message_id: messageId,
+    date: 1_700_000_000,
+    chat: { id: 123, type: 'private' as const },
+    from: { id: 1, is_bot: false, first_name: 'Alice' },
+    text: 'hello',
+  }
+}
+
+function waitForAbort(signal?: AbortSignal): Promise<TelegramUpdate[]> {
+  return new Promise((_resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+    signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+  })
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return
+    await Bun.sleep(1)
+  }
+  throw new Error('condition was not met')
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+class MemoryCursorStore implements TelegramBotCursorStore {
+  writes: TelegramBotCursorState[] = []
+  failWrites = 0
+
+  constructor(public state: TelegramBotCursorState | null) {}
+
+  async read(): Promise<TelegramBotCursorState | null> {
+    return this.state
+  }
+
+  async write(state: TelegramBotCursorState): Promise<void> {
+    this.writes.push(state)
+    if (this.failWrites > 0) {
+      this.failWrites--
+      throw new Error('checkpoint failed')
+    }
+    this.state = state
+  }
+
+  readyOffset(): number | null {
+    return this.state?.status === 'ready' ? this.state.offset : null
+  }
+}
+
+class BlockingCheckpointStore extends MemoryCursorStore {
+  readonly blocked = deferred<void>()
+  readonly release = deferred<void>()
+  private didBlock = false
+
+  constructor(
+    state: TelegramBotCursorState,
+    private readonly blockedOffset: number,
+  ) {
+    super(state)
+  }
+
+  override async write(state: TelegramBotCursorState): Promise<void> {
+    if (state.status === 'ready' && state.offset === this.blockedOffset && !this.didBlock) {
+      this.didBlock = true
+      this.blocked.resolve()
+      await this.release.promise
+    }
+    await super.write(state)
+  }
+}

--- a/src/channels/adapters/telegram-bot-listener.ts
+++ b/src/channels/adapters/telegram-bot-listener.ts
@@ -1,0 +1,408 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import { TelegramBotError } from 'agent-messenger/telegrambot'
+import type { TelegramBotClient, TelegramBotUser, TelegramMessage, TelegramUpdate } from 'agent-messenger/telegrambot'
+
+const CURSOR_VERSION = 1
+const FETCH_TIMEOUT_GRACE_MS = 10_000
+const RECONNECT_BASE_DELAY_MS = 1_000
+const RECONNECT_MAX_DELAY_MS = 30_000
+const FATAL_ERROR_CODES = new Set(['unauthorized', 'conflict'])
+
+export type TelegramBotCursorState =
+  | { version: 1; status: 'initializing' }
+  | { version: 1; status: 'ready'; offset: number }
+
+export interface TelegramBotCursorStore {
+  read(): Promise<TelegramBotCursorState | null>
+  write(state: TelegramBotCursorState): Promise<void>
+}
+
+export type TelegramBotPollingListenerEventMap = {
+  connected: [info: { user: TelegramBotUser }]
+  disconnected: []
+  error: [error: Error]
+  message: [event: TelegramMessage]
+  channel_post: [event: TelegramMessage]
+}
+
+type ListenerEvent = keyof TelegramBotPollingListenerEventMap
+type ListenerHandler<K extends ListenerEvent> = (...args: TelegramBotPollingListenerEventMap[K]) => void | Promise<void>
+type Backoff = (delayMs: number, signal: AbortSignal) => Promise<void>
+
+export type TelegramBotPollingClient = Pick<TelegramBotClient, 'deleteWebhook' | 'getUpdates'>
+
+export type TelegramBotPollingListenerOptions = {
+  agentDir: string
+  botUser: TelegramBotUser
+  timeoutSeconds: number
+  limit: number
+  allowedUpdates: string[]
+  cursorStore?: TelegramBotCursorStore
+  backoff?: Backoff
+}
+
+export type TelegramBotPollingListenerStopOptions = {
+  finishCurrentDispatch?: boolean
+}
+
+export interface TelegramBotPollingListener {
+  start(): Promise<void>
+  stop(options?: TelegramBotPollingListenerStopOptions): Promise<void>
+  on<K extends ListenerEvent>(event: K, handler: ListenerHandler<K>): this
+}
+
+export type TelegramBotPollingListenerFactory = (
+  client: TelegramBotPollingClient,
+  options: TelegramBotPollingListenerOptions,
+) => TelegramBotPollingListener
+
+export function telegramBotCursorPath(agentDir: string, botId: number): string {
+  return join(agentDir, 'channels', 'telegram-bot', 'cursors', `${botId}.json`)
+}
+
+export function createTelegramBotPollingListener(
+  client: TelegramBotPollingClient,
+  options: TelegramBotPollingListenerOptions,
+): TelegramBotPollingListener {
+  return new DurableTelegramBotPollingListener(client, options)
+}
+
+class DurableTelegramBotPollingListener implements TelegramBotPollingListener {
+  private readonly handlers = new Map<ListenerEvent, Set<ListenerHandler<ListenerEvent>>>()
+  private readonly cursorStore: TelegramBotCursorStore
+  private running = false
+  private generation = 0
+  private offset = 0
+  private reconnectAttempts = 0
+  private pollDisconnected = false
+  private activeAbortController: AbortController | null = null
+  private pollLoopPromise: Promise<void> | null = null
+  private dispatchingGeneration: number | null = null
+  private finishingDispatchGeneration: number | null = null
+
+  constructor(
+    private readonly client: TelegramBotPollingClient,
+    private readonly options: TelegramBotPollingListenerOptions,
+  ) {
+    this.cursorStore =
+      options.cursorStore ?? createFileCursorStore(telegramBotCursorPath(options.agentDir, options.botUser.id))
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return
+    this.running = true
+    this.reconnectAttempts = 0
+    this.pollDisconnected = false
+    const generation = ++this.generation
+
+    try {
+      const state = await this.cursorStore.read()
+      if (!this.isCurrent(generation)) return
+
+      if (state === null) {
+        await this.cursorStore.write({ version: 1, status: 'initializing' })
+        if (!this.isCurrent(generation)) return
+        await this.client.deleteWebhook({ drop_pending_updates: true })
+        if (!this.isCurrent(generation)) return
+        await this.cursorStore.write({ version: 1, status: 'ready', offset: 0 })
+        this.offset = 0
+      } else if (state.status === 'initializing') {
+        // A crash may have happened before or after the first destructive drop.
+        // Preserve possible backlog on recovery rather than risk dropping twice.
+        await this.client.deleteWebhook({ drop_pending_updates: false })
+        if (!this.isCurrent(generation)) return
+        await this.cursorStore.write({ version: 1, status: 'ready', offset: 0 })
+        this.offset = 0
+      } else {
+        this.offset = state.offset
+        await this.client.deleteWebhook({ drop_pending_updates: false })
+      }
+
+      if (!this.isCurrent(generation)) return
+      await this.emitSafely('connected', { user: this.options.botUser })
+      if (!this.isCurrent(generation)) return
+      this.pollLoopPromise = this.supervisePollLoop(generation)
+    } catch (error) {
+      if (this.isCurrent(generation)) this.running = false
+      this.abortActiveOperation()
+      throw normalizeError(error)
+    }
+  }
+
+  async stop(options: TelegramBotPollingListenerStopOptions = {}): Promise<void> {
+    this.running = false
+    if (options.finishCurrentDispatch === true && this.dispatchingGeneration === this.generation) {
+      this.finishingDispatchGeneration = this.generation
+    } else {
+      this.generation++
+      this.finishingDispatchGeneration = null
+    }
+    this.abortActiveOperation()
+    await this.pollLoopPromise
+    this.pollLoopPromise = null
+    if (this.finishingDispatchGeneration !== null) {
+      this.generation++
+      this.finishingDispatchGeneration = null
+    }
+  }
+
+  on<K extends ListenerEvent>(event: K, handler: ListenerHandler<K>): this {
+    const handlers = this.handlers.get(event) ?? new Set<ListenerHandler<ListenerEvent>>()
+    handlers.add(handler as ListenerHandler<ListenerEvent>)
+    this.handlers.set(event, handlers)
+    return this
+  }
+
+  private isCurrent(generation: number): boolean {
+    return this.running && generation === this.generation
+  }
+
+  private async supervisePollLoop(generation: number): Promise<void> {
+    try {
+      await this.pollLoop(generation)
+    } catch (error) {
+      if (this.isCurrent(generation)) await this.terminate(normalizeError(error))
+    }
+  }
+
+  private async pollLoop(generation: number): Promise<void> {
+    let firstSuccessfulPoll = true
+    while (this.isCurrent(generation)) {
+      const pollController = new AbortController()
+      this.activeAbortController = pollController
+      const fetchTimeout = setTimeout(
+        () => pollController.abort(),
+        (this.options.timeoutSeconds + FETCH_TIMEOUT_GRACE_MS / 1_000) * 1_000,
+      )
+
+      let updates: TelegramUpdate[]
+      try {
+        updates = await settleWithAbort(
+          this.client.getUpdates(
+            {
+              offset: this.offset,
+              limit: this.options.limit,
+              timeout: this.options.timeoutSeconds,
+              allowed_updates: firstSuccessfulPoll ? this.options.allowedUpdates : undefined,
+            },
+            pollController.signal,
+          ),
+          pollController.signal,
+        )
+      } catch (error) {
+        clearTimeout(fetchTimeout)
+        this.clearActiveOperation(pollController)
+        if (!this.isCurrent(generation)) return
+        if (error instanceof TelegramBotError && FATAL_ERROR_CODES.has(error.code)) {
+          await this.terminate(error)
+          return
+        }
+        this.pollDisconnected = true
+        await this.emitSafely('disconnected')
+        await this.backoff(generation)
+        continue
+      }
+      clearTimeout(fetchTimeout)
+      this.clearActiveOperation(pollController)
+
+      if (!this.isCurrent(generation)) return
+      firstSuccessfulPoll = false
+      this.reconnectAttempts = 0
+      if (this.pollDisconnected) {
+        this.pollDisconnected = false
+        await this.emitSafely('connected', { user: this.options.botUser })
+      }
+      for (const update of updates) {
+        if (!this.isCurrent(generation)) return
+        this.dispatchingGeneration = generation
+        const handlerErrors = await this.dispatch(update)
+        if (handlerErrors.length > 0) {
+          this.dispatchingGeneration = null
+          await this.terminate(new AggregateError(handlerErrors, 'Telegram bot update handler failed'))
+          return
+        }
+        if (!this.mayFinishDispatch(generation)) {
+          this.dispatchingGeneration = null
+          return
+        }
+
+        const nextOffset = update.update_id + 1
+        // Telegram only sees the higher offset after its durable checkpoint exists.
+        try {
+          await this.cursorStore.write({ version: 1, status: 'ready', offset: nextOffset })
+        } catch (error) {
+          this.dispatchingGeneration = null
+          await this.terminate(
+            new Error(
+              `Telegram bot cursor checkpoint failed; update ${update.update_id} was not acknowledged and will replay after recovery: ${normalizeError(error).message}`,
+            ),
+          )
+          return
+        }
+        this.offset = nextOffset
+        this.dispatchingGeneration = null
+        if (!this.running) return
+      }
+    }
+  }
+
+  private async dispatch(update: TelegramUpdate): Promise<Error[]> {
+    const errors: Error[] = []
+    if (update.message !== undefined) errors.push(...(await this.runHandlers('message', update.message)))
+    if (update.channel_post !== undefined) errors.push(...(await this.runHandlers('channel_post', update.channel_post)))
+    return errors
+  }
+
+  private async terminate(error: Error): Promise<void> {
+    this.running = false
+    this.abortActiveOperation()
+    await this.emitSafely('error', error)
+    await this.emitSafely('disconnected')
+  }
+
+  private async emitSafely<K extends ListenerEvent>(
+    event: K,
+    ...args: TelegramBotPollingListenerEventMap[K]
+  ): Promise<void> {
+    await this.runHandlers(event, ...args)
+  }
+
+  private async runHandlers<K extends ListenerEvent>(
+    event: K,
+    ...args: TelegramBotPollingListenerEventMap[K]
+  ): Promise<Error[]> {
+    const handlers = this.handlers.get(event)
+    if (handlers === undefined) return []
+    const errors: Error[] = []
+    for (const handler of handlers) {
+      try {
+        await handler(...args)
+      } catch (error) {
+        errors.push(normalizeError(error))
+      }
+    }
+    return errors
+  }
+
+  private async backoff(generation: number): Promise<void> {
+    if (!this.isCurrent(generation)) return
+    const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempts, RECONNECT_MAX_DELAY_MS)
+    this.reconnectAttempts++
+    const controller = new AbortController()
+    this.activeAbortController = controller
+    try {
+      await (this.options.backoff ?? delayWithAbort)(delay, controller.signal)
+    } finally {
+      this.clearActiveOperation(controller)
+    }
+  }
+
+  private abortActiveOperation(): void {
+    this.activeAbortController?.abort()
+    this.activeAbortController = null
+  }
+
+  private clearActiveOperation(controller: AbortController): void {
+    if (this.activeAbortController === controller) this.activeAbortController = null
+  }
+
+  private mayFinishDispatch(generation: number): boolean {
+    return this.isCurrent(generation) || this.finishingDispatchGeneration === generation
+  }
+}
+
+function createFileCursorStore(path: string): TelegramBotCursorStore {
+  return {
+    async read(): Promise<TelegramBotCursorState | null> {
+      let raw: string
+      try {
+        raw = await readFile(path, 'utf8')
+      } catch (error) {
+        if (isEnoent(error)) return null
+        throw error
+      }
+
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(raw)
+      } catch (error) {
+        throw cursorStateError(path, `invalid JSON: ${normalizeError(error).message}`)
+      }
+      if (!isRecord(parsed) || parsed.version !== CURSOR_VERSION) {
+        const version = isRecord(parsed) ? parsed.version : undefined
+        throw cursorStateError(path, `unsupported version ${String(version)}`)
+      }
+      if (parsed.status === 'initializing') return { version: 1, status: 'initializing' }
+      if (parsed.status === 'ready' && Number.isSafeInteger(parsed.offset) && (parsed.offset as number) >= 0) {
+        return { version: 1, status: 'ready', offset: parsed.offset as number }
+      }
+      throw cursorStateError(path, 'invalid status or offset')
+    },
+
+    async write(state: TelegramBotCursorState): Promise<void> {
+      await mkdir(dirname(path), { recursive: true })
+      const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`
+      await writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+      await rename(temporary, path)
+    },
+  }
+}
+
+function cursorStateError(path: string, detail: string): Error {
+  return new Error(
+    `Telegram bot cursor state at ${path} is corrupt or unsupported (${detail}). ` +
+      'Inspect and repair the file before restarting; moving it aside creates a first boot that drops pending updates.',
+  )
+}
+
+async function delayWithAbort(delayMs: number, signal: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    const timer = setTimeout(resolve, delayMs)
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer)
+        resolve()
+      },
+      { once: true },
+    )
+  })
+}
+
+async function settleWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  // Retaining both outcomes sinks a late SDK settlement after the abort race wins.
+  const retained = promise.then(
+    (value) => ({ kind: 'fulfilled' as const, value }),
+    (error: unknown) => ({ kind: 'rejected' as const, error }),
+  )
+  const aborted = new Promise<{ kind: 'aborted' }>((resolve) => {
+    if (signal.aborted) {
+      resolve({ kind: 'aborted' })
+      return
+    }
+    signal.addEventListener('abort', () => resolve({ kind: 'aborted' }), { once: true })
+  })
+  const result = await Promise.race([retained, aborted])
+  if (result.kind === 'fulfilled') return result.value
+  if (result.kind === 'rejected') throw result.error
+  throw new DOMException('Aborted', 'AbortError')
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function isEnoent(error: unknown): boolean {
+  return isRecord(error) && error.code === 'ENOENT'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/src/channels/adapters/telegram-bot-reload.test.ts
+++ b/src/channels/adapters/telegram-bot-reload.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { TelegramBotClient, TelegramBotUser, TelegramMessage } from 'agent-messenger/telegrambot'
+
+import { createChannelManager, type ChannelManager } from '@/channels/manager'
+import { defaultHistoryConfig, type ChannelsConfig } from '@/channels/schema'
+
+import { createTelegramBotAdapter } from './telegram-bot'
+import type {
+  TelegramBotPollingListener,
+  TelegramBotPollingListenerEventMap,
+  TelegramBotPollingListenerStopOptions,
+} from './telegram-bot-listener'
+
+const BOT_USER: TelegramBotUser = { id: 999, is_bot: true, first_name: 'TypeClaw', username: 'typeclaw_bot' }
+
+type ListenerEvent = keyof TelegramBotPollingListenerEventMap
+type ListenerHandler<K extends ListenerEvent> = (...args: TelegramBotPollingListenerEventMap[K]) => void | Promise<void>
+
+class ReloadListener implements TelegramBotPollingListener {
+  readonly events: string[] = []
+  readonly finishCurrentDispatchValues: boolean[] = []
+  private readonly handlers = new Map<ListenerEvent, Set<ListenerHandler<ListenerEvent>>>()
+  private delivery: Promise<void> | null = null
+  private readonly forced = deferred<void>()
+  private stopRequested = false
+  private finishCurrentDispatch = false
+
+  async start(): Promise<void> {
+    await this.emit('connected', { user: BOT_USER })
+  }
+
+  async stop(options: TelegramBotPollingListenerStopOptions = {}): Promise<void> {
+    this.stopRequested = true
+    this.finishCurrentDispatch = options.finishCurrentDispatch === true
+    this.finishCurrentDispatchValues.push(this.finishCurrentDispatch)
+    this.events.push('stop-requested')
+    if (this.finishCurrentDispatch) await (this.delivery ?? Promise.resolve())
+    else await this.forced.promise
+    this.events.push('stop-drained')
+  }
+
+  on<K extends ListenerEvent>(event: K, handler: ListenerHandler<K>): this {
+    const handlers = this.handlers.get(event) ?? new Set<ListenerHandler<ListenerEvent>>()
+    handlers.add(handler as ListenerHandler<ListenerEvent>)
+    this.handlers.set(event, handlers)
+    return this
+  }
+
+  async deliver(message: TelegramMessage): Promise<void> {
+    this.delivery = (async () => {
+      await this.emit('message', message)
+      if (!this.stopRequested || this.finishCurrentDispatch) this.events.push('checkpoint')
+    })()
+    await this.delivery
+  }
+
+  forceStop(): void {
+    this.forced.resolve()
+  }
+
+  private async emit<K extends ListenerEvent>(event: K, ...args: TelegramBotPollingListenerEventMap[K]): Promise<void> {
+    for (const handler of this.handlers.get(event) ?? []) await handler(...args)
+  }
+}
+
+class ReloadClient {
+  readonly events: string[] = []
+  readonly summarySent = deferred<void>()
+
+  async login(): Promise<this> {
+    return this
+  }
+
+  async getMe(): Promise<TelegramBotUser> {
+    return BOT_USER
+  }
+
+  async getChat(): Promise<{ id: number; type: 'private'; first_name: string }> {
+    return { id: 123, type: 'private', first_name: 'Alice' }
+  }
+
+  async getChatMemberCount(): Promise<number> {
+    return 2
+  }
+
+  async sendMessage(_chatId: string | number, text: string): Promise<TelegramMessage> {
+    this.events.push(`summary:${text}`)
+    this.summarySent.resolve()
+    return { message_id: 20, date: 0, chat: { id: 123, type: 'private' } }
+  }
+
+  async sendDocument(): Promise<TelegramMessage> {
+    return { message_id: 21, date: 0, chat: { id: 123, type: 'private' } }
+  }
+}
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-telegram-reload-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('Telegram /reload teardown', () => {
+  test('disabling the carrying adapter replies before teardown and completes without self-deadlock', async () => {
+    let cfg: ChannelsConfig = { 'telegram-bot': enabledAdapterCfg() }
+    const client = new ReloadClient()
+    const listener = new ReloadListener()
+    let manager: ChannelManager
+    let runReload = async (): Promise<string> => 'not ready'
+    manager = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { TELEGRAM_BOT_TOKEN: 'test-token' },
+      onReload: () => runReload(),
+      createTelegramAdapter: (options) =>
+        createTelegramBotAdapter({
+          ...options,
+          createClient: () => client as unknown as TelegramBotClient,
+          createListener: () => listener,
+        }),
+    })
+    runReload = async () => {
+      cfg = { 'telegram-bot': { ...enabledAdapterCfg(), enabled: false } }
+      const diff = await manager.reload()
+      return `Reloaded: ${diff.stopped.length} stopped`
+    }
+
+    await manager.start()
+    const delivery = listener.deliver(reloadMessage())
+    const replied = await Promise.race([client.summarySent.promise.then(() => true), Bun.sleep(100).then(() => false)])
+    if (!replied) listener.forceStop()
+    await delivery
+
+    expect(replied).toBe(true)
+    expect(listener.finishCurrentDispatchValues).toEqual([true])
+    expect(client.events[0]).toContain('Reloaded')
+    expect(listener.events.indexOf('checkpoint')).toBeGreaterThan(listener.events.indexOf('stop-requested'))
+    expect(client.events).toHaveLength(1)
+
+    await waitUntil(async () => {
+      const result = await manager.router.send({
+        adapter: 'telegram-bot',
+        workspace: 'telegram',
+        chat: '123',
+        text: 'after teardown',
+      })
+      return !result.ok
+    })
+    expect(listener.events).toContain('stop-drained')
+    await manager.stop()
+  })
+})
+
+function enabledAdapterCfg() {
+  return {
+    enabled: true,
+    engagement: {
+      trigger: ['mention', 'reply', 'dm'] as Array<'mention' | 'reply' | 'dm'>,
+      stickiness: { perReply: { window: 300_000 } },
+    },
+    history: defaultHistoryConfig(),
+  }
+}
+
+function reloadMessage(): TelegramMessage {
+  return {
+    message_id: 10,
+    date: 1_700_000_000,
+    chat: { id: 123, type: 'private', first_name: 'Alice' },
+    from: { id: 1, is_bot: false, first_name: 'Alice' },
+    text: '/reload',
+  }
+}
+
+async function waitUntil(predicate: () => Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (await predicate()) return
+    await Bun.sleep(1)
+  }
+  throw new Error('condition was not met')
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/src/channels/adapters/telegram-bot.ts
+++ b/src/channels/adapters/telegram-bot.ts
@@ -1,4 +1,6 @@
-import { TelegramBotClient, TelegramBotListener } from 'agent-messenger/telegrambot'
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+import { TelegramBotClient } from 'agent-messenger/telegrambot'
 import type { TelegramBotUser, TelegramMessage } from 'agent-messenger/telegrambot'
 
 import { readResponseBodyBounded } from '@/agent/network/response-body'
@@ -26,6 +28,11 @@ import { describeError } from '../describe-error'
 import { classifyInbound, type InboundDropReason, TELEGRAM_WORKSPACE } from './telegram-bot-classify'
 import { createTelegramEditMessageCallback } from './telegram-bot-edit'
 import { toTelegramMarkdownV2 } from './telegram-bot-format'
+import {
+  createTelegramBotPollingListener,
+  type TelegramBotPollingListener,
+  type TelegramBotPollingListenerFactory,
+} from './telegram-bot-listener'
 
 export const TELEGRAM_API_BASE = 'https://api.telegram.org'
 
@@ -60,17 +67,15 @@ const consoleLogger: TelegramBotAdapterLogger = {
 }
 
 // Test seams for `createTelegramBotAdapter`. Production callers omit these
-// and the real SDK constructors are used; tests inject fakes to drive
+// and use the real SDK client plus TypeClaw-owned listener; tests inject fakes to drive
 // listener events deterministically (especially the silent-startup and
 // inflight-during-stop paths that the real SDK doesn't expose hooks for).
 export type TelegramBotClientFactory = () => TelegramBotClient
-export type TelegramBotListenerFactory = (
-  client: TelegramBotClient,
-  options: ConstructorParameters<typeof TelegramBotListener>[1],
-) => TelegramBotListener
+export type TelegramBotListenerFactory = TelegramBotPollingListenerFactory
 
 export type TelegramBotAdapterOptions = {
   router: ChannelRouter
+  agentDir: string
   configRef: () => ChannelAdapterConfig
   token: string
   logger?: TelegramBotAdapterLogger
@@ -81,6 +86,7 @@ export type TelegramBotAdapterOptions = {
 export type TelegramBotAdapter = {
   start: () => Promise<void>
   stop: () => Promise<void>
+  stopCompletion?: () => Promise<void> | null
   isConnected: () => boolean
 }
 
@@ -390,14 +396,17 @@ export function createFetchAttachmentCallback(deps: {
 export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): TelegramBotAdapter {
   const logger = options.logger ?? consoleLogger
   const createClient = options.createClient ?? (() => new TelegramBotClient())
+  // agent-messenger@2.35.0 cannot seed its private getUpdates offset.
   const createListener =
-    options.createListener ?? ((client, listenerOptions) => new TelegramBotListener(client, listenerOptions))
+    options.createListener ?? ((client, listenerOptions) => createTelegramBotPollingListener(client, listenerOptions))
   const client = createClient()
-  let listener: TelegramBotListener | null = null
+  let listener: TelegramBotPollingListener | null = null
   let botUser: TelegramBotUser | null = null
   let started = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
+  let stopCompletion: Promise<void> | null = null
+  const inboundContext = new AsyncLocalStorage<boolean>()
 
   const channelResolver = createChannelNameResolver({ client })
 
@@ -445,27 +454,27 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
     // as `pre_connect`, losing a legitimate message.
     const botSnapshot = botUser
     try {
-      const tag = await formatChannelTag(String(event.chat.id))
-      const fromLabel = event.from?.username ?? event.from?.first_name ?? String(event.from?.id ?? '?')
-      const text = event.text ?? event.caption ?? ''
-      logger.info(
-        `[telegram-bot] inbound message_id=${event.message_id} author=${fromLabel} ${tag} text_len=${text.length}`,
-      )
-
-      const verdict = classifyInbound(event, options.configRef(), botSnapshot)
-      if (verdict.kind === 'drop') {
+      await inboundContext.run(true, async () => {
+        const tag = await formatChannelTag(String(event.chat.id))
+        const fromLabel = event.from?.username ?? event.from?.first_name ?? String(event.from?.id ?? '?')
+        const text = event.text ?? event.caption ?? ''
         logger.info(
-          `[telegram-bot] dropped message_id=${event.message_id} reason=${verdict.reason}${dropHint(verdict.reason)}`,
+          `[telegram-bot] inbound message_id=${event.message_id} author=${fromLabel} ${tag} text_len=${text.length}`,
         )
-        return
-      }
 
-      logger.info(
-        `[telegram-bot] routed message_id=${event.message_id} ${tag} mention=${verdict.payload.isBotMention} reply=${verdict.payload.replyToBotMessageId !== null}`,
-      )
-      await options.router.route(verdict.payload)
-    } catch (err) {
-      logger.error(`[telegram-bot] handleInbound failed: ${describeError(err)}`)
+        const verdict = classifyInbound(event, options.configRef(), botSnapshot)
+        if (verdict.kind === 'drop') {
+          logger.info(
+            `[telegram-bot] dropped message_id=${event.message_id} reason=${verdict.reason}${dropHint(verdict.reason)}`,
+          )
+          return
+        }
+
+        logger.info(
+          `[telegram-bot] routed message_id=${event.message_id} ${tag} mention=${verdict.payload.isBotMention} reply=${verdict.payload.replyToBotMessageId !== null}`,
+        )
+        await options.router.route(verdict.payload)
+      })
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -488,13 +497,8 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
         throw err
       }
 
-      // Preflight `getMe()` so an invalid token surfaces here as a thrown
-      // error instead of silently emitting `'error'` from inside the
-      // listener and leaving us in `started=true` with a dead poller. The
-      // listener itself calls `getMe()` internally on `start()` but
-      // catches the failure and returns normally — see
-      // node_modules/agent-messenger/dist/src/platforms/telegrambot/listener.js
-      // around the `try { this.cachedUser = await getMe() }` block.
+      // Preflight once so authentication failure aborts startup and the
+      // owned listener can reuse this identity for its connected event.
       try {
         botUser = await client.getMe()
         const handle = botUser.username !== undefined ? `@${botUser.username}` : botUser.first_name
@@ -507,20 +511,14 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
       }
 
       listener = createListener(client, {
+        agentDir: options.agentDir,
+        botUser,
         timeoutSeconds: 30,
+        limit: 100,
         allowedUpdates: TELEGRAM_ALLOWED_UPDATES,
-        dropPendingUpdates: true,
       })
-      // Track whether the listener emitted `connected` during start(). The
-      // SDK's `start()` returns normally even when `deleteWebhook` or
-      // (less importantly, since we already preflighted) `getMe` fails
-      // internally — see
-      // node_modules/agent-messenger/dist/src/platforms/telegrambot/listener.js
-      // lines 36-60 (try/catch around each setup step that emits 'error'
-      // and returns rather than throwing). Without this flag, a failed
-      // startup leaves us with `started=true`, callbacks registered, and
-      // a dead poller. We use the SDK's own `connected` event as the
-      // single source of truth for "the listener is actually running".
+      // Keep the connected-event contract for injected listeners that may
+      // still return normally after a silent startup failure.
       let listenerConnected = false
       let listenerStartupError: Error | null = null
       listener.on('connected', (info) => {
@@ -528,7 +526,8 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
         botUser = info.user
       })
       listener.on('disconnected', () => {
-        logger.warn('[telegram-bot] disconnected; SDK will reconnect with backoff')
+        botUser = null
+        logger.warn('[telegram-bot] disconnected; listener will reconnect with backoff')
       })
       listener.on('error', (err) => {
         const error = err instanceof Error ? err : new Error(describeError(err))
@@ -537,12 +536,8 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
         }
         logger.error(`[telegram-bot] listener error: ${describeError(err)}`)
       })
-      listener.on('message', (event) => {
-        void handleMessage(event)
-      })
-      listener.on('channel_post', (event) => {
-        void handleMessage(event)
-      })
+      listener.on('message', handleMessage)
+      listener.on('channel_post', handleMessage)
 
       options.router.registerOutbound('telegram-bot', outboundCallback)
       options.router.registerTyping('telegram-bot', typingCallback)
@@ -553,7 +548,7 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
       options.router.registerMembership('telegram-bot', membershipResolver)
       options.router.registerEditMessage('telegram-bot', editMessageCallback)
 
-      const rollbackStart = (reason: string, cause: Error): never => {
+      const rollbackStart = async (reason: string, cause: Error): Promise<never> => {
         options.router.unregisterOutbound('telegram-bot', outboundCallback)
         options.router.unregisterTyping('telegram-bot', typingCallback)
         options.router.setTypingCapability('telegram-bot', false)
@@ -562,7 +557,7 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
         options.router.unregisterFetchAttachment('telegram-bot', fetchAttachmentCallback)
         options.router.unregisterMembership('telegram-bot', membershipResolver)
         options.router.unregisterEditMessage('telegram-bot', editMessageCallback)
-        listener?.stop()
+        await listener?.stop()
         listener = null
         botUser = null
         started = false
@@ -573,48 +568,65 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
       try {
         await listener.start()
       } catch (err) {
-        rollbackStart('listener start threw', err instanceof Error ? err : new Error(describeError(err)))
+        await rollbackStart('listener start threw', err instanceof Error ? err : new Error(describeError(err)))
       }
       if (!listenerConnected) {
         const cause = listenerStartupError ?? new Error('listener.start() returned without emitting connected')
-        rollbackStart('listener start failed silently', cause)
+        await rollbackStart('listener start failed silently', cause)
       }
     },
 
     async stop(): Promise<void> {
+      if (stopCompletion !== null) {
+        const pending = stopCompletion
+        if (inboundContext.getStore() !== true) {
+          await pending
+          if (stopCompletion === pending) stopCompletion = null
+        }
+        return
+      }
       if (!started) return
       started = false
-      options.router.unregisterOutbound('telegram-bot', outboundCallback)
-      options.router.unregisterTyping('telegram-bot', typingCallback)
-      options.router.setTypingCapability('telegram-bot', false)
-      options.router.unregisterChannelNameResolver('telegram-bot', channelResolver)
-      options.router.unregisterSelfIdentity('telegram-bot', selfIdentityResolver)
-      options.router.unregisterFetchAttachment('telegram-bot', fetchAttachmentCallback)
-      options.router.unregisterMembership('telegram-bot', membershipResolver)
-      options.router.unregisterEditMessage('telegram-bot', editMessageCallback)
-      // Stop the listener BEFORE waiting for inflight handlers. The SDK's
-      // `stop()` aborts the in-flight `getUpdates` long-poll and
-      // increments its generation counter so any pending dispatch is
-      // dropped. Doing this before the wait bounds the drain: nothing
-      // new can land in `handleMessage()`, so `inflightInbounds` only
-      // decreases.
-      listener?.stop()
-      listener = null
-      if (inflightInbounds > 0) {
-        await new Promise<void>((resolve) => {
-          stopWaiters.push(resolve)
-        })
-      }
-      // Null `botUser` only AFTER inflight handlers have drained.
-      // `handleMessage` snapshots `botUser` at dispatch time so this is
-      // belt-and-suspenders, but freeing the reference here keeps
-      // `isConnected()` honest after stop completes.
-      botUser = null
+      const reentrantInboundStop = inboundContext.getStore() === true
+      const currentListener = listener
+      // An inbound /reload cannot await its own dispatch. Quiesce now, then
+      // unregister only after that handler replies and the listener checkpoints.
+      const completion = (async (): Promise<void> => {
+        await currentListener?.stop({ finishCurrentDispatch: reentrantInboundStop })
+        unregisterCallbacks()
+        if (listener === currentListener) listener = null
+        if (inflightInbounds > 0) {
+          await new Promise<void>((resolve) => {
+            stopWaiters.push(resolve)
+          })
+        }
+        botUser = null
+      })()
+      stopCompletion = completion
+      void completion.catch((err) => logger.error(`[telegram-bot] deferred stop failed: ${describeError(err)}`))
+      if (reentrantInboundStop) return
+      await completion
+      if (stopCompletion === completion) stopCompletion = null
+    },
+
+    stopCompletion(): Promise<void> | null {
+      return stopCompletion
     },
 
     isConnected(): boolean {
       return botUser !== null
     },
+  }
+
+  function unregisterCallbacks(): void {
+    options.router.unregisterOutbound('telegram-bot', outboundCallback)
+    options.router.unregisterTyping('telegram-bot', typingCallback)
+    options.router.setTypingCapability('telegram-bot', false)
+    options.router.unregisterChannelNameResolver('telegram-bot', channelResolver)
+    options.router.unregisterSelfIdentity('telegram-bot', selfIdentityResolver)
+    options.router.unregisterFetchAttachment('telegram-bot', fetchAttachmentCallback)
+    options.router.unregisterMembership('telegram-bot', membershipResolver)
+    options.router.unregisterEditMessage('telegram-bot', editMessageCallback)
   }
 }
 

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -35,6 +35,14 @@ function deferred<T = void>(): Deferred<T> {
   return { promise, resolve, reject }
 }
 
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return
+    await Bun.sleep(1)
+  }
+  throw new Error('condition was not met')
+}
+
 function makeFakeAdapter(): FakeAdapter & { connected: boolean } {
   const adapter = {
     connected: true,
@@ -959,6 +967,83 @@ describe('channel manager — connection recovery', () => {
 })
 
 describe('channel manager — restartAdapter serialization', () => {
+  test('defers a Telegram replacement until an inbound stop completion drains', async () => {
+    cfg['telegram-bot'] = enabledAdapterCfg()
+    const events: string[] = []
+    const drain = deferred<void>()
+    const oldAdapter = makeRecordingAdapter(events, 'telegram#1')
+    const deferredOldAdapter = {
+      ...oldAdapter,
+      stopCompletion: () => drain.promise,
+    }
+    const replacement = makeRecordingAdapter(events, 'telegram#2')
+    const adapters = [deferredOldAdapter, replacement]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { TELEGRAM_BOT_TOKEN: 'test-token' },
+      createTelegramAdapter: () => adapters.shift()!,
+    })
+
+    await mgr.start()
+    await mgr.restartAdapter('telegram-bot')
+
+    expect(events).toEqual([
+      'telegram#1:start:begin',
+      'telegram#1:start:end',
+      'telegram#1:stop:begin',
+      'telegram#1:stop:end',
+    ])
+
+    drain.resolve()
+    await waitUntil(() => events.includes('telegram#2:start:end'))
+    expect(events).toContain('telegram#2:start:end')
+    await mgr.stop()
+  })
+
+  test('does not commit a deferred Telegram replacement disabled while start is pending', async () => {
+    cfg['telegram-bot'] = enabledAdapterCfg()
+    const events: string[] = []
+    const drain = deferred<void>()
+    const startGate = deferred<void>()
+    const oldAdapter = makeRecordingAdapter(events, 'telegram#1')
+    const deferredOldAdapter = {
+      ...oldAdapter,
+      stopCompletion: () => drain.promise,
+    }
+    const replacement = makeRecordingAdapter(events, 'telegram#2', { start: startGate.promise })
+    const adapters = [deferredOldAdapter, replacement]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { TELEGRAM_BOT_TOKEN: 'test-token' },
+      createTelegramAdapter: () => adapters.shift()!,
+    })
+
+    await mgr.start()
+    await mgr.restartAdapter('telegram-bot')
+    drain.resolve()
+    await waitUntil(() => events.includes('telegram#2:start:begin'))
+
+    cfg['telegram-bot'] = { ...enabledAdapterCfg(), enabled: false }
+    startGate.resolve()
+    await waitUntil(() => replacement.stopCalls === 1)
+
+    expect(events).toEqual([
+      'telegram#1:start:begin',
+      'telegram#1:start:end',
+      'telegram#1:stop:begin',
+      'telegram#1:stop:end',
+      'telegram#2:start:begin',
+      'telegram#2:start:end',
+      'telegram#2:stop:begin',
+      'telegram#2:stop:end',
+    ])
+    await mgr.reload()
+    await mgr.stop()
+    expect(replacement.stopCalls).toBe(1)
+  })
+
   test('restartAdapter stops a live github adapter before starting it again', async () => {
     cfg.github = enabledGithubCfg()
     await writeGithubSecrets(agentDir)
@@ -1599,7 +1684,7 @@ describe('channel manager — telegram adapter lifecycle', () => {
   test('starts telegram adapter and forwards TELEGRAM_BOT_TOKEN to it', async () => {
     cfg['telegram-bot'] = enabledAdapterCfg()
     const fake = makeFakeAdapter()
-    let captured: { token?: string; configRef?: () => unknown } | undefined
+    let captured: { agentDir?: string; token?: string; configRef?: () => unknown } | undefined
     const env: NodeJS.ProcessEnv = { TELEGRAM_BOT_TOKEN: 'tg-tok-abc' }
     const mgr = createChannelManager({
       agentDir,
@@ -1617,6 +1702,7 @@ describe('channel manager — telegram adapter lifecycle', () => {
     // wrong env var (or hardcoded a string) would still pass any test
     // that didn't capture the actual token passed to the adapter.
     expect(captured?.token).toBe('tg-tok-abc')
+    expect(captured?.agentDir).toBe(agentDir)
     expect(typeof captured?.configRef).toBe('function')
 
     await mgr.stop()

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -276,6 +276,8 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   const failed = new Map<AdapterId, FailedAdapter>()
   const failedInputSignatures = new WeakMap<FailedAdapter, string>()
   const perAdapterSerial = new Map<AdapterId, Promise<unknown>>()
+  const deferredStops = new Map<AdapterId, Promise<void>>()
+  const deferredRestarts = new Set<AdapterId>()
   const recovery = options.connectionRecovery ?? {}
   const recoveryCheckIntervalMs = recovery.checkIntervalMs ?? 5_000
   const recoveryDisconnectedGraceMs = recovery.disconnectedGraceMs ?? 90_000
@@ -444,6 +446,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       const token = env.TELEGRAM_BOT_TOKEN
       if (token === undefined || token.trim() === '') return null
       return createTelegramAdapter({
+        agentDir: options.agentDir,
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         token,
@@ -482,6 +485,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     canCommit: () => boolean,
   ): Promise<StartAdapterResult | { status: 'credential-changed' }> => {
     if (!canCommit()) return { status: 'aborted' }
+    if (deferredStops.has(name)) return { status: 'aborted' }
     if (cfg.enabled === false) {
       logger.info(`[channels] adapter "${name}" is disabled; skipping`)
       return { status: 'disabled' }
@@ -697,6 +701,22 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     if (!entry) return true
     try {
       await entry.adapter.stop()
+      const completion = 'stopCompletion' in entry.adapter ? (entry.adapter.stopCompletion?.() ?? null) : null
+      if (completion !== null) {
+        deferredStops.set(name, completion)
+        void completion.then(
+          () => {
+            if (live.get(name) === entry) live.delete(name)
+            if (deferredStops.get(name) === completion) deferredStops.delete(name)
+            logger.info(`[channels] adapter "${name}" stopped after inbound drain`)
+          },
+          (err: unknown) => {
+            if (deferredStops.get(name) === completion) deferredStops.delete(name)
+            logger.error(`[channels] adapter "${name}" deferred stop failed: ${describeError(err)}`)
+          },
+        )
+        return true
+      }
       if (live.get(name) === entry) live.delete(name)
       logger.info(`[channels] adapter "${name}" stopped`)
       return true
@@ -716,9 +736,35 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     const previousFailure = failed.get(name)
     failed.delete(name)
     if (!(await stopAdapter(name))) return 'stop-failed'
+    const deferredStop = deferredStops.get(name)
+    if (deferredStop !== undefined) {
+      scheduleRestartAfterDeferredStop(name, deferredStop)
+      return 'recovery-pending'
+    }
     const queuedEpoch = lifecycleEpoch
     const result = await startAdapter(name, currentCfg, () => running && queuedEpoch === lifecycleEpoch)
     return applyStartResult(name, currentCfg, result, previousFailure) ? 'restarted' : 'recovery-pending'
+  }
+
+  const scheduleRestartAfterDeferredStop = (name: AdapterId, completion: Promise<void>): void => {
+    if (deferredRestarts.has(name)) return
+    deferredRestarts.add(name)
+    void completion
+      .then(() =>
+        runSerially(name, async () => {
+          if (!running || deferredStops.has(name) || live.has(name)) return
+          const cfg = options.channelsConfigRef()[name]
+          if (cfg === undefined || cfg.enabled === false) return
+          const queuedEpoch = lifecycleEpoch
+          const result = await startAdapter(name, cfg, () => {
+            const latest = options.channelsConfigRef()[name]
+            return running && queuedEpoch === lifecycleEpoch && latest !== undefined && latest.enabled !== false
+          })
+          applyStartResult(name, cfg, result)
+        }),
+      )
+      .catch((err) => logger.error(`[channels] deferred restart for "${name}" failed: ${describeError(err)}`))
+      .finally(() => deferredRestarts.delete(name))
   }
 
   const superviseAdapters = (): void => {
@@ -759,6 +805,11 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
           }
           const stopped = await stopAdapter(name)
           if (!stopped || !running || queuedEpoch !== lifecycleEpoch) return
+          const deferredStop = deferredStops.get(name)
+          if (deferredStop !== undefined) {
+            scheduleRestartAfterDeferredStop(name, deferredStop)
+            return
+          }
           const latestCfg = options.channelsConfigRef()[name]
           if (latestCfg === undefined || latestCfg.enabled === false) return
           try {


### PR DESCRIPTION
## Background

The previous adapter passed `dropPendingUpdates: true` to `TelegramBotListener` on every `start()` call, and the SDK held its `getUpdates` offset only in memory with no way to seed it externally. So every restart — deploy, crash, `typeclaw restart` — began by discarding whatever Telegram had queued: any message that arrived while the process was down, or in the gap between the previous stop and this start, was dropped rather than delivered.

Fixes #1409.

## Summary

Replace the SDK listener with a TypeClaw-owned polling listener (`telegram-bot-listener.ts`) that persists its own `getUpdates` offset, since agent-messenger cannot seed one.

- **Bot-ID-scoped atomic cursor.** The cursor lives at `channels/telegram-bot/cursors/<botId>.json` under `agentDir`, keyed by bot ID so multiple bots never collide. Writes go to a temp file (`<path>.<pid>.<uuid>.tmp`) and `rename()` into place, so a crash mid-write never leaves a partially-written cursor.
- **One-time cold-start drop, ambiguous-backlog recovery.** On first-ever start (`state === null`), the listener writes an `initializing` marker, THEN calls `deleteWebhook({ drop_pending_updates: true })`, THEN writes `ready` with offset 0. If the process crashes between those steps, the next start finds `initializing` and treats it as ambiguous — it re-runs `deleteWebhook` with `drop_pending_updates: false` instead of dropping again, so a backlog that may or may not have already been cleared is never dropped twice.
- **Durable-checkpoint-first offset advance.** For each update, handlers are awaited to completion first. Only once the next offset is durably written to the cursor store does the in-memory offset advance — so a higher offset is only ever handed to Telegram's `getUpdates` after that update is checkpointed on disk. If the checkpoint write itself fails, the listener terminates and disconnects with the offset left unchanged, so the update replays after recovery instead of being silently acknowledged without a durable record.
- **Two-phase reentrant `/reload`.** A `/reload` command handler runs inside the same inbound dispatch it needs to stop, so it cannot await its own listener teardown. `stop()` detects this reentrant case and quiesces polling immediately — carrying the in-flight command's reply and its checkpoint write through to completion — then defers callback unregistration and listener replacement until that dispatch actually finishes. The channel manager waits on this completion before wiring in the replacement adapter, so a `/reload` can never race a still-finishing dispatch against the new listener starting up.
- **Abort-aware `getUpdates` race.** Each poll races `getUpdates` against an abort signal (timeout or `stop()`) rather than relying on the SDK call itself to cancel promptly — Telegram's own SDK can ignore the abort while sleeping through a 429 backoff. Both outcomes of the underlying promise are retained, so a late SDK resolution or rejection arriving after the race has already resolved is still consumed instead of becoming an unhandled rejection.
- **Truthful liveness and recovery.** `connected`/`disconnected` now reflect the real poll state instead of the SDK's own approximation: a poll failure emits `disconnected` and enters exponential backoff (1s up to 30s), and the next successful poll emits `connected` again. `unauthorized`/`conflict` errors from Telegram are treated as fatal and terminate the listener instead of retrying forever.

`telegram-bot.ts` and `channels/manager.ts` are updated to construct and thread the new listener (`agentDir` now flows into the adapter), and the previous try/catch-and-continue around `handleMessage` is removed since dispatch failures are now surfaced by the listener itself rather than swallowed at the call site.

## What this does NOT do

- Does not change the Telegram Bot API surface used (`deleteWebhook`, `getUpdates`) or the message-classification/routing logic downstream of dispatch.
- Does not add a maximum-retry limit to the reconnect backoff — non-fatal poll failures retry indefinitely with capped exponential delay, matching the previous SDK behavior.
- Does not migrate or read any cursor state the SDK itself may have held; there was none, since the SDK never persisted an offset.

## Review notes

The load-bearing invariant is the `initializing` → `ready` sequencing in `start()`: the marker must be written and durable *before* the destructive `drop_pending_updates: true` call, and recovery from `initializing` must never re-drop. Also verify the offset never advances ahead of its durable checkpoint, and that the `/reload` two-phase stop genuinely lets the in-flight dispatch finish and checkpoint before the listener is replaced.

## Verification

- `bun run lint` — clean
- `bun run format:check` — clean
- `bun run typecheck` — clean
- `bun run test` — 13,455 passed, 32 skipped
