### PR TITLE
Require a close-out on an addressed review thread

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -407,6 +407,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
               stream: options.stream,
               allowBackgroundFromSubagent: options.allowBackgroundFromSubagent,
               coalescer: options.subagentCoalescer,
+              channelRouter: options.channelRouter,
             }),
           ]
         : [
@@ -449,6 +450,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
               permissions: options.permissions,
               stream: options.stream,
               coalescer: options.subagentCoalescer,
+              channelRouter: options.channelRouter,
             }),
             ...buildRoleGrantTools({
               agentDir: options.plugins?.agentDir,
@@ -862,6 +864,7 @@ export function buildSubagentOrchestrationTools(opts: {
   stream: Stream | undefined
   allowBackgroundFromSubagent?: boolean
   coalescer?: SubagentCoalescer
+  channelRouter?: ChannelRouter
 }): ToolDefinition[] {
   if (
     opts.liveRegistry === undefined ||
@@ -896,6 +899,12 @@ export function buildSubagentOrchestrationTools(opts: {
       liveRegistry: opts.liveRegistry,
       getOrigin: opts.getOrigin,
       callerSessionId: opts.parentSessionId,
+      ...(opts.channelRouter !== undefined
+        ? {
+            hasOutstandingReviewThreadCloseout: (sessionId: string) =>
+              opts.channelRouter?.hasOutstandingGithubReviewThreadCloseout?.(sessionId) ?? false,
+          }
+        : {}),
       ...(opts.permissions ? { permissions: opts.permissions } : {}),
     }),
   ]

--- a/src/agent/tools/subagent-cancel.test.ts
+++ b/src/agent/tools/subagent-cancel.test.ts
@@ -74,6 +74,45 @@ describe('createSubagentCancelTool', () => {
     expect(abortCount).toBe(1)
   })
 
+  test('warns after cancelling the only running child while a review-thread closeout is outstanding', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive({ parentSessionId: 'ses_parent', background: true }))
+    const tool = createSubagentCancelTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      callerSessionId: 'ses_parent',
+      hasOutstandingReviewThreadCloseout: () => true,
+    })
+
+    const result = await tool.execute('call_1', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const text = result.content.map((part) => (part.type === 'text' ? part.text : '')).join('')
+
+    expect(result.details).toMatchObject({ ok: true, alreadyDone: false })
+    expect(text).toContain('cancellation requested')
+    expect(text).toContain('still owes its GitHub review thread a close-out')
+    expect(text).toContain('leaving the thread open')
+  })
+
+  test('cancels without the closeout warning when another running child remains', async () => {
+    const liveRegistry = new LiveSubagentRegistry()
+    liveRegistry.register(makeLive({ parentSessionId: 'ses_parent', background: true }))
+    liveRegistry.register(
+      makeLive({ taskId: 'bg_c2', sessionId: 'ses_s2', parentSessionId: 'ses_parent', background: true }),
+    )
+    const tool = createSubagentCancelTool({
+      liveRegistry,
+      getOrigin: () => undefined,
+      callerSessionId: 'ses_parent',
+      hasOutstandingReviewThreadCloseout: () => true,
+    })
+
+    const result = await tool.execute('call_1', { task_id: 'bg_c1' }, undefined, undefined, ctx)
+    const text = result.content.map((part) => (part.type === 'text' ? part.text : '')).join('')
+
+    expect(result.details).toMatchObject({ ok: true, alreadyDone: false })
+    expect(text).not.toContain('still owes')
+  })
+
   test('already-completed task → ok=true with alreadyDone=true, no abort call', async () => {
     const liveRegistry = new LiveSubagentRegistry()
     let abortCount = 0

--- a/src/agent/tools/subagent-cancel.ts
+++ b/src/agent/tools/subagent-cancel.ts
@@ -16,10 +16,11 @@ export type CreateSubagentCancelToolOptions = {
   getOrigin: () => SessionOrigin | undefined
   permissions?: PermissionService
   callerSessionId?: string
+  hasOutstandingReviewThreadCloseout?: (sessionId: string) => boolean
 }
 
 export function createSubagentCancelTool(options: CreateSubagentCancelToolOptions) {
-  const { liveRegistry, getOrigin, permissions, callerSessionId } = options
+  const { liveRegistry, getOrigin, permissions, callerSessionId, hasOutstandingReviewThreadCloseout } = options
 
   return defineTool({
     name: 'subagent_cancel',
@@ -71,6 +72,17 @@ export function createSubagentCancelTool(options: CreateSubagentCancelToolOption
         return errorResult(`abort failed: ${message}`)
       }
       live.releaseCoalesceKey?.()
+      const owesReviewThreadCloseout =
+        callerSessionId !== undefined && hasOutstandingReviewThreadCloseout?.(callerSessionId) === true
+      const hasOtherRunningChild =
+        callerSessionId !== undefined &&
+        liveRegistry
+          .list({ parentSessionId: callerSessionId })
+          .some((candidate) => candidate.taskId !== live.taskId && candidate.status === 'running')
+      const closeoutWarning =
+        owesReviewThreadCloseout && !hasOtherRunningChild
+          ? ' Warning: cancellation succeeded, but this session still owes its GitHub review thread a close-out. Reply now with an explicit resolve choice, or explain why you are leaving the thread open.'
+          : ''
       const details: SubagentCancelToolDetails = {
         ok: true,
         taskId: live.taskId,
@@ -81,7 +93,7 @@ export function createSubagentCancelTool(options: CreateSubagentCancelToolOption
         content: [
           {
             type: 'text' as const,
-            text: `${live.subagentName} (${live.taskId}) cancellation requested. It will stop on the next abort checkpoint.`,
+            text: `${live.subagentName} (${live.taskId}) cancellation requested. It will stop on the next abort checkpoint.${closeoutWarning}`,
           },
         ],
         details,

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -52,6 +52,11 @@ describe('classifyGithubInbound', () => {
       expect(msg?.replyToBotMessageId).toBe('101')
       expect(msg?.replyToOtherMessageId).toBe(null)
       expect(msg?.suppressSticky).toBe(true)
+      expect(msg?.githubReviewThreadCloseout).toEqual({
+        workspace: 'acme/project',
+        prNumber: 7,
+        rootCommentId: '101',
+      })
     })
 
     it('marks a reply to someone else review comment as explicit-only and reply-to-other', () => {
@@ -61,6 +66,20 @@ describe('classifyGithubInbound', () => {
       expect(msg?.replyToBotMessageId).toBe(null)
       expect(msg?.replyToOtherMessageId).toBe('101')
       expect(msg?.suppressSticky).toBe(true)
+      expect(msg?.githubReviewThreadCloseout).toBeUndefined()
+    })
+
+    it('does not stamp a closeout obligation on a peer-bot reply to the bot review comment', () => {
+      const payload = reviewCommentPayload()
+      ;(payload.comment as Record<string, unknown>).user = { login: 'peer-bot', id: 20, type: 'Bot' }
+
+      const msg = classifyGithubInbound('pull_request_review_comment', payload, 'typeclaw-bot', {
+        reviewCommentParent: { isSelf: true, parentId: 101 },
+      })
+
+      expect(msg?.authorIsBot).toBe(true)
+      expect(msg?.replyToBotMessageId).toBe('101')
+      expect(msg?.githubReviewThreadCloseout).toBeUndefined()
     })
 
     it('marks a top-level review comment as explicit-only without reply fields', () => {
@@ -73,6 +92,7 @@ describe('classifyGithubInbound', () => {
       expect(msg?.replyToBotMessageId).toBe(null)
       expect(msg?.replyToOtherMessageId).toBe(null)
       expect(msg?.suppressSticky).toBe(true)
+      expect(msg?.githubReviewThreadCloseout).toBeUndefined()
     })
 
     it('preserves @mention detection on explicit-only review comments', () => {
@@ -1165,6 +1185,11 @@ describe('createGithubWebhookHandler — review comment parent lookup', () => {
     expect(routed[0]?.replyToBotMessageId).toBe('101')
     expect(routed[0]?.replyToOtherMessageId).toBe(null)
     expect(routed[0]?.suppressSticky).toBe(true)
+    expect(routed[0]?.githubReviewThreadCloseout).toEqual({
+      workspace: 'acme/project',
+      prNumber: 7,
+      rootCommentId: '101',
+    })
   })
 
   it('routes review-comment replies to other authors with replyToOtherMessageId', async () => {
@@ -1177,6 +1202,7 @@ describe('createGithubWebhookHandler — review comment parent lookup', () => {
     expect(routed[0]?.replyToBotMessageId).toBe(null)
     expect(routed[0]?.replyToOtherMessageId).toBe('101')
     expect(routed[0]?.suppressSticky).toBe(true)
+    expect(routed[0]?.githubReviewThreadCloseout).toBeUndefined()
   })
 })
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -2,7 +2,7 @@ import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto'
 
 import { registerOrJoinReplyReviewRound } from '@/channels/github-review-verdict-coordinator'
 import type { GithubReviewOn } from '@/channels/schema'
-import type { GithubReviewFollowupRound, InboundMessage } from '@/channels/types'
+import type { GithubReviewFollowupRound, GithubReviewThreadCloseout, InboundMessage } from '@/channels/types'
 
 import { describeError } from '../../describe-error'
 import type { GithubAuthContext } from './auth'
@@ -572,6 +572,10 @@ export function classifyGithubInbound(
     const parent =
       parentId !== null && options?.reviewCommentParent?.parentId === parentId ? options.reviewCommentParent : null
     const commenter = readUser(comment.user)
+    const githubReviewThreadCloseout: GithubReviewThreadCloseout | undefined =
+      parent?.isSelf === true && commenter !== null && !isBotUser(commenter)
+        ? { workspace: base.workspace, prNumber: number, rootCommentId: String(root) }
+        : undefined
     const directedAtBot =
       parentId === null &&
       isSelfPr(readUser(pr.user), selfLogin, options?.authType ?? 'pat') &&
@@ -591,6 +595,7 @@ export function classifyGithubInbound(
         ...(directedAtBot ? { forceBotMention: true } : {}),
         replyToBotMessageId: parent?.isSelf === true ? String(parent.parentId) : null,
         replyToOtherMessageId: parent?.isSelf === false ? String(parent.parentId) : null,
+        ...(githubReviewThreadCloseout !== undefined ? { githubReviewThreadCloseout } : {}),
       },
     )
   }
@@ -785,6 +790,7 @@ type BuildInboundOptions = {
   suppressSticky?: boolean
   replyToBotMessageId?: string | null
   replyToOtherMessageId?: string | null
+  githubReviewThreadCloseout?: GithubReviewThreadCloseout
   // Forces isBotMention=true with no @-handle in the body. A review (or
   // top-level review comment) on a PR the agent ITSELF authored is directed at
   // the bot — the inverse of review_requested — so it engages even though the
@@ -1009,9 +1015,12 @@ function buildInbound(
     ...(reactionTarget !== null ? { reactionRef: encodeGithubReactionRef(reactionTarget) } : {}),
     authorId: String(user.id),
     authorName: user.login,
-    authorIsBot: user.type === 'Bot',
+    authorIsBot: isBotUser(user),
     isBotMention,
     ...(options?.suppressSticky === true ? { suppressSticky: true } : {}),
+    ...(options?.githubReviewThreadCloseout !== undefined
+      ? { githubReviewThreadCloseout: options.githubReviewThreadCloseout }
+      : {}),
     replyToBotMessageId,
     replyToOtherMessageId,
     ts: typeof rawTs === 'string' ? Date.parse(rawTs) || 0 : 0,
@@ -1240,6 +1249,10 @@ function isSelfAuthor(author: GithubUser, selfId: string | null, selfLogin: stri
   if (selfId !== null && String(author.id) === selfId) return true
   if (selfLogin !== null && author.login === selfLogin) return true
   return false
+}
+
+function isBotUser(user: GithubUser): boolean {
+  return user.type === 'Bot'
 }
 
 // Whether the PR's OPENER is this agent. Distinct from isSelfAuthor (which

--- a/src/channels/github-verdict-activity.test.ts
+++ b/src/channels/github-verdict-activity.test.ts
@@ -84,8 +84,9 @@ describe('renderPrVerdictStandDownReminder', () => {
     expect(text).toContain('<system-reminder>')
     expect(text).toContain('#42')
     expect(text).toContain('APPROVE')
-    // verdict-only carve-out: thread replies are still allowed
-    expect(text.toLowerCase()).toContain('inline')
+    expect(text).toContain('ONLY to formal PR-level verdicts')
+    expect(text).toContain("does NOT discharge this session's inline review-thread close-out")
+    expect(text).toContain('reply to the inline thread')
     // soft wording: a genuine new-evidence verdict is not suppressed
     expect(text.toLowerCase()).toContain('unless new information')
   })

--- a/src/channels/github-verdict-activity.ts
+++ b/src/channels/github-verdict-activity.ts
@@ -61,9 +61,11 @@ export function renderPrVerdictStandDownReminder(args: { prNumber: number; verdi
   return (
     `<system-reminder>\n` +
     `Another session in this agent has already posted a formal ${args.verdict} review for PR #${args.prNumber}. ` +
-    `Do not submit your own ${args.verdict} (or any redundant verdict) for this PR this turn unless new ` +
+    `This notice applies ONLY to formal PR-level verdicts. Do not submit your own ${args.verdict} (or any redundant ` +
+    `verdict) for this PR this turn unless new ` +
     `information genuinely invalidates that result (e.g. new commits, or a different verdict warranted by ` +
-    `fresh evidence). You may still reply to inline review comments / threads as normal.\n` +
+    `fresh evidence). It does NOT discharge this session's inline review-thread close-out: you must still reply to ` +
+    `the inline thread as normal, resolving it if addressed or leaving it open with an explanation.\n` +
     `</system-reminder>`
   )
 }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -68,6 +68,7 @@ import {
   EMPTY_STOP_AFTER_TOOL_WORK_NUDGE,
   EMPTY_TURN_FALLBACK_TEXT,
   EMPTY_TURN_RETRY_NUDGE,
+  GITHUB_REVIEW_THREAD_CLOSEOUT_FALLBACK_TEXT,
   extractPlainTextChannelToolCallText,
   getPlainTextChannelToolCallKind,
   stripTrailingLeakedToolCall,
@@ -3539,7 +3540,7 @@ describe('ChannelRouter reaction cleanup on deliberate silence', () => {
   test('skip_response leaves no :eyes: on the triggering message', async () => {
     const dir = await tempDir()
     const { router, sessions, captured } = await setupSilentTurn(dir)
-    sessions[0]!.onPrompt = () => {
+    sessions[0]!.onPrompt = async () => {
       router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing to add' })
       sessions[0]!.setAssistantText('Nothing actionable here.')
     }
@@ -3551,7 +3552,7 @@ describe('ChannelRouter reaction cleanup on deliberate silence', () => {
   test('an explicit NO_REPLY leaves no :eyes: on the triggering message', async () => {
     const dir = await tempDir()
     const { router, sessions, captured } = await setupSilentTurn(dir)
-    sessions[0]!.onPrompt = () => {
+    sessions[0]!.onPrompt = async () => {
       sessions[0]!.setAssistantText('NO_REPLY')
     }
     await router.__testing!.flushDebounce(KEY)
@@ -18828,5 +18829,320 @@ describe('ChannelRouter background-child await suppression', () => {
 
     expect(continuationRuns).toBe(0)
     expect(logs.some((m) => m.includes('skipping todo continuation while background child runs'))).toBe(true)
+  })
+})
+
+describe('ChannelRouter GitHub review-thread closeout obligation', () => {
+  const GITHUB_KEY: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:123', thread: '456' }
+  const closeoutInbound = (over: Partial<InboundMessage> = {}): InboundMessage =>
+    inbound({
+      ...GITHUB_KEY,
+      externalMessageId: '789',
+      text: 'I pushed the requested fix.',
+      replyToBotMessageId: '456',
+      githubReviewThreadCloseout: { workspace: 'acme/repo', prNumber: 123, rootCommentId: '456' },
+      ...over,
+    })
+
+  test('queues one correction for a skip with no running child, then posts one open-thread fallback', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+
+    await router.route(closeoutInbound())
+    sessions[0]!.onPrompt = () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'stand down' })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain('PR #123')
+    expect(sessions[0]!.prompts[1]).toContain('root comment 456')
+    expect(sessions[0]!.prompts[1]).toContain('resolve_review_thread')
+    expect(logs.filter((line) => line.includes('github_thread_closeout_retry'))).toHaveLength(1)
+    expect(sent.map((message) => message.text)).toEqual([GITHUB_REVIEW_THREAD_CLOSEOUT_FALLBACK_TEXT])
+    expect(sent[0]?.thread).toBe('456')
+    expect(sessions[0]!.prompts).toHaveLength(2)
+  })
+
+  test('honors a skip while a child started after the obligation is still running', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir, {
+      logs,
+      newestRunningChildSubagentStartedAt: () => 1000,
+    })
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+
+    await router.route(closeoutInbound())
+    sessions[0]!.onPrompt = () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'waiting for reviewer' })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toHaveLength(0)
+    expect(logs.some((line) => line.includes('github_thread_closeout_retry'))).toBe(false)
+    expect(logs.some((line) => line.includes('skipped_by_tool'))).toBe(true)
+  })
+
+  test('a completed or cancelled child does not defer the closeout correction', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir, { newestRunningChildSubagentStartedAt: () => null })
+    router.registerOutbound('github', async () => ({ ok: true }))
+
+    await router.route(closeoutInbound())
+    sessions[0]!.onPrompt = async () => {
+      if (sessions[0]!.prompts.length === 1) {
+        router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'child cancelled' })
+      } else {
+        await router.send({ ...GITHUB_KEY, text: 'This still needs manual review.' })
+      }
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain('resolve_review_thread')
+  })
+
+  test('a running child from before the obligation does not defer it', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir, { newestRunningChildSubagentStartedAt: () => 999 })
+    router.registerOutbound('github', async () => ({ ok: true }))
+
+    await router.route(closeoutInbound())
+    sessions[0]!.onPrompt = async () => {
+      if (sessions[0]!.prompts.length === 1) {
+        router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'old child still running' })
+      } else {
+        await router.send({ ...GITHUB_KEY, text: 'This remains open pending manual review.' })
+      }
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+  })
+
+  test('intercepts NO_REPLY without a skip tool and preserves the obligation across the reminder-only retry', async () => {
+    const dir = await tempDir()
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+
+    await router.route(closeoutInbound())
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain('root comment 456')
+    expect(sent.map((message) => message.text)).toEqual([GITHUB_REVIEW_THREAD_CLOSEOUT_FALLBACK_TEXT])
+  })
+
+  for (const resolveReviewThread of [true, false]) {
+    test(`an exact-thread channel_reply with resolve_review_thread:${resolveReviewThread} clears the obligation`, async () => {
+      const dir = await tempDir()
+      const logs: string[] = []
+      const sent: OutboundMessage[] = []
+      const { router, sessions } = makeRouter(dir, { logs })
+      router.registerOutbound('github', async (message) => {
+        sent.push(message)
+        return { ok: true }
+      })
+      router.registerReviewStateResolver('github', async () => ({
+        ok: true,
+        selfBlocking: false,
+        selfBlockingReviewId: null,
+        approve: true,
+      }))
+      router.registerReviewThreadResolver('github', async () => ({ ok: true }))
+      const reply = createChannelReplyTool({ router, origin: GITHUB_KEY, sessionId: 'ses_fake_1' })
+
+      await router.route(closeoutInbound())
+      sessions[0]!.onPrompt = async () => {
+        const result = await reply.execute(
+          'reply-call',
+          {
+            text: resolveReviewThread
+              ? 'Verified the change; this concern is addressed.'
+              : 'This concern remains open.',
+            more_work_this_turn: false,
+            resolve_review_thread: resolveReviewThread,
+          },
+          undefined,
+          undefined,
+          {} as Parameters<typeof reply.execute>[4],
+        )
+        expect(result.details).toMatchObject({ ok: true })
+        router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'done' })
+      }
+      await router.__testing!.flushDebounce(GITHUB_KEY)
+
+      expect(sent).toHaveLength(1)
+      expect(logs.some((line) => line.includes('github_thread_closeout_retry'))).toBe(false)
+      expect(router.hasOutstandingGithubReviewThreadCloseout?.('ses_fake_1') ?? false).toBe(false)
+    })
+  }
+
+  test('leaves non-GitHub, top-level GitHub, and human-rooted review traffic unchanged', async () => {
+    const dir = await tempDir()
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+
+    const cases = [
+      { key: KEY, message: inbound({ text: 'ordinary skip' }) },
+      {
+        key: { ...GITHUB_KEY, thread: null },
+        message: closeoutInbound({
+          thread: null,
+          githubReviewThreadCloseout: undefined,
+          externalMessageId: 'top-level',
+        }),
+      },
+      {
+        key: GITHUB_KEY,
+        message: closeoutInbound({ githubReviewThreadCloseout: undefined, externalMessageId: 'human-root' }),
+      },
+    ] as const
+
+    for (const [index, item] of cases.entries()) {
+      await router.route(item.message)
+      const session = sessions[index]!
+      session.onPrompt = () => {
+        router.markTurnSkipped({ parentSessionId: `ses_fake_${index + 1}`, reason: 'ordinary skip' })
+        session.setAssistantText('NO_REPLY')
+      }
+      await router.__testing!.flushDebounce(item.key)
+    }
+
+    expect(sent).toHaveLength(0)
+    expect(sessions.map((session) => session.prompts.length)).toEqual([1, 1, 1])
+  })
+
+  test('a post-send skip remains recorded-after-send and does not queue a correction', async () => {
+    const dir = await tempDir()
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+    let skipKind = ''
+
+    await router.route(closeoutInbound())
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ ...GITHUB_KEY, text: 'This remains open pending another change.' })
+      skipKind = router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'done' }).kind
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(skipKind).toBe('recorded-after-send')
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toHaveLength(1)
+  })
+
+  test('a peer-bot review-thread reply can stay silent when loop protection applies', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+
+    for (let index = 0; index < 5; index++) {
+      await router.route(
+        closeoutInbound({
+          externalMessageId: `peer-${index}`,
+          authorId: `peer-bot-${index}`,
+          authorName: `peer-bot-${index}`,
+          authorIsBot: true,
+          githubReviewThreadCloseout: undefined,
+        }),
+      )
+      sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+      await router.__testing!.flushDebounce(GITHUB_KEY)
+    }
+
+    expect(sessions[0]!.prompts.at(-1)).toContain('Peer bots have engaged you')
+    expect(sent).toHaveLength(0)
+    expect(logs.some((line) => line.includes('github_thread_closeout_retry'))).toBe(false)
+    expect(logs.some((line) => line.includes('github_thread_closeout_fallback'))).toBe(false)
+  })
+
+  test('a hard prompt throw after tool execution still runs the bounded closeout ladder', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+
+    await router.route(closeoutInbound())
+    sessions[0]!.prompt = async (text) => {
+      sessions[0]!.prompts.push(text)
+      sessions[0]!.emit({ type: 'tool_execution_start', toolCallId: 'call-1', toolName: 'read', args: {} })
+      throw new Error('internal prompt failure')
+    }
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain('resolve_review_thread')
+    expect(logs.filter((line) => line.includes('github_thread_closeout_retry'))).toHaveLength(1)
+    expect(sent.map((message) => message.text)).toEqual([GITHUB_REVIEW_THREAD_CLOSEOUT_FALLBACK_TEXT])
+    expect(sent[0]?.thread).toBe('456')
+  })
+
+  test('a landed provider notice satisfies the send baseline without a second closeout post', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: OutboundMessage[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('github', async (message) => {
+      sent.push(message)
+      return { ok: true }
+    })
+
+    await router.route(closeoutInbound())
+    sessions[0]!.prompt = async (text) => {
+      sessions[0]!.prompts.push(text)
+      throw new Error('429 rate limit exceeded')
+    }
+    await router.__testing!.flushDebounce(GITHUB_KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]?.thread).toBe('456')
+    expect(sent[0]?.text).toContain('rate-limited')
+    expect(sent[0]?.text).not.toBe(GITHUB_REVIEW_THREAD_CLOSEOUT_FALLBACK_TEXT)
+    expect(logs.some((line) => line.includes('github_thread_closeout_retry'))).toBe(false)
+    expect(logs.some((line) => line.includes('github_thread_closeout_fallback'))).toBe(false)
   })
 })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -114,6 +114,7 @@ import type {
   HistoryCallback,
   InboundAttachment,
   GithubReviewFollowupRound,
+  GithubReviewThreadCloseout,
   InboundMessage,
   InboundReferenceContext,
   ListCallback,
@@ -419,6 +420,8 @@ export const STRANDED_TOOLUSE_CONTINUATION_NUDGE = [
 // drop so the human is never left staring at dead air after a degenerate turn.
 export const EMPTY_TURN_FALLBACK_TEXT =
   "⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?"
+export const GITHUB_REVIEW_THREAD_CLOSEOUT_FALLBACK_TEXT =
+  "I wasn't able to complete this follow-up. Leaving this thread open for manual review."
 // Distinct from EMPTY_TURN_RETRY_NUDGE: that one diagnoses budget exhaustion
 // ("ran out of output budget"), which is FALSE for a clean `stop` with empty
 // text. This nudge names the real failure — a turn that ended sending nothing
@@ -770,6 +773,7 @@ type QueuedInbound = {
   // prefix for those).
   ts: number
   githubReviewRound?: GithubReviewFollowupRound
+  githubReviewThreadCloseout?: GithubReviewThreadCloseout
 }
 
 type ObservedInbound = {
@@ -878,6 +882,15 @@ type LiveSession = {
   resolvedNames: ResolvedChannelNames
   originRef: { current: SessionOrigin | undefined }
   githubReviewRound: GithubReviewFollowupRound | null
+  // A real-user reply to one of this agent's own review-thread roots must end
+  // with a reply on that exact thread. This spans reminder-only retry iterations.
+  githubReviewThreadCloseout:
+    | (GithubReviewThreadCloseout & {
+        sendCountAtStart: number
+        startedAt: number
+        correctionAttempts: number
+      })
+    | null
   // Round key of a close-out that arrived while the round was still pending
   // completion. Replayed once the round completes; see replayPendingRoundCloseouts.
   pendingGithubReviewRoundCloseout: string | null
@@ -1584,6 +1597,7 @@ export type ChannelRouter = {
     prNumber: number
     state: ReviewOutputState
   }) => { kind: 'stamped' | 'no-live-session' }
+  hasOutstandingGithubReviewThreadCloseout?: (sessionId: string) => boolean
   // Record that the agent invoked `skip_response` during the current turn
   // for the channel session identified by `parentSessionId`. The reason is
   // logged at INFO level inside `validateChannelTurn` (single log line per
@@ -2217,9 +2231,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // still run. Session scope would let one long-running child silence every
   // subsequent turn, and a wedged child would strand them with nothing to revisit
   // them after the backstop expires.
-  const isAwaitingBackgroundChild = (live: LiveSession, label: string): boolean => {
+  const isAwaitingBackgroundChild = (
+    live: LiveSession,
+    label: string,
+    startedAt = live.logicalTurnStartedAt,
+  ): boolean => {
     const childStartedAt = newestRunningChildSubagentStartedAt(live.sessionId)
-    if (childStartedAt === null || childStartedAt < live.logicalTurnStartedAt) return false
+    if (childStartedAt === null || childStartedAt < startedAt) return false
     return isPinnedByRunningChild(live.sessionId, live.keyId, label)
   }
 
@@ -2660,6 +2678,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         resolvedNames,
         originRef,
         githubReviewRound: restoredRound,
+        githubReviewThreadCloseout: null,
         pendingGithubReviewRoundCloseout: null,
         promptQueue: [],
         pendingSystemReminders: [],
@@ -3393,6 +3412,59 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  const postGithubReviewThreadCloseoutFallback = async (live: LiveSession): Promise<void> => {
+    const obligation = live.githubReviewThreadCloseout
+    if (obligation === null) return
+    // Consume before sending so adapter failure cannot turn this one-shot
+    // fallback into a reminder/fallback loop.
+    live.githubReviewThreadCloseout = null
+    logger.warn(
+      `[channels] ${live.keyId} github_thread_closeout_fallback pr=${obligation.prNumber} root=${obligation.rootCommentId}`,
+    )
+    const result = await send(
+      {
+        adapter: 'github',
+        workspace: obligation.workspace,
+        chat: `pr:${obligation.prNumber}`,
+        thread: obligation.rootCommentId,
+        text: GITHUB_REVIEW_THREAD_CLOSEOUT_FALLBACK_TEXT,
+      },
+      { source: 'system', outputKind: 'meta' },
+    )
+    if (!result.ok) {
+      logger.warn(`[channels] ${live.keyId}: github review-thread closeout fallback send failed: ${result.error}`)
+    }
+  }
+
+  const enforceGithubReviewThreadCloseout = async (live: LiveSession): Promise<void> => {
+    const closeout = live.githubReviewThreadCloseout
+    if (
+      closeout === null ||
+      live.successfulChannelSends !== closeout.sendCountAtStart ||
+      isAwaitingBackgroundChild(live, 'github-thread-closeout', closeout.startedAt)
+    ) {
+      return
+    }
+    if (live.skippedTurn?.turnSeq === live.turnSeq) live.skippedTurn = null
+    if (closeout.correctionAttempts === 0) {
+      closeout.correctionAttempts++
+      logger.warn(
+        `[channels] ${live.keyId} github_thread_closeout_retry attempt=1/1 pr=${closeout.prNumber} root=${closeout.rootCommentId}`,
+      )
+      live.pendingSystemReminders.push(
+        retryReminder(
+          `<system-reminder>\nThis session still owes a close-out on GitHub PR #${closeout.prNumber}, ` +
+            `review thread root comment ${closeout.rootCommentId}. Your previous turn sent no reply to that thread. ` +
+            `Call channel_reply now with an explicit resolve_review_thread choice: true if the concern is addressed, ` +
+            `or false to leave it open with an explanation. Do not treat a PR-level verdict stand-down as satisfying ` +
+            `this thread-level obligation.\n</system-reminder>`,
+        ),
+      )
+      return
+    }
+    await postGithubReviewThreadCloseoutFallback(live)
+  }
+
   // Resolve a fallback STAGED by a willingness-ack exhaustion path, run AFTER
   // maybeContinueTodosChannel so the idle/todo continuation has already had its
   // chance to queue a re-prompt (the mechanism that self-recovers the promised
@@ -3849,6 +3921,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.emptyStopAfterToolWorkArmed = false
           live.willingnessNudges = 0
           live.logicalTurnStartedAt = now()
+          const stampedCloseout = batch.findLast((item) => item.githubReviewThreadCloseout !== undefined)
+          live.githubReviewThreadCloseout =
+            stampedCloseout?.githubReviewThreadCloseout !== undefined
+              ? {
+                  ...stampedCloseout.githubReviewThreadCloseout,
+                  sendCountAtStart: live.successfulChannelSends,
+                  startedAt: live.logicalTurnStartedAt,
+                  correctionAttempts: 0,
+                }
+              : null
           // A fresh batch supersedes a still-pending staged fallback. That staged
           // turn produced no usable reply, so it must not leave the PRIOR turn's
           // committed lastQuestionSignal behind — otherwise the new question would
@@ -4076,6 +4158,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             sentReplyThisTurn && !live.promisedWorkOutstandingThisLogicalTurn,
             retryQueuedThisTurn,
           )
+          // Provider notices own the first terminal output opportunity. A notice
+          // that lands on the owed thread clears the obligation through send();
+          // a suppressed or failed notice leaves it intact for this bounded net.
+          await enforceGithubReviewThreadCloseout(live)
           await fireSessionTurnEnd(live)
         }
         await fireSessionIdle(live)
@@ -4609,6 +4695,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       isDm: event.isDm,
       ...(event.typingThread !== undefined ? { typingThread: event.typingThread } : {}),
       ...(event.githubReviewRound !== undefined ? { githubReviewRound: event.githubReviewRound } : {}),
+      ...(event.githubReviewThreadCloseout !== undefined
+        ? { githubReviewThreadCloseout: event.githubReviewThreadCloseout }
+        : {}),
       receivedAt: now(),
       ts: event.ts,
     })
@@ -5459,6 +5548,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     if (live) {
       live.successfulChannelSends++
+      const closeout = live.githubReviewThreadCloseout
+      if (closeout !== null) {
+        const landedOnOwedThread =
+          msg.adapter === 'github' &&
+          msg.workspace === closeout.workspace &&
+          msg.chat === `pr:${closeout.prNumber}` &&
+          (msg.thread ?? null) === closeout.rootCommentId
+        if (landedOnOwedThread) {
+          live.githubReviewThreadCloseout = null
+        } else {
+          // successfulChannelSends is session-wide. Advance the baseline for an
+          // unrelated delivery so equality continues to mean no owed-thread send.
+          closeout.sendCountAtStart++
+        }
+      }
       // Promise fulfillment follows OUTPUT KIND, never source:
       //   (a) ordinary substantive tool output clears;
       //   (b) multilingual continuation-willingness/status output preserves;
@@ -6910,6 +7014,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         candidate.key.chat === chat &&
         candidate.key.thread === args.thread,
     )
+    if (live !== undefined) live.githubReviewThreadCloseout = null
     if (live?.githubReviewRound === null || live?.githubReviewRound === undefined) return
     const round = live.githubReviewRound
     if (!isGithubReviewRoundComplete(round)) {
@@ -6984,6 +7089,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return { kind: 'recorded', keyId: live.keyId }
     }
     return { kind: 'no-live-session' }
+  }
+
+  const hasOutstandingGithubReviewThreadCloseout = (sessionId: string): boolean => {
+    for (const live of liveSessions.values()) {
+      if (live.destroyed || live.sessionId !== sessionId) continue
+      const obligation = live.githubReviewThreadCloseout
+      return obligation !== null && live.successfulChannelSends === obligation.sendCountAtStart
+    }
+    return false
   }
 
   const clearSticky = (key: ChannelKey): { keyId: string; cleared: number } => {
@@ -7227,6 +7341,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     completeGithubReviewRound: completeRoundForVerifiedVerdict,
     finishGithubReviewRoundCloseout,
     noteGithubReviewOutput,
+    hasOutstandingGithubReviewThreadCloseout,
     markTurnSkipped,
     clearSticky,
     reserveRestartHandoff,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -55,12 +55,22 @@ export type GithubReviewFollowupRound = {
   carrierThread: string | null
 }
 
+export type GithubReviewThreadCloseout = {
+  workspace: string
+  prNumber: number
+  rootCommentId: string
+}
+
 export type InboundMessage = {
   adapter: AdapterId
   workspace: string
   chat: string
   thread: string | null
   githubReviewRound?: GithubReviewFollowupRound
+  // Adapter-authoritative obligation created only for a non-self reply whose
+  // review-thread ROOT comment was authored by this agent. Kept separate from
+  // replyToBotMessageId, which describes only the immediate parent.
+  githubReviewThreadCloseout?: GithubReviewThreadCloseout
   // Structural "this message lives in a thread room" signal, kept SEPARATE
   // from `thread`. `thread` is a reply-routing field whose meaning differs per
   // platform: Slack puts the thread ts here (so `thread !== null` ⇒ thread


### PR DESCRIPTION
A GitHub review-thread session can end its turn having neither replied to nor resolved the thread it was created for, and nothing ever retries it. The thread stays open forever with the human's reply as the last word.

## What happened

A PR had four inline review threads from the bot's own `CHANGES_REQUESTED`. The author answered all four at once, so four sibling sessions woke up — one per thread. Three replied with `channel_reply({ resolve_review_thread: true })` and resolved. The fourth did this:

1. `spawn_subagent(reviewer)` → `skip_response("waiting for the re-review")` — correct, a child was running
2. received the PR-level verdict stand-down reminder ("another session already posted a formal APPROVE…")
3. `subagent_cancel` on its own reviewer — destroying the only evidence it had
4. `skip_response` — no child running anymore
5. `subagent_output` → "completed with no final message"
6. `skip_response` → turn over, thread orphaned

It read a **PR-level** verdict stand-down as discharging its **thread-level** reply duty. Its three siblings got the same reminder and replied anyway, so nothing structural stopped this — the guard surface simply allowed it.

## Why the existing guards missed it

The required `resolve_review_thread` choice, the false-receipt guard, and the re-review guard all live inside `channel_reply` / `channel_send`. They only fire *if the model calls one of them*. Every terminal exit — `skip_response`, `NO_REPLY`, an empty completion, provider termination — walks past all of them.

So the missing piece is not a tool guard. It is a turn-completion invariant:

> a human reply to a thread we rooted must end in either a reply on that exact thread, or a deferral the runtime can actually verify.

"Verify" is the load-bearing word. The failing session's first skip was legitimate and its later ones were not, and the reason strings ("waiting for the re-review" vs "approval already posted") are not what separates them — a running child is.

## The invariant

The adapter stamps the obligation where it already knows the thread root is self-authored, rather than having the router re-derive it from GitHub traffic later. `replyToBotMessageId` was not reusable here: it tracks the immediate parent, not the thread root.

```
owesCloseout = obligation set
               AND no send has landed on {workspace, PR, rootCommentId} since it began
mayDefer     = a background child spawned for this obligation is still running
```

`isAwaitingBackgroundChild` already encoded "silence is fine, a child is running" for `armRetainedOutputAckIfEligible`, so it is reused with an explicit start time instead of growing a parallel predicate. Existing callers keep the old default and are behaviorally unchanged.

The ladder is bounded at one correction and one fallback:

| state | outcome |
| --- | --- |
| `owesCloseout && mayDefer` | honor the skip (step 1 above keeps working) |
| `owesCloseout && !mayDefer`, first time | one reminder naming the PR and root comment; ask for an explicit resolve choice |
| `owesCloseout && !mayDefer`, after that | one truthful fallback, thread left **open**, turn ends |

Boundedness is deliberate. `skip-response.ts` documents a livelock where denying a skip drove the model to re-send, get re-denied, and repeat to the turn cap. The obligation is consumed before the fallback send, so adapter failure cannot re-enter the ladder.

Enforcement sits at turn completion rather than inside `skip_response`, which is why `NO_REPLY` is covered by the same code path — there is a test for it.

**The runtime never resolves a thread on the model's behalf.** Only the model may assert a concern is addressed; the fallback says it could not finish and leaves the thread open for a human. Auto-resolving something the runtime cannot semantically verify would be the worse failure.

## Guard accounting

Per `AGENTS.md`, for each control — the threat, and the authorized workflow that has to survive it:

- **Turn-completion invariant.** Stops: silent termination of an addressed self-rooted review thread. Preserves: waiting on a live child, `resolve_review_thread: false` replies that intentionally leave a thread open, non-GitHub silence, top-level PR comments, human-rooted threads, post-send skips. Scoped to one session, one logical obligation, one root comment. Recovery is in-band — one prompt, then a visible fallback, never a repeated denial.
- **`subagent_cancel` warning.** Stops: silently destroying the only in-flight evidence. Preserves: every cancellation, including runaway children and changed user intent. It is a warning on a *successful* cancel, never a block.
- **Stand-down wording.** Stops: reading a PR-level verdict notice as thread-level. Preserves: genuinely flipped verdicts.

No config flag and no model-facing switch turns any of this off.

## Tests

Both directions for every control:

- one correction on the first unmet skip; exactly one fallback on the second, then termination
- `NO_REPLY` with no skip tool intercepts identically, and the obligation survives the reminder-only retry
- a child started after the obligation defers; one started before it does not; a completed or cancelled child does not
- exact-thread `channel_reply` clears the obligation for `resolve_review_thread` **both** `true` and `false`
- non-GitHub, top-level GitHub, and human-rooted review traffic unchanged
- post-send skip still returns `recorded-after-send` with no correction
- `subagent_cancel` warns only when it leaves the obligation with no other running child, and cancels successfully in both cases

`bun run lint`, `format:check`, `typecheck` clean; full suite 13411 pass / 0 fail.

## Not in this PR

This fixes the live session. It does not add the durable floor: an orphaned thread created by a crash, a provider failure, or an older build still needs a reconciliation sweep. `listUnresolvedSelfReviewThreads` already exists but is only wired to the post-push `pull_request.synchronize` path, so a thread orphaned without a subsequent push is never revisited — which is exactly what happened here. That sweep needs a `comments(last:1)` query extension, a reservation to avoid racing a live session, and bounded retries, so it belongs in its own PR. Filed as a follow-up.
