### PR TITLE
Recover missed Discord messages after reconnects

### DIFF
--- a/docs/content/docs/reference/discord.mdx
+++ b/docs/content/docs/reference/discord.mdx
@@ -86,6 +86,14 @@ Discord chats fall into two internal workspace shapes:
 
 In role match rules, DMs are addressed by the canonical `dm` **bucket** scope, not the internal `@dm` workspace value: `discord:*` for everything, `discord:dm/*` for any DM, `discord:<guildId>` for one server, or `discord:<guildId>/<channelId>` for a concrete server channel. A concrete parent-channel scope also covers its resolved child threads; a scope naming a thread ID remains exact. See the [match-rule DSL](/docs/reference/match-rule-dsl).
 
+## Reconnect recovery
+
+The adapter keeps durable, account-scoped cursors for each channel and uses them to replay messages after a gateway reconnect or TypeClaw restart. Each recovery pass is bounded to 50 messages per channel, messages from the last 30 minutes, 20 channels, 100 messages total, and 20 seconds. Capped or unavailable recovery outcomes are written to the operator logs.
+
+These cursors live in the gitignored, local runtime state file `channels/discord-recovery.json`. The file survives process and container restarts in the same working tree, but it does not follow a Git clone or fresh checkout.
+
+The user-token SDK exposes only a bounded window of the latest channel history, not an `after` cursor. Messages beyond that window or older than the recovery limits may require manual history inspection. Recovery reduces reconnect gaps but does not guarantee exactly-once delivery across process crashes.
+
 ## Quirks
 
 - **User token, not a bot token**: outbound and REST calls use the raw session token with no `Bot ` prefix. There are no gateway intents to configure and no server invite step — the account already sees whatever servers and DMs it's a member of.

--- a/src/channels/adapters/discord-recovery.test.ts
+++ b/src/channels/adapters/discord-recovery.test.ts
@@ -1,0 +1,630 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { DiscordMessage } from 'agent-messenger/discord'
+
+import {
+  DISCORD_RECOVERY_MAX_AGE_MS,
+  DISCORD_RECOVERY_MAX_ACCOUNTS,
+  DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT,
+  DISCORD_RECOVERY_MAX_FILE_BYTES,
+  DISCORD_RECOVERY_MAX_MESSAGES,
+  DISCORD_RECOVERY_MAX_RECENT_IDS_PER_CHANNEL,
+  discordRecoveryPath,
+  fetchDiscordRecovery,
+  loadDiscordRecoveryStore,
+} from './discord-recovery'
+
+describe('Discord user recovery store', () => {
+  let agentDir: string
+
+  beforeEach(async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-discord-user-recovery-'))
+    await mkdir(join(agentDir, 'channels'))
+  })
+
+  afterEach(async () => {
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('persists monotonic per-channel cursors and retained replay anchors for one account', async () => {
+    const store = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await store.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '402',
+      processedAt: 2,
+    })
+    await store.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '401',
+      processedAt: 1,
+    })
+    await store.markDisconnected(3)
+    await store.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '404',
+      processedAt: 4,
+    })
+
+    const reloaded = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    expect(reloaded.listCursors()).toEqual([
+      { channelId: '300000000000000001', workspace: '200000000000000001', messageId: '404', processedAt: 4 },
+    ])
+    expect(reloaded.listReplayCursors()).toEqual([
+      { channelId: '300000000000000001', workspace: '200000000000000001', messageId: '402', processedAt: 2 },
+    ])
+    expect(reloaded.disconnectedAt()).toBe(3)
+    expect(reloaded.isProcessed('300000000000000001', '403')).toBe(false)
+    expect(reloaded.isProcessed('300000000000000001', '404')).toBe(true)
+
+    const stat = await lstat(discordRecoveryPath(agentDir))
+    if (process.platform !== 'win32') {
+      expect(stat.mode & 0o777).toBe(0o600)
+    }
+  })
+
+  test('persists a synthetic zero predecessor anchor for a first-message route failure', async () => {
+    const store = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+
+    await store.markRouteFailed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      failedMessageId: '1',
+      failedAt: 10,
+    })
+
+    const reloaded = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    expect(reloaded.listCursors()).toEqual([])
+    expect(reloaded.listReplayCursors()).toEqual([
+      {
+        channelId: '300000000000000001',
+        workspace: '200000000000000001',
+        messageId: '0',
+        processedAt: 10,
+      },
+    ])
+    expect(reloaded.disconnectedAt()).toBe(10)
+  })
+
+  test('route failure preserves an older replay anchor and snapshots other current channels', async () => {
+    const store = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await store.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '401',
+      processedAt: 1,
+    })
+    await store.markProcessed({
+      channelId: '300000000000000002',
+      workspace: '@dm',
+      messageId: '501',
+      processedAt: 2,
+    })
+    await store.markDisconnected(3)
+    await store.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '404',
+      processedAt: 4,
+    })
+
+    await store.markRouteFailed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      failedMessageId: '403',
+      failedAt: 5,
+    })
+
+    expect(store.listReplayCursors()).toEqual([
+      {
+        channelId: '300000000000000001',
+        workspace: '200000000000000001',
+        messageId: '401',
+        processedAt: 1,
+      },
+      { channelId: '300000000000000002', workspace: '@dm', messageId: '501', processedAt: 2 },
+    ])
+    expect(store.disconnectedAt()).toBe(3)
+  })
+
+  test('route failure uses the prior successful cursor instead of a newer synthetic anchor', async () => {
+    const store = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await store.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '401',
+      processedAt: 1,
+    })
+
+    await store.markRouteFailed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      failedMessageId: '405',
+      failedAt: 2,
+    })
+
+    expect(store.listReplayCursors()).toEqual([
+      {
+        channelId: '300000000000000001',
+        workspace: '200000000000000001',
+        messageId: '401',
+        processedAt: 1,
+      },
+    ])
+  })
+
+  test('stale completion cannot clear anchors after a newer disconnect epoch', async () => {
+    const replay = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await replay.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '401',
+      processedAt: 1,
+    })
+    await replay.markDisconnected(2)
+    const replayEpoch = replay.currentEpoch()
+    const newer = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+
+    await newer.markDisconnected(3)
+    await replay.completeReplay('300000000000000001', replayEpoch)
+
+    const reloaded = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    expect(reloaded.currentEpoch()).toBe(replayEpoch + 1)
+    expect(reloaded.listReplayCursors()).toHaveLength(1)
+    expect(reloaded.disconnectedAt()).toBe(2)
+  })
+
+  test('stale completion cannot clear anchors after a newer route-failure epoch', async () => {
+    const replay = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await replay.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '401',
+      processedAt: 1,
+    })
+    await replay.markDisconnected(2)
+    const replayEpoch = replay.currentEpoch()
+    const newer = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+
+    await newer.markRouteFailed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      failedMessageId: '402',
+      failedAt: 3,
+    })
+    await replay.completeReplay('300000000000000001', replayEpoch)
+
+    const reloaded = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    expect(reloaded.currentEpoch()).toBe(replayEpoch + 1)
+    expect(reloaded.listReplayCursors()).toHaveLength(1)
+  })
+
+  test('same-epoch channel completions clear the final disconnect state', async () => {
+    const store = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await store.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '401',
+      processedAt: 1,
+    })
+    await store.markProcessed({
+      channelId: '300000000000000002',
+      workspace: '200000000000000001',
+      messageId: '402',
+      processedAt: 2,
+    })
+    await store.markDisconnected(3)
+    const epoch = store.currentEpoch()
+
+    await store.completeReplay('300000000000000001', epoch)
+    expect(store.disconnectedAt()).toBe(3)
+    await store.completeReplay('300000000000000002', epoch)
+
+    expect(store.listReplayCursors()).toEqual([])
+    expect(store.disconnectedAt()).toBeNull()
+  })
+
+  test('does not expose one authenticated account cursor to another account', async () => {
+    const first = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await first.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '401',
+      processedAt: 1,
+    })
+    await first.markDisconnected(2)
+
+    const second = await loadDiscordRecoveryStore(agentDir, '100000000000000002')
+    expect(second.listCursors()).toEqual([])
+    expect(second.listReplayCursors()).toEqual([])
+    await second.markProcessed({
+      channelId: '300000000000000001',
+      workspace: '200000000000000002',
+      messageId: '501',
+      processedAt: 3,
+    })
+
+    expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listReplayCursors()).toEqual([
+      { channelId: '300000000000000001', workspace: '200000000000000001', messageId: '401', processedAt: 1 },
+    ])
+    const persisted = JSON.parse(await readFile(discordRecoveryPath(agentDir), 'utf8')) as { accounts: unknown[] }
+    expect(persisted.accounts).toHaveLength(2)
+  })
+
+  test('merges concurrent writes from independently loaded account stores', async () => {
+    const first = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    const second = await loadDiscordRecoveryStore(agentDir, '100000000000000002')
+
+    await Promise.all([
+      first.markProcessed({
+        channelId: '300000000000000001',
+        workspace: '200000000000000001',
+        messageId: '400000000000000001',
+        processedAt: 1,
+      }),
+      second.markProcessed({
+        channelId: '300000000000000002',
+        workspace: '200000000000000002',
+        messageId: '400000000000000002',
+        processedAt: 2,
+      }),
+    ])
+
+    expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listCursors()).toHaveLength(1)
+    expect((await loadDiscordRecoveryStore(agentDir, '100000000000000002')).listCursors()).toHaveLength(1)
+  })
+
+  test('applies concurrent same-account cursor writes to the latest locked state', async () => {
+    const first = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    const second = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+
+    await Promise.all([
+      first.markProcessed({
+        channelId: '300000000000000001',
+        workspace: '200000000000000001',
+        messageId: '400000000000000001',
+        processedAt: 1,
+      }),
+      second.markProcessed({
+        channelId: '300000000000000002',
+        workspace: '200000000000000001',
+        messageId: '400000000000000002',
+        processedAt: 2,
+      }),
+    ])
+
+    expect(
+      (await loadDiscordRecoveryStore(agentDir, '100000000000000001'))
+        .listCursors()
+        .map((cursor) => cursor.channelId)
+        .sort(),
+    ).toEqual(['300000000000000001', '300000000000000002'])
+  })
+
+  test('rejects semantically inconsistent disconnect and replay state', async () => {
+    const cursor = {
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      messageId: '400000000000000001',
+      processedAt: 1,
+    }
+    for (const state of [
+      { disconnectedAt: null, replayCursors: [cursor] },
+      { disconnectedAt: 1, replayCursors: [] },
+    ]) {
+      await writeFile(
+        discordRecoveryPath(agentDir),
+        JSON.stringify({
+          version: 1,
+          accounts: [
+            {
+              accountId: '100000000000000001',
+              recoveryEpoch: 0,
+              cursors: [cursor],
+              recentMessageIds: [],
+              ...state,
+            },
+          ],
+        }),
+      )
+      expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listCursors()).toEqual([])
+    }
+
+    await writeFile(
+      discordRecoveryPath(agentDir),
+      JSON.stringify({
+        version: 1,
+        accounts: [
+          {
+            accountId: '100000000000000001',
+            recoveryEpoch: Number.MAX_SAFE_INTEGER + 1,
+            disconnectedAt: null,
+            cursors: [cursor],
+            replayCursors: [],
+            recentMessageIds: [],
+          },
+        ],
+      }),
+    )
+    expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listCursors()).toEqual([])
+  })
+
+  test('rejects malformed writes and malformed persisted identifiers', async () => {
+    const store = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    await expect(
+      store.markProcessed({ channelId: 'not-a-snowflake', workspace: '@dm', messageId: '401', processedAt: 1 }),
+    ).rejects.toThrow('invalid Discord channel id')
+
+    await writeFile(
+      discordRecoveryPath(agentDir),
+      JSON.stringify({
+        version: 1,
+        accounts: [
+          {
+            accountId: 'invalid-account',
+            recoveryEpoch: 0,
+            disconnectedAt: -1,
+            cursors: [],
+            replayCursors: [],
+            recentMessageIds: [],
+          },
+        ],
+      }),
+    )
+    const lines: string[] = []
+    const reloaded = await loadDiscordRecoveryStore(agentDir, '100000000000000001', {
+      warn: (message) => lines.push(message),
+      error: (message) => lines.push(message),
+    })
+    expect(reloaded.listCursors()).toEqual([])
+    expect(lines.some((line) => line.includes('invalid'))).toBe(true)
+
+    await writeFile(
+      discordRecoveryPath(agentDir),
+      JSON.stringify({
+        version: 1,
+        accounts: [
+          {
+            accountId: '100000000000000001',
+            recoveryEpoch: 0,
+            disconnectedAt: null,
+            cursors: [
+              {
+                channelId: '300000000000000001',
+                workspace: 'invalid-workspace',
+                messageId: '400000000000000001',
+                processedAt: Number.POSITIVE_INFINITY,
+              },
+            ],
+            replayCursors: [],
+            recentMessageIds: [],
+          },
+        ],
+      }),
+    )
+    expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listCursors()).toEqual([])
+  })
+
+  test('rejects oversized files and account cardinality before parsing into live state', async () => {
+    await writeFile(discordRecoveryPath(agentDir), Buffer.alloc(DISCORD_RECOVERY_MAX_FILE_BYTES + 1, 0x20))
+    const oversized = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    expect(oversized.listCursors()).toEqual([])
+
+    await writeFile(
+      discordRecoveryPath(agentDir),
+      JSON.stringify({
+        version: 1,
+        accounts: Array.from({ length: DISCORD_RECOVERY_MAX_ACCOUNTS + 1 }, (_, index) => ({
+          accountId: String(100000000000000001n + BigInt(index)),
+          recoveryEpoch: 0,
+          disconnectedAt: null,
+          cursors: [],
+          replayCursors: [],
+          recentMessageIds: [],
+        })),
+      }),
+    )
+    const overCardinality = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    expect(overCardinality.listCursors()).toEqual([])
+
+    const cursor = (index: number) => ({
+      channelId: String(300000000000000001n + BigInt(index)),
+      workspace: '200000000000000001',
+      messageId: String(400000000000000001n + BigInt(index)),
+      processedAt: index,
+    })
+    await writeFile(
+      discordRecoveryPath(agentDir),
+      JSON.stringify({
+        version: 1,
+        accounts: [
+          {
+            accountId: '100000000000000001',
+            recoveryEpoch: 0,
+            disconnectedAt: 1,
+            cursors: Array.from({ length: DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT + 1 }, (_, index) => cursor(index)),
+            replayCursors: [cursor(0)],
+            recentMessageIds: [],
+          },
+        ],
+      }),
+    )
+    expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listCursors()).toEqual([])
+
+    await writeFile(
+      discordRecoveryPath(agentDir),
+      JSON.stringify({
+        version: 1,
+        accounts: [
+          {
+            accountId: '100000000000000001',
+            recoveryEpoch: 0,
+            disconnectedAt: null,
+            cursors: [],
+            replayCursors: [],
+            recentMessageIds: [
+              {
+                channelId: '300000000000000001',
+                messageIds: Array.from({ length: DISCORD_RECOVERY_MAX_RECENT_IDS_PER_CHANNEL + 1 }, (_, index) =>
+                  String(400000000000000001n + BigInt(index)),
+                ),
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listCursors()).toEqual([])
+  })
+
+  test('rejects a symlink recovery target on read and write', async () => {
+    const target = join(agentDir, 'outside.json')
+    await writeFile(target, JSON.stringify({ version: 1, accounts: [] }))
+    await symlink(target, discordRecoveryPath(agentDir))
+
+    const store = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+    expect(store.listCursors()).toEqual([])
+    await expect(
+      store.markProcessed({
+        channelId: '300000000000000001',
+        workspace: '200000000000000001',
+        messageId: '400000000000000001',
+        processedAt: 1,
+      }),
+    ).rejects.toThrow('symbolic link')
+  })
+})
+
+describe('Discord user bounded recovery fetch', () => {
+  test('uses the user client history API and returns only newer messages oldest-first', async () => {
+    const calls: unknown[][] = []
+    const client = recoveryClient([message('403', 'third'), message('401', 'old'), message('402', 'second')], calls)
+
+    const result = await fetchDiscordRecovery({
+      client,
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      after: '401',
+      now: Date.parse('2026-08-28T10:05:00.000Z'),
+    })
+
+    expect(result).toMatchObject({ ok: true, outcome: 'succeeded', skippedByAge: 0, skippedByCount: 0 })
+    if (!result.ok) throw new Error('expected recovery success')
+    expect(result.messages.map((item) => item.id)).toEqual(['402', '403'])
+    expect(calls).toEqual([
+      ['getChannel', '300000000000000001'],
+      ['getMessages', '300000000000000001', DISCORD_RECOVERY_MAX_MESSAGES + 1],
+    ])
+  })
+
+  test('retains an unavailable result on REST failure', async () => {
+    const result = await fetchDiscordRecovery({
+      client: {
+        getChannel: async () => ({
+          id: '300000000000000001',
+          guild_id: '200000000000000001',
+          name: 'general',
+          type: 0,
+        }),
+        getMessages: async () => {
+          throw new Error('network unavailable')
+        },
+      },
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      after: '401',
+      now: 0,
+    })
+
+    expect(result).toEqual({ ok: false, outcome: 'unavailable', error: 'network unavailable' })
+  })
+
+  test('bounds replay by age and per-channel message count', async () => {
+    const now = Date.parse('2026-08-28T12:00:00.000Z')
+    const messages = Array.from({ length: DISCORD_RECOVERY_MAX_MESSAGES + 1 }, (_, index) =>
+      message(
+        String(400000000000000001n + BigInt(index)),
+        `message-${index}`,
+        new Date(now - index * 1_000).toISOString(),
+      ),
+    )
+    messages[messages.length - 1]!.timestamp = new Date(now - DISCORD_RECOVERY_MAX_AGE_MS - 1).toISOString()
+
+    const result = await fetchDiscordRecovery({
+      client: recoveryClient(messages),
+      channelId: '300000000000000001',
+      workspace: '200000000000000001',
+      after: '400000000000000000',
+      now,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      outcome: 'capped',
+      skipped: 1,
+      skippedByAge: 1,
+      skippedByCount: 0,
+      moreMayExist: true,
+    })
+    if (!result.ok) throw new Error('expected recovery success')
+    expect(result.messages).toHaveLength(DISCORD_RECOVERY_MAX_MESSAGES)
+  })
+
+  test('rejects malformed recovery identifiers without authenticated client calls', async () => {
+    const cases = [
+      { channelId: '../messages', workspace: '@dm', after: '400000000000000001', error: 'invalid Discord channel id' },
+      {
+        channelId: '300000000000000001',
+        workspace: 'invalid-workspace',
+        after: '400000000000000001',
+        error: 'invalid Discord workspace id',
+      },
+      {
+        channelId: '300000000000000001',
+        workspace: '@dm',
+        after: 'invalid-message',
+        error: 'invalid Discord message id',
+      },
+    ]
+    for (const item of cases) {
+      const calls: unknown[][] = []
+      const result = await fetchDiscordRecovery({
+        client: recoveryClient([], calls),
+        channelId: item.channelId,
+        workspace: item.workspace,
+        after: item.after,
+        now: 0,
+      })
+      expect(result).toEqual({ ok: false, outcome: 'unavailable', error: item.error })
+      expect(calls).toEqual([])
+    }
+  })
+})
+
+function message(id: string, content: string, timestamp = '2026-08-28T10:00:00.000Z'): DiscordMessage {
+  return {
+    id,
+    channel_id: '300000000000000001',
+    author: { id: '500000000000000001', username: 'alice' },
+    content,
+    timestamp,
+  }
+}
+
+function recoveryClient(messages: DiscordMessage[], calls: unknown[][] = []) {
+  return {
+    getChannel: async (channelId: string) => {
+      calls.push(['getChannel', channelId])
+      return { id: channelId, guild_id: '200000000000000001', name: 'general', type: 0 }
+    },
+    getMessages: async (channelId: string, limit: number) => {
+      calls.push(['getMessages', channelId, limit])
+      return messages
+    },
+  }
+}

--- a/src/channels/adapters/discord-recovery.ts
+++ b/src/channels/adapters/discord-recovery.ts
@@ -1,0 +1,637 @@
+import { randomUUID } from 'node:crypto'
+import { constants as fsConstants } from 'node:fs'
+import { lstat, mkdir, open, rename, rm } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+import type { DiscordChannel, DiscordClient, DiscordMessage } from 'agent-messenger/discord'
+import lockfile from 'proper-lockfile'
+
+import { describeError } from '../describe-error'
+
+const FILE_VERSION = 1
+export const DISCORD_RECOVERY_MAX_FILE_BYTES = 1024 * 1024
+export const DISCORD_RECOVERY_MAX_ACCOUNTS = 32
+export const DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT = 1_024
+export const DISCORD_RECOVERY_MAX_MESSAGES = 50
+export const DISCORD_RECOVERY_MAX_AGE_MS = 30 * 60 * 1_000
+export const DISCORD_RECOVERY_REQUEST_TIMEOUT_MS = 10_000
+export const DISCORD_RECOVERY_MAX_RECENT_IDS_PER_CHANNEL = DISCORD_RECOVERY_MAX_MESSAGES * 4
+
+export type DiscordRecoveryCursor = {
+  channelId: string
+  workspace: string
+  messageId: string
+  processedAt: number
+}
+
+type AccountRecoveryState = {
+  accountId: string
+  recoveryEpoch: number
+  disconnectedAt: number | null
+  cursors: DiscordRecoveryCursor[]
+  replayCursors: DiscordRecoveryCursor[]
+  recentMessageIds: Array<{ channelId: string; messageIds: string[] }>
+}
+
+type RecoveryFileV1 = {
+  version: 1
+  accounts: AccountRecoveryState[]
+}
+
+export type DiscordRecoveryStore = {
+  listCursors: () => DiscordRecoveryCursor[]
+  listReplayCursors: () => DiscordRecoveryCursor[]
+  disconnectedAt: () => number | null
+  currentEpoch: () => number
+  isProcessed: (channelId: string, messageId: string) => boolean
+  isReplayProcessed: (channelId: string, messageId: string) => boolean
+  markProcessed: (cursor: DiscordRecoveryCursor) => Promise<void>
+  markRouteFailed: (failure: {
+    channelId: string
+    workspace: string
+    failedMessageId: string
+    failedAt: number
+  }) => Promise<void>
+  markDisconnected: (at: number) => Promise<void>
+  completeReplay: (channelId: string, expectedEpoch: number) => Promise<void>
+}
+
+export type DiscordRecoveryLogger = {
+  warn: (message: string) => void
+  error: (message: string) => void
+}
+
+const consoleLogger: DiscordRecoveryLogger = {
+  warn: (message) => console.warn(message),
+  error: (message) => console.error(message),
+}
+
+export function discordRecoveryPath(agentDir: string): string {
+  return join(agentDir, 'channels', 'discord-recovery.json')
+}
+
+export async function loadDiscordRecoveryStore(
+  agentDir: string,
+  accountId: string,
+  logger: DiscordRecoveryLogger = consoleLogger,
+): Promise<DiscordRecoveryStore> {
+  const path = discordRecoveryPath(agentDir)
+  assertDiscordSnowflake(accountId, 'account id')
+  const file = await readRecoveryFile(path, logger)
+  return createRecoveryStore(accountFromFile(file, accountId), async (operation) => {
+    const directory = dirname(path)
+    await mkdir(directory, { recursive: true, mode: 0o700 })
+    await assertRealDirectory(directory)
+    const release = await lockfile.lock(path, {
+      realpath: false,
+      stale: 10_000,
+      update: 2_000,
+      retries: { retries: 5, minTimeout: 5, maxTimeout: 50 },
+    })
+    try {
+      const latest = await readRecoveryFile(path, logger)
+      const nextAccount = cloneAccount(accountFromFile(latest, accountId))
+      if (!operation(nextAccount)) return nextAccount
+      const otherAccounts = latest.accounts.filter((entry) => entry.accountId !== accountId)
+      const merged: RecoveryFileV1 = {
+        version: FILE_VERSION,
+        accounts: [...otherAccounts.slice(-(DISCORD_RECOVERY_MAX_ACCOUNTS - 1)), nextAccount],
+      }
+      await writeRecoveryFile(path, merged)
+      return nextAccount
+    } finally {
+      await release().catch(() => undefined)
+    }
+  })
+}
+
+export function createInMemoryDiscordRecoveryStore(accountId = '1'): DiscordRecoveryStore {
+  assertDiscordSnowflake(accountId, 'account id')
+  return createRecoveryStore(emptyAccount(accountId))
+}
+
+export type DiscordRecoveryResult =
+  | {
+      ok: true
+      outcome: 'succeeded' | 'capped'
+      messages: DiscordMessage[]
+      skipped: number
+      skippedByAge: number
+      skippedByCount: number
+      moreMayExist: boolean
+    }
+  | { ok: false; outcome: 'unavailable'; error: string }
+
+export async function fetchDiscordRecovery(args: {
+  client: Pick<DiscordClient, 'getChannel' | 'getMessages'>
+  channelId: string
+  workspace: string
+  after: string
+  now: number
+  requestTimeoutMs?: number
+}): Promise<DiscordRecoveryResult> {
+  const inputError = validateRecoveryRequest(args.channelId, args.workspace, args.after)
+  if (inputError !== null) return { ok: false, outcome: 'unavailable', error: inputError }
+  const timeoutMs = args.requestTimeoutMs ?? DISCORD_RECOVERY_REQUEST_TIMEOUT_MS
+  const channelResult = await settleWithin(args.client.getChannel(args.channelId), timeoutMs)
+  if (channelResult.kind === 'timed-out') {
+    return { ok: false, outcome: 'unavailable', error: `channel lookup timed out after ${timeoutMs}ms` }
+  }
+  if (channelResult.kind === 'failed') {
+    return { ok: false, outcome: 'unavailable', error: `channel lookup failed: ${describeError(channelResult.error)}` }
+  }
+  const channel = channelResult.value as DiscordChannel & { guild_id?: string }
+  if (!isDiscordSnowflake(channel.id) || channel.id !== args.channelId) {
+    return { ok: false, outcome: 'unavailable', error: 'channel lookup response mismatch' }
+  }
+  if ((channel.guild_id ?? '@dm') !== args.workspace) {
+    return { ok: false, outcome: 'unavailable', error: 'channel workspace mismatch' }
+  }
+
+  const limit = DISCORD_RECOVERY_MAX_MESSAGES + 1
+  const historyResult = await settleWithin(args.client.getMessages(args.channelId, limit), timeoutMs)
+  if (historyResult.kind === 'timed-out') {
+    return { ok: false, outcome: 'unavailable', error: `message history timed out after ${timeoutMs}ms` }
+  }
+  if (historyResult.kind === 'failed') {
+    return { ok: false, outcome: 'unavailable', error: describeError(historyResult.error) }
+  }
+  if (historyResult.value.some((message) => message.channel_id !== args.channelId)) {
+    return { ok: false, outcome: 'unavailable', error: 'message history channel mismatch' }
+  }
+  if (historyResult.value.some((message) => !isDiscordSnowflake(message.id))) {
+    return { ok: false, outcome: 'unavailable', error: 'invalid message history snowflake' }
+  }
+
+  const newer = historyResult.value.filter((message) => compareSnowflakes(message.id, args.after) > 0)
+  const cutoff = args.now - DISCORD_RECOVERY_MAX_AGE_MS
+  const recent = newer.filter((message) => {
+    const timestamp = Date.parse(message.timestamp)
+    return Number.isFinite(timestamp) && timestamp >= cutoff
+  })
+  const selected = recent
+    .sort((left, right) => compareSnowflakes(left.id, right.id))
+    .slice(-DISCORD_RECOVERY_MAX_MESSAGES)
+  const skippedByAge = newer.length - recent.length
+  const skippedByCount = recent.length - selected.length
+  const skipped = skippedByAge + skippedByCount
+  const moreMayExist =
+    historyResult.value.length === limit &&
+    historyResult.value.every((message) => compareSnowflakes(message.id, args.after) > 0)
+  const outcome = skipped > 0 || moreMayExist ? 'capped' : 'succeeded'
+  return { ok: true, outcome, messages: selected, skipped, skippedByAge, skippedByCount, moreMayExist }
+}
+
+type AccountMutation = (draft: AccountRecoveryState) => boolean
+
+function createRecoveryStore(
+  initialAccount: AccountRecoveryState,
+  applyLatest?: (operation: AccountMutation) => Promise<AccountRecoveryState>,
+): DiscordRecoveryStore {
+  let account = initialAccount
+  let writeBarrier = Promise.resolve()
+
+  const mutate = async (operation: AccountMutation): Promise<void> => {
+    const write = writeBarrier.then(async () => {
+      if (applyLatest !== undefined) {
+        account = await applyLatest(operation)
+        return
+      }
+      const draft = cloneAccount(account)
+      if (!operation(draft)) return
+      account = draft
+    })
+    writeBarrier = write.catch(() => undefined)
+    await write
+  }
+
+  return {
+    listCursors: () => account.cursors.map((cursor) => ({ ...cursor })),
+    listReplayCursors: () => account.replayCursors.map((cursor) => ({ ...cursor })),
+    disconnectedAt: () => account.disconnectedAt,
+    currentEpoch: () => account.recoveryEpoch,
+    isProcessed: (channelId, messageId) => {
+      const cursor = account.cursors.find((entry) => entry.channelId === channelId)
+      const anchor = account.replayCursors.find((entry) => entry.channelId === channelId)
+      const recent = account.recentMessageIds.find((entry) => entry.channelId === channelId)
+      if (anchor !== undefined) {
+        return compareSnowflakes(messageId, anchor.messageId) <= 0 || recent?.messageIds.includes(messageId) === true
+      }
+      return cursor !== undefined && compareSnowflakes(messageId, cursor.messageId) <= 0
+    },
+    isReplayProcessed: (channelId, messageId) => {
+      const anchor = account.replayCursors.find((entry) => entry.channelId === channelId)
+      const recent = account.recentMessageIds.find((entry) => entry.channelId === channelId)
+      return (
+        (anchor !== undefined && compareSnowflakes(messageId, anchor.messageId) <= 0) ||
+        recent?.messageIds.includes(messageId) === true
+      )
+    },
+    markProcessed: async (cursor) => {
+      assertValidCursor(cursor)
+      await mutate((draft) => {
+        const currentIndex = draft.cursors.findIndex((entry) => entry.channelId === cursor.channelId)
+        let changed = false
+        if (currentIndex === -1 || compareSnowflakes(cursor.messageId, draft.cursors[currentIndex]!.messageId) > 0) {
+          if (currentIndex === -1) {
+            if (draft.cursors.length >= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT) evictOldestChannel(draft)
+            draft.cursors.push(cursor)
+          } else draft.cursors[currentIndex] = cursor
+          changed = true
+        }
+        let recent = draft.recentMessageIds.find((entry) => entry.channelId === cursor.channelId)
+        if (recent === undefined) {
+          if (draft.recentMessageIds.length >= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT) {
+            draft.recentMessageIds.shift()
+          }
+          recent = { channelId: cursor.channelId, messageIds: [] }
+          draft.recentMessageIds.push(recent)
+        }
+        if (!recent.messageIds.includes(cursor.messageId)) {
+          recent.messageIds.push(cursor.messageId)
+          if (recent.messageIds.length > DISCORD_RECOVERY_MAX_RECENT_IDS_PER_CHANNEL) {
+            recent.messageIds.splice(0, recent.messageIds.length - DISCORD_RECOVERY_MAX_RECENT_IDS_PER_CHANNEL)
+          }
+          changed = true
+        }
+        return changed
+      })
+    },
+    markRouteFailed: async (failure) => {
+      assertDiscordSnowflake(failure.channelId, 'channel id')
+      if (!isDiscordWorkspace(failure.workspace)) throw new Error('invalid Discord workspace id')
+      assertDiscordSnowflake(failure.failedMessageId, 'message id')
+      if (!isFiniteNonnegative(failure.failedAt)) throw new Error('invalid Discord failure timestamp')
+      await mutate((draft) => {
+        draft.recoveryEpoch = nextRecoveryEpoch(draft.recoveryEpoch)
+        let changed = true
+        if (draft.disconnectedAt === null) {
+          draft.disconnectedAt = failure.failedAt
+          changed = true
+        }
+        if (!draft.replayCursors.some((cursor) => cursor.channelId === failure.channelId)) {
+          const current = draft.cursors.find((cursor) => cursor.channelId === failure.channelId)
+          const anchor =
+            current !== undefined && compareSnowflakes(current.messageId, failure.failedMessageId) < 0
+              ? { ...current }
+              : {
+                  channelId: failure.channelId,
+                  workspace: failure.workspace,
+                  messageId: predecessorSnowflake(failure.failedMessageId),
+                  processedAt: failure.failedAt,
+                }
+          addReplayAnchorBounded(draft, anchor, failure.channelId)
+          changed = true
+        }
+        for (const cursor of draft.cursors) {
+          if (cursor.channelId === failure.channelId) continue
+          if (draft.replayCursors.some((entry) => entry.channelId === cursor.channelId)) continue
+          if (draft.replayCursors.length >= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT) continue
+          draft.replayCursors.push({ ...cursor })
+          changed = true
+        }
+        return changed
+      })
+    },
+    markDisconnected: async (at) => {
+      if (!isFiniteNonnegative(at)) throw new Error('invalid Discord disconnect timestamp')
+      await mutate((draft) => {
+        if (draft.cursors.length === 0 && draft.replayCursors.length === 0) return false
+        draft.recoveryEpoch = nextRecoveryEpoch(draft.recoveryEpoch)
+        let changed = true
+        if (draft.disconnectedAt === null) {
+          draft.disconnectedAt = at
+          draft.replayCursors = []
+          changed = true
+        }
+        for (const cursor of draft.cursors) {
+          if (draft.replayCursors.some((entry) => entry.channelId === cursor.channelId)) continue
+          if (draft.replayCursors.length >= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT) continue
+          draft.replayCursors.push({ ...cursor })
+          changed = true
+        }
+        return changed
+      })
+    },
+    completeReplay: async (channelId, expectedEpoch) => {
+      assertDiscordSnowflake(channelId, 'channel id')
+      if (!isRecoveryEpoch(expectedEpoch)) throw new Error('invalid Discord recovery epoch')
+      await mutate((draft) => {
+        if (draft.recoveryEpoch !== expectedEpoch) return false
+        const next = draft.replayCursors.filter((cursor) => cursor.channelId !== channelId)
+        if (next.length === draft.replayCursors.length) return false
+        draft.replayCursors = next
+        if (next.length === 0) draft.disconnectedAt = null
+        return true
+      })
+    },
+  }
+}
+
+function accountFromFile(file: RecoveryFileV1, accountId: string): AccountRecoveryState {
+  return file.accounts.find((account) => account.accountId === accountId) ?? emptyAccount(accountId)
+}
+
+function cloneAccount(account: AccountRecoveryState): AccountRecoveryState {
+  return {
+    accountId: account.accountId,
+    recoveryEpoch: account.recoveryEpoch,
+    disconnectedAt: account.disconnectedAt,
+    cursors: account.cursors.map((cursor) => ({ ...cursor })),
+    replayCursors: account.replayCursors.map((cursor) => ({ ...cursor })),
+    recentMessageIds: account.recentMessageIds.map((entry) => ({
+      channelId: entry.channelId,
+      messageIds: [...entry.messageIds],
+    })),
+  }
+}
+
+function evictOldestChannel(account: AccountRecoveryState): void {
+  const oldest = account.cursors.reduce((candidate, cursor) =>
+    cursor.processedAt < candidate.processedAt ? cursor : candidate,
+  )
+  account.cursors = account.cursors.filter((cursor) => cursor.channelId !== oldest.channelId)
+  account.replayCursors = account.replayCursors.filter((cursor) => cursor.channelId !== oldest.channelId)
+  account.recentMessageIds = account.recentMessageIds.filter((entry) => entry.channelId !== oldest.channelId)
+}
+
+function addReplayAnchorBounded(
+  account: AccountRecoveryState,
+  cursor: DiscordRecoveryCursor,
+  protectedChannelId: string,
+): void {
+  if (account.replayCursors.length >= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT) {
+    const candidates = account.replayCursors.filter((entry) => entry.channelId !== protectedChannelId)
+    const oldest = candidates.reduce((candidate, entry) =>
+      entry.processedAt < candidate.processedAt ? entry : candidate,
+    )
+    account.replayCursors = account.replayCursors.filter((entry) => entry.channelId !== oldest.channelId)
+  }
+  account.replayCursors.push(cursor)
+}
+
+function predecessorSnowflake(messageId: string): string {
+  return (BigInt(messageId) - 1n).toString()
+}
+
+function nextRecoveryEpoch(epoch: number): number {
+  return epoch === Number.MAX_SAFE_INTEGER ? 0 : epoch + 1
+}
+
+async function writeRecoveryFile(path: string, file: RecoveryFileV1): Promise<void> {
+  if (!isRecoveryFile(file)) throw new Error('invalid Discord recovery state')
+  const serialized = `${JSON.stringify(file, null, 2)}\n`
+  if (Buffer.byteLength(serialized) > DISCORD_RECOVERY_MAX_FILE_BYTES) {
+    throw new Error(`Discord recovery state exceeds ${DISCORD_RECOVERY_MAX_FILE_BYTES} bytes`)
+  }
+  const directory = dirname(path)
+  await assertRealDirectory(directory)
+  await assertSafeRecoveryTarget(path)
+  const temporaryPath = join(directory, `.${basename(path)}.${randomUUID()}.tmp`)
+  const temporary = await open(temporaryPath, 'wx', 0o600)
+  try {
+    await temporary.writeFile(serialized, 'utf8')
+    await temporary.close()
+    // `channels/` is runtime-owned. Node has no dirfd-relative rename API, so
+    // revalidate it and the target at the last available point before rename.
+    await assertRealDirectory(directory)
+    await assertSafeRecoveryTarget(path)
+    await rename(temporaryPath, path)
+  } finally {
+    await temporary.close().catch(() => undefined)
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
+}
+
+async function assertRealDirectory(path: string): Promise<void> {
+  const stat = await lstat(path)
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Discord recovery directory is not a real directory: ${path}`)
+  }
+}
+
+async function assertSafeRecoveryTarget(path: string): Promise<void> {
+  try {
+    const stat = await lstat(path)
+    if (stat.isSymbolicLink()) throw new Error(`Discord recovery target is a symbolic link: ${path}`)
+    if (!stat.isFile()) throw new Error(`Discord recovery target is not a regular file: ${path}`)
+  } catch (error) {
+    if (isErrorWithCode(error) && error.code === 'ENOENT') return
+    throw error
+  }
+}
+
+function validateRecoveryRequest(channelId: string, workspace: string, after: string): string | null {
+  if (!isDiscordSnowflake(channelId)) return 'invalid Discord channel id'
+  if (!isDiscordWorkspace(workspace)) return 'invalid Discord workspace id'
+  if (!isDiscordRecoveryAnchor(after)) return 'invalid Discord message id'
+  return null
+}
+
+function assertValidCursor(cursor: DiscordRecoveryCursor): void {
+  assertDiscordSnowflake(cursor.channelId, 'channel id')
+  if (!isDiscordWorkspace(cursor.workspace)) throw new Error('invalid Discord workspace id')
+  assertDiscordSnowflake(cursor.messageId, 'message id')
+  if (!isFiniteNonnegative(cursor.processedAt)) throw new Error('invalid Discord processed timestamp')
+}
+
+function assertDiscordSnowflake(value: string, label: string): void {
+  if (!isDiscordSnowflake(value)) throw new Error(`invalid Discord ${label}`)
+}
+
+const MAX_DISCORD_SNOWFLAKE = 18_446_744_073_709_551_615n
+
+function isDiscordSnowflake(value: unknown): value is string {
+  if (typeof value !== 'string' || !/^[1-9]\d{0,19}$/.test(value)) return false
+  return BigInt(value) <= MAX_DISCORD_SNOWFLAKE
+}
+
+function isDiscordRecoveryAnchor(value: unknown): value is string {
+  return value === '0' || isDiscordSnowflake(value)
+}
+
+function isDiscordWorkspace(value: unknown): value is string {
+  return value === '@dm' || isDiscordSnowflake(value)
+}
+
+function isFiniteNonnegative(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function isRecoveryEpoch(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}
+
+async function readRecoveryFile(path: string, logger: DiscordRecoveryLogger): Promise<RecoveryFileV1> {
+  let handle: Awaited<ReturnType<typeof open>>
+  try {
+    handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+  } catch (error) {
+    if (isErrorWithCode(error) && error.code === 'ENOENT') return emptyRecoveryFile()
+    logger.error(`[discord] failed to read recovery state at ${path}: ${describeError(error)}; starting fresh`)
+    return emptyRecoveryFile()
+  }
+  let raw: string
+  try {
+    const stat = await handle.stat()
+    if (!stat.isFile()) {
+      logger.warn(`[discord] recovery state at ${path} is not a regular file; starting fresh`)
+      return emptyRecoveryFile()
+    }
+    if (stat.size > DISCORD_RECOVERY_MAX_FILE_BYTES) {
+      logger.warn(
+        `[discord] recovery state at ${path} exceeds ${DISCORD_RECOVERY_MAX_FILE_BYTES} bytes; starting fresh`,
+      )
+      return emptyRecoveryFile()
+    }
+    const contents = await readBoundedRecoveryFile(handle)
+    if (contents === null) {
+      logger.warn(
+        `[discord] recovery state at ${path} exceeds ${DISCORD_RECOVERY_MAX_FILE_BYTES} bytes; starting fresh`,
+      )
+      return emptyRecoveryFile()
+    }
+    raw = contents.toString('utf8')
+  } catch (error) {
+    logger.error(`[discord] failed to read recovery state at ${path}: ${describeError(error)}; starting fresh`)
+    return emptyRecoveryFile()
+  } finally {
+    await handle.close().catch(() => undefined)
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecoveryFile(parsed)) {
+      logger.warn(`[discord] recovery state at ${path} is invalid; starting fresh`)
+      return emptyRecoveryFile()
+    }
+    return parsed
+  } catch (error) {
+    logger.error(`[discord] recovery state at ${path} is corrupted: ${describeError(error)}; starting fresh`)
+    return emptyRecoveryFile()
+  }
+}
+
+async function readBoundedRecoveryFile(handle: Awaited<ReturnType<typeof open>>): Promise<Buffer<ArrayBuffer> | null> {
+  const buffer = Buffer.alloc(DISCORD_RECOVERY_MAX_FILE_BYTES + 1)
+  let offset = 0
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset)
+    if (bytesRead === 0) break
+    offset += bytesRead
+  }
+  if (offset > DISCORD_RECOVERY_MAX_FILE_BYTES) return null
+  return buffer.subarray(0, offset)
+}
+
+function emptyRecoveryFile(): RecoveryFileV1 {
+  return { version: FILE_VERSION, accounts: [] }
+}
+
+function emptyAccount(accountId: string): AccountRecoveryState {
+  return { accountId, recoveryEpoch: 0, disconnectedAt: null, cursors: [], replayCursors: [], recentMessageIds: [] }
+}
+
+function isRecoveryFile(value: unknown): value is RecoveryFileV1 {
+  return (
+    isObject(value) &&
+    value.version === FILE_VERSION &&
+    Array.isArray(value.accounts) &&
+    value.accounts.length <= DISCORD_RECOVERY_MAX_ACCOUNTS &&
+    new Set(value.accounts.map((account) => (isObject(account) ? account.accountId : undefined))).size ===
+      value.accounts.length &&
+    value.accounts.every(isAccount)
+  )
+}
+
+function isAccount(value: unknown): value is AccountRecoveryState {
+  return (
+    isObject(value) &&
+    isDiscordSnowflake(value.accountId) &&
+    isRecoveryEpoch(value.recoveryEpoch) &&
+    (value.disconnectedAt === null || isFiniteNonnegative(value.disconnectedAt)) &&
+    Array.isArray(value.cursors) &&
+    value.cursors.length <= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT &&
+    value.cursors.every(isCursor) &&
+    Array.isArray(value.replayCursors) &&
+    value.replayCursors.length <= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT &&
+    value.replayCursors.every(isReplayCursor) &&
+    ((value.disconnectedAt === null && value.replayCursors.length === 0) ||
+      (isFiniteNonnegative(value.disconnectedAt) && value.replayCursors.length > 0)) &&
+    Array.isArray(value.recentMessageIds) &&
+    value.recentMessageIds.length <= DISCORD_RECOVERY_MAX_CHANNELS_PER_ACCOUNT &&
+    value.recentMessageIds.every(isRecentMessageIds)
+  )
+}
+
+function isCursor(value: unknown): value is DiscordRecoveryCursor {
+  return (
+    isObject(value) &&
+    isDiscordSnowflake(value.channelId) &&
+    isDiscordWorkspace(value.workspace) &&
+    isDiscordSnowflake(value.messageId) &&
+    isFiniteNonnegative(value.processedAt)
+  )
+}
+
+function isReplayCursor(value: unknown): value is DiscordRecoveryCursor {
+  return (
+    isObject(value) &&
+    isDiscordSnowflake(value.channelId) &&
+    isDiscordWorkspace(value.workspace) &&
+    isDiscordRecoveryAnchor(value.messageId) &&
+    isFiniteNonnegative(value.processedAt)
+  )
+}
+
+function isRecentMessageIds(value: unknown): value is AccountRecoveryState['recentMessageIds'][number] {
+  return (
+    isObject(value) &&
+    isDiscordSnowflake(value.channelId) &&
+    Array.isArray(value.messageIds) &&
+    value.messageIds.length <= DISCORD_RECOVERY_MAX_RECENT_IDS_PER_CHANNEL &&
+    value.messageIds.every(isDiscordSnowflake)
+  )
+}
+
+export function compareDiscordSnowflakes(left: string, right: string): number {
+  try {
+    const leftId = BigInt(left)
+    const rightId = BigInt(right)
+    return leftId < rightId ? -1 : leftId > rightId ? 1 : 0
+  } catch {
+    return left.localeCompare(right)
+  }
+}
+
+function compareSnowflakes(left: string, right: string): number {
+  return compareDiscordSnowflakes(left, right)
+}
+
+export type TimedSettlement<T> =
+  | { kind: 'completed'; value: T }
+  | { kind: 'failed'; error: unknown }
+  | { kind: 'timed-out' }
+
+export function settleWithin<T>(operation: Promise<T>, timeoutMs: number): Promise<TimedSettlement<T>> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve({ kind: 'timed-out' }), Math.max(0, timeoutMs))
+    void operation.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve({ kind: 'completed', value })
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        resolve({ kind: 'failed', error })
+      },
+    )
+  })
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isErrorWithCode(value: unknown): value is Error & { code: string } {
+  return value instanceof Error && 'code' in value && typeof value.code === 'string'
+}

--- a/src/channels/adapters/discord.test.ts
+++ b/src/channels/adapters/discord.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import type { DiscordGatewayMessageCreateEvent, DiscordListener } from 'agent-messenger/discord'
 
@@ -8,6 +11,7 @@ import type { InboundMessage, OutboundCallback } from '@/channels/types'
 import type { DiscordAccountRecord } from '@/secrets/schema'
 
 import { createDiscordAdapter, createDiscordHistoryCallback, type DiscordAdapterLogger } from './discord'
+import { createInMemoryDiscordRecoveryStore, loadDiscordRecoveryStore } from './discord-recovery'
 
 const config = channelsSchema.parse({ discord: {} }).discord!
 
@@ -56,7 +60,7 @@ class FakeListener {
   }
 }
 
-function router(): ChannelRouter & {
+function router(routeHook?: (message: InboundMessage) => Promise<void>): ChannelRouter & {
   routed: InboundMessage[]
   registered: string[]
   unregistered: string[]
@@ -71,6 +75,7 @@ function router(): ChannelRouter & {
     registered,
     unregistered,
     route: async (msg: InboundMessage) => {
+      await routeHook?.(msg)
       routed.push(msg)
     },
     registerOutbound: (adapter: string, cb: OutboundCallback) => {
@@ -167,6 +172,743 @@ describe('createDiscordAdapter', () => {
     expect(listener.stopped).toBe(true)
     expect(r.unregistered).toContain('outbound:discord')
     expect(r.unregistered).toContain('remove-reaction:discord')
+  })
+
+  test('does not replay on initial connect or duplicate normal live delivery', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const historyCalls: unknown[][] = []
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getMessages: async (...args: unknown[]) => {
+            historyCalls.push(args)
+            return []
+          },
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('400000000000000010', 'normal'))
+    listener.emit('message_create', gatewayMessage('400000000000000010', 'normal'))
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000010'])
+    expect(historyCalls).toEqual([])
+  })
+
+  test('replays a reconnect gap oldest-first before overlapping live delivery', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    let history = [
+      restMessage('400000000000000003', 'third'),
+      restMessage('400000000000000002', 'second'),
+      restMessage('400000000000000001', 'first'),
+    ]
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient({ getMessages: async () => history }),
+      createListener: () => listener as unknown as DiscordListener,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('400000000000000001', 'first'))
+    await Bun.sleep(0)
+    listener.emit('disconnected', undefined)
+    history = [restMessage('400000000000000003', 'third'), restMessage('400000000000000002', 'second')]
+    listener.emit('connected', connectedInfo())
+    listener.emit('message_create', gatewayMessage('400000000000000003', 'third'))
+    await Bun.sleep(10)
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual([
+      '400000000000000001',
+      '400000000000000002',
+      '400000000000000003',
+    ])
+  })
+
+  test('replays before a gap-time gateway event and deduplicates their overlap', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getMessages: async () => [
+            restMessage('400000000000000003', 'third'),
+            restMessage('400000000000000002', 'second'),
+          ],
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('400000000000000001', 'first'))
+    await waitFor(() => r.routed.length === 1)
+    listener.emit('disconnected', undefined)
+    listener.emit('message_create', gatewayMessage('400000000000000003', 'third'))
+    listener.emit('connected', connectedInfo())
+    await waitFor(() => r.routed.length === 3)
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual([
+      '400000000000000001',
+      '400000000000000002',
+      '400000000000000003',
+    ])
+  })
+
+  test('retains an unavailable replay anchor for the next reconnect', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '300000000000000003',
+      workspace: '200000000000000002',
+      messageId: '400000000000000001',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    let attempts = 0
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getMessages: async () => {
+            attempts++
+            if (attempts === 1) throw new Error('temporary failure')
+            return [restMessage('400000000000000002', 'missed')]
+          },
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      recoveryStore,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    await Bun.sleep(10)
+    expect(attempts).toBe(1)
+    expect(recoveryStore.listReplayCursors()).toHaveLength(1)
+    listener.emit('disconnected', undefined)
+    listener.emit('connected', connectedInfo())
+    await Bun.sleep(10)
+
+    expect(attempts).toBe(2)
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000002'])
+    expect(recoveryStore.listReplayCursors()).toEqual([])
+    await adapter.stop()
+  })
+
+  test('replays a durable pending gap on the recreated adapter first connection', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '300000000000000003',
+      workspace: '200000000000000002',
+      messageId: '400000000000000001',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    const r = router()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({ getMessages: async () => [restMessage('400000000000000002', 'missed while stopped')] }),
+      createListener: () => new FakeListener() as unknown as DiscordListener,
+      recoveryStore,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    await Bun.sleep(10)
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000002'])
+    expect(recoveryStore.listReplayCursors()).toEqual([])
+    await adapter.stop()
+  })
+
+  test('orders a pre-connected live event behind persisted startup replay', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '300000000000000003',
+      workspace: '200000000000000002',
+      messageId: '400000000000000001',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    const r = router()
+    const listener = new FakeListener()
+    listener.start = async () => {
+      listener.emit('message_create', gatewayMessage('400000000000000003', 'pre-connected live'))
+      listener.emit('connected', connectedInfo())
+    }
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getMessages: async () => [
+            restMessage('400000000000000003', 'third'),
+            restMessage('400000000000000002', 'second'),
+          ],
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      recoveryStore,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    await waitFor(() => r.routed.length === 2)
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000002', '400000000000000003'])
+  })
+
+  test('a dropped first event establishes recovery coverage for a later gap mention', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({ getMessages: async () => [restMessage('400000000000000002', '<@100000000000000001> gap')] }),
+      createListener: () => listener as unknown as DiscordListener,
+      recoveryStore,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', {
+      ...gatewayMessage('400000000000000001', 'self-authored'),
+      author: { id: '100000000000000001', username: 'self' },
+    })
+    await waitFor(() => recoveryStore.listCursors()[0]?.messageId === '400000000000000001')
+    expect(r.routed).toEqual([])
+    listener.emit('disconnected', undefined)
+    listener.emit('connected', connectedInfo())
+    await waitFor(() => r.routed.length === 1)
+    await adapter.stop()
+
+    expect(r.routed[0]?.externalMessageId).toBe('400000000000000002')
+  })
+
+  test('disconnect timeout anchors pending inbound before reconnect replay', async () => {
+    const routeStarted = deferred<void>()
+    const releaseRoute = deferred<void>()
+    const historyRequested = deferred<void>()
+    const r = router(async (message) => {
+      if (message.externalMessageId !== '400000000000000001') return
+      routeStarted.resolve(undefined)
+      await releaseRoute.promise
+    })
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getMessages: async () => {
+            historyRequested.resolve(undefined)
+            return [restMessage('400000000000000002', 'outage'), restMessage('400000000000000001', 'pending')]
+          },
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      disconnectDrainTimeoutMs: 5,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('400000000000000001', 'pending'))
+    await routeStarted.promise
+    listener.emit('disconnected', undefined)
+    listener.emit('connected', connectedInfo())
+    await historyRequested.promise
+    releaseRoute.resolve(undefined)
+    await waitFor(() => r.routed.length === 2)
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000001', '400000000000000002'])
+  })
+
+  test('bounds each reconnect pass by channels and aggregate messages while retaining deferred anchors', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    for (let channel = 1; channel <= 21; channel++) {
+      await recoveryStore.markProcessed({
+        channelId: String(300000000000000000n + BigInt(channel)),
+        workspace: '200000000000000002',
+        messageId: '400000000000000000',
+        processedAt: channel,
+      })
+    }
+    const requestedChannels: string[] = []
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getChannel: async (channelId: string) => ({
+            id: channelId,
+            guild_id: '200000000000000002',
+            name: channelId,
+            type: 0,
+          }),
+          getMessages: async (channelId: string) => {
+            requestedChannels.push(channelId)
+            return Array.from({ length: 40 }, (_, index) => ({
+              ...restMessage(String(400000000000000001n + BigInt(index)), `missed-${index}`),
+              channel_id: channelId,
+            }))
+          },
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      recoveryStore,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    expect(requestedChannels).toEqual([])
+    listener.emit('disconnected', undefined)
+    listener.emit('connected', connectedInfo())
+    await Bun.sleep(30)
+
+    expect(requestedChannels).toHaveLength(3)
+    expect(r.routed).toHaveLength(100)
+    expect(recoveryStore.listReplayCursors()).toHaveLength(19)
+    expect(
+      r.routed.filter((message) => message.chat === requestedChannels[2]).map((message) => message.externalMessageId),
+    ).toEqual(Array.from({ length: 20 }, (_, index) => String(400000000000000001n + BigInt(index))))
+    await adapter.stop()
+  })
+
+  test('stops a duration-bounded replay without allowing queued delivery after stop', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '300000000000000003',
+      workspace: '200000000000000002',
+      messageId: '400000000000000001',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getChannel: async () => await new Promise<never>(() => undefined),
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      recoveryStore,
+      recoveryMaxDurationMs: 5,
+    })
+
+    await adapter.start()
+    listener.emit('disconnected', undefined)
+    listener.emit('connected', connectedInfo())
+    await adapter.stop()
+    listener.emit('message_create', gatewayMessage('400000000000000002', 'late'))
+    await Bun.sleep(10)
+
+    expect(r.routed).toEqual([])
+    expect(recoveryStore.listReplayCursors()).toHaveLength(1)
+  })
+
+  test('drains a live inbound accepted before stop while it waits behind recovery', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '300000000000000003',
+      workspace: '200000000000000002',
+      messageId: '400000000000000001',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    const channelLookup = deferred<{
+      id: string
+      guild_id: string
+      name: string
+      type: number
+    }>()
+    const lookupStarted = deferred<void>()
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getChannel: async () => {
+            lookupStarted.resolve(undefined)
+            return await channelLookup.promise
+          },
+          getMessages: async () => [],
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      recoveryStore,
+    })
+
+    await adapter.start()
+    await lookupStarted.promise
+    listener.emit('message_create', gatewayMessage('400000000000000002', 'queued'))
+    const stopping = adapter.stop()
+    channelLookup.resolve({
+      id: '300000000000000003',
+      guild_id: '200000000000000002',
+      name: 'general',
+      type: 0,
+    })
+    await stopping
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000002'])
+  })
+
+  test('graceful stop drains accepted inbound and leaves a durable restart replay anchor', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-discord-graceful-restart-'))
+    try {
+      const routeStarted = deferred<void>()
+      const releaseRoute = deferred<void>()
+      const firstRouter = router(async (message) => {
+        if (message.externalMessageId !== '400000000000000001') return
+        routeStarted.resolve(undefined)
+        await releaseRoute.promise
+      })
+      const firstListener = new FakeListener()
+      const first = createDiscordAdapter({
+        agentDir,
+        router: firstRouter,
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () => fakeClient(),
+        createListener: () => firstListener as unknown as DiscordListener,
+        enrichHistoricalProvenance: async () => ({
+          scanned: 0,
+          attempted: 0,
+          resolved: 0,
+          failed: 0,
+          timedOut: 0,
+          changed: false,
+        }),
+        now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+      })
+      await first.start()
+      firstListener.emit('message_create', gatewayMessage('400000000000000001', 'accepted'))
+      await routeStarted.promise
+      const stopping = first.stop()
+      releaseRoute.resolve(undefined)
+      await stopping
+
+      expect(firstRouter.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000001'])
+      const secondRouter = router()
+      const second = createDiscordAdapter({
+        agentDir,
+        router: secondRouter,
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () =>
+          fakeClient({ getMessages: async () => [restMessage('400000000000000002', 'restart downtime')] }),
+        createListener: () => new FakeListener() as unknown as DiscordListener,
+        enrichHistoricalProvenance: async () => ({
+          scanned: 0,
+          attempted: 0,
+          resolved: 0,
+          failed: 0,
+          timedOut: 0,
+          changed: false,
+        }),
+        now: () => Date.parse('2026-01-01T00:06:00.000Z'),
+      })
+      await second.start()
+      await waitFor(() => secondRouter.routed.length === 1)
+      await second.stop()
+
+      expect(secondRouter.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000002'])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('stop immediately after listener disconnect still preserves the durable replay snapshot', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-discord-disconnect-stop-'))
+    try {
+      const firstRouter = router()
+      const firstListener = new FakeListener()
+      const first = createDiscordAdapter({
+        agentDir,
+        router: firstRouter,
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () => fakeClient(),
+        createListener: () => firstListener as unknown as DiscordListener,
+        enrichHistoricalProvenance: async () => ({
+          scanned: 0,
+          attempted: 0,
+          resolved: 0,
+          failed: 0,
+          timedOut: 0,
+          changed: false,
+        }),
+      })
+      await first.start()
+      firstListener.emit('message_create', gatewayMessage('400000000000000001', 'before disconnect'))
+      await waitFor(() => firstRouter.routed.length === 1)
+      firstListener.emit('disconnected', undefined)
+      await first.stop()
+
+      const secondRouter = router()
+      const second = createDiscordAdapter({
+        agentDir,
+        router: secondRouter,
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () => fakeClient({ getMessages: async () => [restMessage('400000000000000002', 'gap')] }),
+        createListener: () => new FakeListener() as unknown as DiscordListener,
+        enrichHistoricalProvenance: async () => ({
+          scanned: 0,
+          attempted: 0,
+          resolved: 0,
+          failed: 0,
+          timedOut: 0,
+          changed: false,
+        }),
+        now: () => Date.parse('2026-01-01T00:06:00.000Z'),
+      })
+      await second.start()
+      await waitFor(() => secondRouter.routed.length === 1)
+      await second.stop()
+
+      expect(secondRouter.routed[0]?.externalMessageId).toBe('400000000000000002')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('replays an earlier route failure after a newer live message succeeds', async () => {
+    let failMessage102 = true
+    const r = router(async (message) => {
+      if (message.externalMessageId === '400000000000000002' && failMessage102) {
+        failMessage102 = false
+        throw new Error('route failed')
+      }
+    })
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getMessages: async () => [
+            restMessage('400000000000000003', 'newer success'),
+            restMessage('400000000000000002', 'failed earlier'),
+          ],
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('400000000000000001', 'first'))
+    listener.emit('message_create', gatewayMessage('400000000000000002', 'fails'))
+    listener.emit('message_create', gatewayMessage('400000000000000003', 'succeeds'))
+    await waitFor(() => r.routed.length === 2)
+    listener.emit('disconnected', undefined)
+    listener.emit('connected', connectedInfo())
+    await waitFor(() => r.routed.length === 3)
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual([
+      '400000000000000001',
+      '400000000000000003',
+      '400000000000000002',
+    ])
+  })
+
+  test('resolves initial and reconnect waits after disconnect before first ready', async () => {
+    const recoveryStore = createInMemoryDiscordRecoveryStore()
+    await recoveryStore.markProcessed({
+      channelId: '300000000000000003',
+      workspace: '200000000000000002',
+      messageId: '400000000000000001',
+      processedAt: 1,
+    })
+    await recoveryStore.markDisconnected(2)
+    const r = router()
+    const listener = new FakeListener()
+    listener.start = async () => {
+      listener.emit('disconnected', undefined)
+      listener.emit('connected', connectedInfo())
+    }
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient({ getMessages: async () => [restMessage('400000000000000002', 'replayed')] }),
+      createListener: () => listener as unknown as DiscordListener,
+      recoveryStore,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    await waitFor(() => r.routed.length === 1)
+    listener.emit('message_create', gatewayMessage('400000000000000003', 'later'))
+    await waitFor(() => r.routed.length === 2)
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000002', '400000000000000003'])
+  })
+
+  test('replays a failed first channel message while deduplicating a newer exact success', async () => {
+    let failFirst = true
+    const r = router(async (message) => {
+      if (message.externalMessageId === '400000000000000001' && failFirst) {
+        failFirst = false
+        throw new Error('first route failed')
+      }
+    })
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getMessages: async () => [
+            restMessage('400000000000000002', 'newer success'),
+            restMessage('400000000000000001', 'failed first'),
+          ],
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+      now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+    })
+
+    await adapter.start()
+    listener.emit('message_create', gatewayMessage('400000000000000001', 'fails'))
+    listener.emit('message_create', gatewayMessage('400000000000000002', 'succeeds'))
+    await waitFor(() => r.routed.length === 1)
+    listener.emit('disconnected', undefined)
+    listener.emit('connected', connectedInfo())
+    await waitFor(() => r.routed.length === 2)
+    await adapter.stop()
+
+    expect(r.routed.map((message) => message.externalMessageId)).toEqual(['400000000000000002', '400000000000000001'])
+  })
+
+  test('recreates and replays when the first channel message fails immediately before stop', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-discord-first-failure-'))
+    try {
+      const firstListener = new FakeListener()
+      const first = createDiscordAdapter({
+        agentDir,
+        router: router(async () => {
+          throw new Error('first route failed')
+        }),
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () => fakeClient(),
+        createListener: () => firstListener as unknown as DiscordListener,
+        enrichHistoricalProvenance: async () => ({
+          scanned: 0,
+          attempted: 0,
+          resolved: 0,
+          failed: 0,
+          timedOut: 0,
+          changed: false,
+        }),
+        now: () => Date.parse('2026-01-01T00:05:00.000Z'),
+      })
+      await first.start()
+      firstListener.emit('message_create', gatewayMessage('400000000000000001', 'fails'))
+      await first.stop()
+
+      const secondRouter = router()
+      const second = createDiscordAdapter({
+        agentDir,
+        router: secondRouter,
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () => fakeClient({ getMessages: async () => [restMessage('400000000000000001', 'retry')] }),
+        createListener: () => new FakeListener() as unknown as DiscordListener,
+        enrichHistoricalProvenance: async () => ({
+          scanned: 0,
+          attempted: 0,
+          resolved: 0,
+          failed: 0,
+          timedOut: 0,
+          changed: false,
+        }),
+        now: () => Date.parse('2026-01-01T00:06:00.000Z'),
+      })
+      await second.start()
+      await waitFor(() => secondRouter.routed.length === 1)
+      await second.stop()
+
+      expect(secondRouter.routed[0]?.externalMessageId).toBe('400000000000000001')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('durable cursors survive recreation but remain isolated by authenticated account', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-discord-adapter-recovery-'))
+    try {
+      const firstStore = await loadDiscordRecoveryStore(agentDir, '100000000000000001')
+      await firstStore.markProcessed({
+        channelId: '300000000000000003',
+        workspace: '200000000000000002',
+        messageId: '400000000000000001',
+        processedAt: 1,
+      })
+      await firstStore.markDisconnected(2)
+
+      const isolated = await loadDiscordRecoveryStore(agentDir, '100000000000000099')
+      expect(isolated.listReplayCursors()).toEqual([])
+      expect((await loadDiscordRecoveryStore(agentDir, '100000000000000001')).listReplayCursors()).toHaveLength(1)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
   })
 
   test('captures Discord thread parent id and name before routing', async () => {
@@ -448,6 +1190,93 @@ describe('createDiscordAdapter', () => {
     expect(r.unregistered).toContain('outbound:discord')
     expect(r.unregistered).toContain('remove-reaction:discord')
   })
+
+  test('a stale authentication failure cannot clear a newer successful lifecycle', async () => {
+    const firstAuthStarted = deferred<void>()
+    const releaseFirstAuth = deferred<void>()
+    let authCalls = 0
+    const r = router()
+    const listeners: FakeListener[] = []
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          testAuth: async () => {
+            authCalls++
+            if (authCalls === 1) {
+              firstAuthStarted.resolve(undefined)
+              await releaseFirstAuth.promise
+              throw new Error('stale auth failed')
+            }
+            return { id: '100000000000000001', username: 'self', global_name: 'Self' }
+          },
+        }),
+      createListener: () => {
+        const created = new FakeListener()
+        listeners.push(created)
+        return created as unknown as DiscordListener
+      },
+    })
+
+    const firstResult = adapter.start().then(
+      () => 'resolved' as const,
+      () => 'rejected' as const,
+    )
+    await firstAuthStarted.promise
+    await adapter.stop()
+    await adapter.start()
+    const unregisterCount = r.unregistered.length
+    releaseFirstAuth.resolve(undefined)
+
+    expect(await firstResult).toBe('rejected')
+    expect(adapter.isConnected()).toBe(true)
+    expect(listeners).toHaveLength(1)
+    expect(listeners[0]?.stopped).toBe(false)
+    expect(r.unregistered).toHaveLength(unregisterCount)
+  })
+
+  test('a stale listener failure stops only its listener and preserves newer callbacks', async () => {
+    const firstListenerStarted = deferred<void>()
+    const releaseFirstListener = deferred<void>()
+    const firstListener = new FakeListener()
+    firstListener.start = async () => {
+      firstListenerStarted.resolve(undefined)
+      await releaseFirstListener.promise
+      throw new Error('stale listener failed')
+    }
+    const secondListener = new FakeListener()
+    const listeners = [firstListener, secondListener]
+    const r = router()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient(),
+      createListener: () => listeners.shift()! as unknown as DiscordListener,
+    })
+
+    const firstResult = adapter.start().then(
+      () => 'resolved' as const,
+      () => 'rejected' as const,
+    )
+    await firstListenerStarted.promise
+    await adapter.stop()
+    await adapter.start()
+    const unregisterCount = r.unregistered.length
+    releaseFirstListener.resolve(undefined)
+
+    expect(await firstResult).toBe('rejected')
+    expect(adapter.isConnected()).toBe(true)
+    expect(firstListener.stopped).toBe(true)
+    expect(secondListener.stopped).toBe(false)
+    expect(r.unregistered).toHaveLength(unregisterCount)
+    secondListener.emit('message_create', gatewayMessage('400000000000000099', 'still live'))
+    await waitFor(() => r.routed.length === 1)
+  })
 })
 
 describe('createDiscordHistoryCallback', () => {
@@ -569,4 +1398,46 @@ function fakeClient(
     removeReaction: async () => {},
     ...overrides,
   } as unknown as ReturnType<NonNullable<Parameters<typeof createDiscordAdapter>[0]['createClient']>>
+}
+
+function connectedInfo() {
+  return { user: { id: '100000000000000001', username: 'self' }, sessionId: 'session-reconnect' }
+}
+
+function gatewayMessage(id: string, content: string): DiscordGatewayMessageCreateEvent {
+  return {
+    type: 'MESSAGE_CREATE',
+    id,
+    channel_id: '300000000000000003',
+    guild_id: '200000000000000002',
+    author: { id: '500000000000000005', username: 'alice' },
+    content,
+    timestamp: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+function restMessage(id: string, content: string) {
+  const { type: _type, guild_id: _guildId, ...message } = gatewayMessage(id, content)
+  return message
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolvePromise: ((value: T) => void) | undefined
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return {
+    promise,
+    resolve: (value) => {
+      resolvePromise?.(value)
+    },
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = performance.now() + timeoutMs
+  while (!predicate()) {
+    if (performance.now() >= deadline) throw new Error('timed out waiting for condition')
+    await Bun.sleep(1)
+  }
 }

--- a/src/channels/adapters/discord.ts
+++ b/src/channels/adapters/discord.ts
@@ -44,6 +44,20 @@ import {
 } from './discord-classify'
 import { createDiscordUserEditMessageCallback } from './discord-edit'
 import { createDiscordReactionCallback, createDiscordRemoveReactionCallback } from './discord-reactions'
+import {
+  createInMemoryDiscordRecoveryStore,
+  DISCORD_RECOVERY_REQUEST_TIMEOUT_MS,
+  fetchDiscordRecovery,
+  loadDiscordRecoveryStore,
+  settleWithin,
+  type DiscordRecoveryCursor,
+  type DiscordRecoveryStore,
+} from './discord-recovery'
+
+const DISCORD_RECOVERY_MAX_CHANNELS = 20
+const DISCORD_RECOVERY_MAX_TOTAL_MESSAGES = 100
+const DISCORD_RECOVERY_MAX_DURATION_MS = 20_000
+const DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS = 5_000
 
 export type DiscordAdapterLogger = {
   info: (msg: string) => void
@@ -72,6 +86,10 @@ export type DiscordAdapterOptions = {
   createListener?: (client: DiscordClient) => DiscordListener
   fetchImpl?: typeof fetch
   enrichHistoricalProvenance?: typeof enrichHistoricalProvenance
+  recoveryStore?: DiscordRecoveryStore
+  now?: () => number
+  recoveryMaxDurationMs?: number
+  disconnectDrainTimeoutMs?: number
 }
 
 export type DiscordAdapter = {
@@ -209,8 +227,19 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
   let token: string | null = null
   let connected = false
   let started = false
+  let lifecycleGeneration = 0
   let inflightInbounds = 0
+  const inflightOperations = new Set<Promise<void>>()
+  const pendingInbounds = new Map<symbol, DiscordRecoveryCursor>()
   let stopWaiters: Array<() => void> = []
+  let recoveryStore = options.recoveryStore ?? null
+  let recoveryBarrier = Promise.resolve()
+  let pendingInitialConnect: { promise: Promise<void>; resolve: () => void } | null = null
+  let pendingReconnect: { promise: Promise<void>; resolve: () => void } | null = null
+  const channelBarriers = new Map<string, Promise<void>>()
+  const now = options.now ?? Date.now
+  const recoveryMaxDurationMs = options.recoveryMaxDurationMs ?? DISCORD_RECOVERY_MAX_DURATION_MS
+  const disconnectDrainTimeoutMs = options.disconnectDrainTimeoutMs ?? DISCORD_DISCONNECT_DRAIN_TIMEOUT_MS
 
   const channelResolver = createDiscordChannelResolver({ client })
   const authorResolver = createDiscordAuthorResolver({ client })
@@ -235,91 +264,369 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
   const removeReactionCallback = createDiscordRemoveReactionCallback({ client })
   const editMessageCallback = createDiscordUserEditMessageCallback({ client })
 
-  const handleMessage = async (event: DiscordGatewayMessageCreateEvent): Promise<void> => {
+  const processMessage = async (event: DiscordGatewayMessageCreateEvent): Promise<boolean> => {
+    const verdict = classifyInbound(event, options.configRef(), {
+      selfUserId,
+      selfAliases: options.selfAliasesRef?.() ?? [],
+    })
+    const tag = event.guild_id === undefined ? `channel=${event.channel_id}` : await formatChannelTag(event.channel_id)
+    logger.info(
+      `[discord] inbound id=${event.id} author=${event.author.id || '(none)'} ${tag} text_len=${event.content.length}`,
+    )
+    if (verdict.kind === 'drop') {
+      logger.info(`[discord] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+      return false
+    }
+    const attachments = (event.attachments ?? []).map((file, index) => ({
+      id: index + 1,
+      kind: 'file' as const,
+      ref: file.url,
+      filename: file.filename,
+      mimetype: file.content_type,
+    }))
+    const room = verdict.payload.isDm ? undefined : await channelResolver.resolveRoom(verdict.payload.chat)
+    const payload = {
+      ...verdict.payload,
+      authorName: await authorResolver.resolve(verdict.payload.authorId),
+      ...(room !== undefined ? { room } : {}),
+      ...(attachments.length > 0 ? { attachments } : {}),
+    }
+    logger.info(`[discord] routed id=${event.id} ${tag} mention=${payload.isBotMention}`)
+    await options.router.route(payload)
+    return true
+  }
+
+  const trackInbound = (operation: Promise<void>): Promise<void> => {
     inflightInbounds++
-    try {
-      const verdict = classifyInbound(event, options.configRef(), {
-        selfUserId,
-        selfAliases: options.selfAliasesRef?.() ?? [],
-      })
-      const tag =
-        event.guild_id === undefined ? `channel=${event.channel_id}` : await formatChannelTag(event.channel_id)
-      logger.info(
-        `[discord] inbound id=${event.id} author=${event.author.id || '(none)'} ${tag} text_len=${event.content.length}`,
-      )
-      if (verdict.kind === 'drop') {
-        logger.info(`[discord] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
-        return
-      }
-      const attachments = (event.attachments ?? []).map((file, index) => ({
-        id: index + 1,
-        kind: 'file' as const,
-        ref: file.url,
-        filename: file.filename,
-        mimetype: file.content_type,
-      }))
-      const room = verdict.payload.isDm ? undefined : await channelResolver.resolveRoom(verdict.payload.chat)
-      const payload = {
-        ...verdict.payload,
-        authorName: await authorResolver.resolve(verdict.payload.authorId),
-        ...(room !== undefined ? { room } : {}),
-        ...(attachments.length > 0 ? { attachments } : {}),
-      }
-      logger.info(`[discord] routed id=${event.id} ${tag} mention=${payload.isBotMention}`)
-      await options.router.route(payload)
-    } catch (err) {
-      logger.error(`[discord] handleInbound failed: ${describeError(err)}`)
-    } finally {
+    inflightOperations.add(operation)
+    return operation.finally(() => {
+      inflightOperations.delete(operation)
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
         const waiters = stopWaiters
         stopWaiters = []
         for (const w of waiters) w()
       }
+    })
+  }
+
+  const enqueueChannelOperation = <T>(channelId: string, operation: () => Promise<T>): Promise<T> => {
+    const previous = channelBarriers.get(channelId) ?? Promise.resolve()
+    const queued = previous.then(operation)
+    const barrier = queued.then(
+      () => undefined,
+      () => undefined,
+    )
+    channelBarriers.set(channelId, barrier)
+    void barrier.finally(() => {
+      if (channelBarriers.get(channelId) === barrier) channelBarriers.delete(channelId)
+    })
+    return queued
+  }
+
+  const enqueueChannelInbound = (channelId: string, operation: () => Promise<void>): Promise<void> => {
+    const recoveryGate = recoveryBarrier
+    return trackInbound(recoveryGate.then(() => enqueueChannelOperation(channelId, operation)))
+  }
+
+  const enqueueRecovery = (operation: () => Promise<void>): Promise<void> => {
+    const queued = recoveryBarrier.then(operation)
+    recoveryBarrier = queued.catch(() => undefined)
+    return trackInbound(queued)
+  }
+
+  const handleMessage = (event: DiscordGatewayMessageCreateEvent, acceptedGeneration: number): Promise<void> => {
+    if (!started || acceptedGeneration !== lifecycleGeneration) return Promise.resolve()
+    const pendingKey = Symbol(event.id)
+    pendingInbounds.set(pendingKey, {
+      channelId: event.channel_id,
+      workspace: event.guild_id ?? '@dm',
+      messageId: event.id,
+      processedAt: now(),
+    })
+    const operation = enqueueChannelInbound(event.channel_id, async () => {
+      if (recoveryStore?.isProcessed(event.channel_id, event.id) === true) {
+        logger.info(`[discord] deduplicated id=${event.id} channel=${event.channel_id}`)
+        return
+      }
+      try {
+        await processMessage(event)
+        await recoveryStore?.markProcessed({
+          channelId: event.channel_id,
+          workspace: event.guild_id ?? '@dm',
+          messageId: event.id,
+          processedAt: now(),
+        })
+      } catch (err) {
+        logger.error(`[discord] handleInbound failed: ${describeError(err)}`)
+        try {
+          await recoveryStore?.markRouteFailed({
+            channelId: event.channel_id,
+            workspace: event.guild_id ?? '@dm',
+            failedMessageId: event.id,
+            failedAt: now(),
+          })
+        } catch (persistError) {
+          logger.error(`[discord] failed to retain route gap: ${describeError(persistError)}`)
+        }
+      }
+    })
+    return operation.finally(() => {
+      pendingInbounds.delete(pendingKey)
+    })
+  }
+
+  const replayAfterReconnect = async (): Promise<void> => {
+    if (!started || recoveryStore === null) return
+    const store = recoveryStore
+    const disconnectedAt = store.disconnectedAt()
+    if (disconnectedAt === null) return
+    const replayEpoch = store.currentEpoch()
+
+    const downtimeMs = Math.max(0, now() - disconnectedAt)
+    const deadline = performance.now() + recoveryMaxDurationMs
+    const replayCursors = store.listReplayCursors().sort((left, right) => right.processedAt - left.processedAt)
+    const selectedCursors = replayCursors.slice(0, DISCORD_RECOVERY_MAX_CHANNELS)
+    let remainingMessages = DISCORD_RECOVERY_MAX_TOTAL_MESSAGES
+    let replayed = 0
+    let skipped = 0
+    let cappedChannels = replayCursors.length - selectedCursors.length
+    let unavailableChannels = 0
+    let deadlineReached = false
+
+    cursorLoop: for (const [cursorIndex, cursor] of selectedCursors.entries()) {
+      if (!started) break
+      const fetchBudgetMs = deadline - performance.now()
+      if (remainingMessages === 0) {
+        cappedChannels += selectedCursors.length - cursorIndex
+        break
+      }
+      if (fetchBudgetMs <= 0) {
+        deadlineReached = true
+        cappedChannels += selectedCursors.length - cursorIndex
+        break
+      }
+      const fetched = await settleWithin(
+        fetchDiscordRecovery({
+          client,
+          channelId: cursor.channelId,
+          workspace: cursor.workspace,
+          after: cursor.messageId,
+          now: now(),
+          requestTimeoutMs: Math.min(DISCORD_RECOVERY_REQUEST_TIMEOUT_MS, fetchBudgetMs),
+        }),
+        fetchBudgetMs,
+      )
+      if (!started) break
+      if (fetched.kind === 'timed-out') {
+        deadlineReached = true
+        cappedChannels += selectedCursors.length - cursorIndex
+        break
+      }
+      if (fetched.kind === 'failed') {
+        unavailableChannels++
+        logger.warn(
+          `[discord] replay downtime_ms=${downtimeMs} outcome=unavailable channel=${cursor.channelId} error=${describeError(fetched.error)}`,
+        )
+        continue
+      }
+      const result = fetched.value
+      if (!result.ok) {
+        unavailableChannels++
+        logger.warn(
+          `[discord] replay downtime_ms=${downtimeMs} outcome=unavailable channel=${cursor.channelId} error=${result.error}`,
+        )
+        continue
+      }
+
+      let cursorCompleted = true
+      if (result.outcome === 'capped') {
+        cappedChannels++
+        skipped += result.skipped
+        logger.warn(
+          `[discord] replay downtime_ms=${downtimeMs} outcome=capped channel=${cursor.channelId} skipped_age=${result.skippedByAge} skipped_count=${result.skippedByCount} more_may_exist=${String(result.moreMayExist)}`,
+        )
+      }
+      const aggregateOverflow = Math.max(0, result.messages.length - remainingMessages)
+      if (aggregateOverflow > 0) {
+        cursorCompleted = false
+        cappedChannels++
+        skipped += aggregateOverflow
+        logger.warn(
+          `[discord] replay downtime_ms=${downtimeMs} outcome=capped channel=${cursor.channelId} skipped_aggregate=${aggregateOverflow}`,
+        )
+      }
+      const messages = result.messages.slice(0, remainingMessages)
+      remainingMessages -= messages.length
+      for (const [messageIndex, message] of messages.entries()) {
+        if (!started) {
+          cursorCompleted = false
+          break cursorLoop
+        }
+        if (performance.now() >= deadline) {
+          cursorCompleted = false
+          deadlineReached = true
+          skipped += messages.length - messageIndex
+          cappedChannels += selectedCursors.length - cursorIndex - 1
+          break cursorLoop
+        }
+        const delivery = await enqueueChannelOperation(message.channel_id, async () => {
+          if (!started) return 'stopped' as const
+          if (store.isReplayProcessed(message.channel_id, message.id)) return 'deduplicated' as const
+          try {
+            await processMessage(toGatewayMessage(message, cursor.workspace))
+            await store.markProcessed({
+              channelId: message.channel_id,
+              workspace: cursor.workspace,
+              messageId: message.id,
+              processedAt: now(),
+            })
+            return 'replayed' as const
+          } catch (err) {
+            logger.error(
+              `[discord] replay downtime_ms=${downtimeMs} outcome=route_failed channel=${cursor.channelId} id=${message.id} error=${describeError(err)}`,
+            )
+            return 'failed' as const
+          }
+        })
+        if (delivery === 'replayed') replayed++
+        else if (delivery === 'failed' || delivery === 'stopped') {
+          cursorCompleted = false
+          if (delivery === 'failed') unavailableChannels++
+          break
+        }
+      }
+      if (cursorCompleted && started) await store.completeReplay(cursor.channelId, replayEpoch)
     }
+
+    if (!started) return
+    if (deadlineReached) {
+      logger.warn(
+        `[discord] replay downtime_ms=${downtimeMs} outcome=capped reason=duration duration_limit_ms=${recoveryMaxDurationMs}`,
+      )
+    }
+    if (replayCursors.length > selectedCursors.length) {
+      logger.warn(
+        `[discord] replay downtime_ms=${downtimeMs} outcome=capped skipped_channels=${replayCursors.length - selectedCursors.length} channel_limit=${DISCORD_RECOVERY_MAX_CHANNELS} message_limit=${DISCORD_RECOVERY_MAX_TOTAL_MESSAGES} duration_limit_ms=${recoveryMaxDurationMs}`,
+      )
+    }
+    const outcome = unavailableChannels > 0 ? 'partial' : cappedChannels > 0 ? 'capped' : 'succeeded'
+    const log = unavailableChannels > 0 || cappedChannels > 0 ? logger.warn : logger.info
+    log(
+      `[discord] replay downtime_ms=${downtimeMs} outcome=${outcome} replayed=${replayed} skipped_observed=${skipped} capped_channels=${cappedChannels} unavailable_channels=${unavailableChannels}`,
+    )
   }
 
   return {
     async start(): Promise<void> {
       if (started) return
       started = true
+      const generation = ++lifecycleGeneration
+      let startInitialConnectSignal: { promise: Promise<void>; resolve: () => void } | null = null
       try {
         const account = await (options.credentialsStore ?? null)?.getAccount()
         if (account === null || account === undefined) {
           throw new Error('no Discord account in secrets.json#channels.discord (run typeclaw init to authenticate)')
         }
-        token = account.token
         await client.login({ token: account.token })
         const auth = await client.testAuth()
+        const loadedRecoveryStore =
+          recoveryStore ??
+          (options.agentDir === undefined
+            ? createInMemoryDiscordRecoveryStore(auth.id)
+            : await loadDiscordRecoveryStore(options.agentDir, auth.id, logger))
+        if (!started || generation !== lifecycleGeneration) throw new Error('Discord adapter stopped during start')
+        token = account.token
         selfUserId = auth.id
         selfName = auth.global_name ?? auth.username
+        recoveryStore = loadedRecoveryStore
         logger.info(`[discord] authenticated as ${selfName} (${selfUserId})`)
+        if (recoveryStore.disconnectedAt() !== null) {
+          startInitialConnectSignal = createSignal()
+          pendingInitialConnect = startInitialConnectSignal
+          const signal = startInitialConnectSignal
+          void enqueueRecovery(async () => {
+            await signal.promise
+            if (started && generation === lifecycleGeneration) await replayAfterReconnect()
+          }).catch((err) => {
+            logger.error(`[discord] replay failed: ${describeError(err)}`)
+          })
+        }
       } catch (err) {
-        started = false
-        selfUserId = null
-        token = null
+        if (generation === lifecycleGeneration) {
+          started = false
+          selfUserId = null
+          token = null
+        }
         logger.error(`[discord] login failed: ${describeError(err)}`)
         throw err
       }
 
-      listener = createListener(client)
+      const startListener = createListener(client)
+      listener = startListener
       let listenerConnected = false
       let listenerStartupError: Error | null = null
       listener.on('connected', (info) => {
+        if (!started || generation !== lifecycleGeneration) return
         listenerConnected = true
         connected = true
         selfUserId = info.user.id
         selfName = info.user.username
+        const initialConnect = pendingInitialConnect
+        const reconnect = pendingReconnect
+        if (initialConnect !== null) {
+          pendingInitialConnect = null
+          initialConnect.resolve()
+        }
+        if (reconnect !== null) {
+          pendingReconnect = null
+          reconnect.resolve()
+        }
       })
       listener.on('disconnected', () => {
+        if (generation !== lifecycleGeneration) return
         connected = false
+        if (started && pendingReconnect === null) {
+          const reconnect = createSignal()
+          pendingReconnect = reconnect
+          const disconnectedAt = now()
+          const pendingChannels = Array.from(inflightOperations)
+          const pendingMetadata = Array.from(pendingInbounds.entries())
+          void enqueueRecovery(async () => {
+            const drain = await settleWithin(
+              Promise.all(pendingChannels).then(() => undefined),
+              disconnectDrainTimeoutMs,
+            )
+            if (drain.kind === 'timed-out') {
+              logger.warn(
+                `[discord] disconnect drain timed out after ${disconnectDrainTimeoutMs}ms; snapshotting pending anchors`,
+              )
+              for (const [pendingKey, pending] of pendingMetadata) {
+                if (!pendingInbounds.has(pendingKey)) continue
+                await recoveryStore?.markRouteFailed({
+                  channelId: pending.channelId,
+                  workspace: pending.workspace,
+                  failedMessageId: pending.messageId,
+                  failedAt: pending.processedAt,
+                })
+              }
+            }
+            if (started && generation === lifecycleGeneration) {
+              await recoveryStore?.markDisconnected(disconnectedAt)
+            }
+            await reconnect.promise
+            if (started && generation === lifecycleGeneration) await replayAfterReconnect()
+          }).catch((err) => {
+            logger.error(`[discord] failed to persist disconnect: ${describeError(err)}`)
+          })
+        }
         logger.warn('[discord] disconnected')
       })
       listener.on('error', (err) => {
         if (!listenerConnected && listenerStartupError === null) listenerStartupError = err
         logger.error(`[discord] listener error: ${describeError(err)}`)
       })
-      listener.on('message_create', (event) => void handleMessage(event))
+      listener.on('message_create', (event) => void handleMessage(event, generation))
       listener.on('message_reaction_add', (event) =>
         logger.info(
           `[discord] reaction_added channel=${event.channel_id} message=${event.message_id} emoji=${event.emoji.name}`,
@@ -334,21 +641,31 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
       registerCallbacks(options.router)
 
       const rollbackStart = (reason: string, cause: Error): never => {
-        unregisterCallbacks(options.router)
-        listener?.stop()
-        listener = null
-        selfUserId = null
-        token = null
-        connected = false
-        started = false
+        startListener.stop()
+        startInitialConnectSignal?.resolve()
+        if (pendingInitialConnect === startInitialConnectSignal) pendingInitialConnect = null
+        if (generation === lifecycleGeneration) {
+          unregisterCallbacks(options.router)
+          if (listener === startListener) listener = null
+          selfUserId = null
+          token = null
+          connected = false
+          started = false
+          pendingReconnect?.resolve()
+          pendingReconnect = null
+          if (options.recoveryStore === undefined) recoveryStore = null
+        }
         logger.error(`[discord] ${reason}: ${describeError(cause)}`)
         throw cause
       }
 
       try {
-        await listener.start()
+        await startListener.start()
       } catch (err) {
         rollbackStart('listener start threw', err instanceof Error ? err : new Error(describeError(err)))
+      }
+      if (!started || generation !== lifecycleGeneration) {
+        rollbackStart('listener start superseded', new Error('Discord adapter stopped during listener start'))
       }
       if (!listenerConnected) {
         rollbackStart(
@@ -396,7 +713,13 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
 
     async stop(): Promise<void> {
       if (!started) return
+      const disconnectedAt = now()
       started = false
+      lifecycleGeneration++
+      pendingInitialConnect?.resolve()
+      pendingInitialConnect = null
+      pendingReconnect?.resolve()
+      pendingReconnect = null
       unregisterCallbacks(options.router)
       listener?.stop()
       listener = null
@@ -406,8 +729,14 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
           stopWaiters.push(resolve)
         })
       }
+      try {
+        await recoveryStore?.markDisconnected(disconnectedAt)
+      } catch (err) {
+        logger.error(`[discord] failed to persist stop recovery snapshot: ${describeError(err)}`)
+      }
       selfUserId = null
       token = null
+      if (options.recoveryStore === undefined) recoveryStore = null
     },
 
     isConnected(): boolean {
@@ -472,6 +801,22 @@ function mapDiscordHistoryMessage(msg: DiscordMessage): ChannelHistoryMessage {
 function parseDiscordTimestamp(timestamp: string): number {
   const millis = Date.parse(timestamp)
   return Number.isFinite(millis) ? millis : 0
+}
+
+function toGatewayMessage(message: DiscordMessage, workspace: string): DiscordGatewayMessageCreateEvent {
+  return {
+    ...message,
+    type: 'MESSAGE_CREATE',
+    guild_id: workspace === '@dm' ? undefined : workspace,
+  }
+}
+
+function createSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolvePromise: (() => void) | undefined
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: () => resolvePromise?.() }
 }
 
 const DISCORD_ATTACHMENT_HOSTS = new Set(['cdn.discordapp.com', 'media.discordapp.net'])


### PR DESCRIPTION
## Background

The user-token `discord` adapter resumed listening after gateway reconnects without reconciling messages that arrived during the gap. It needs recovery wiring separate from `discord-bot` because it has its own connection lifecycle and user-token credential model.

## What changed

- Add an account-scoped, per-channel recovery store with atomic locked writes, bounded state, strict validation, and stale-replay epochs.
- Snapshot cursors on disconnect, graceful stop, and route failure, then replay bounded REST history before live delivery resumes.
- Serialize replay and live messages per channel, including events received before READY or during reconnect, while deduplicating exact processed IDs.
- Preserve pending anchors across unavailable, timed-out, capped, or superseded replay passes.
- Fence stale start/stop callbacks with lifecycle generations and drain accepted inbound work safely.
- Document recovery bounds and the user SDK latest-history limitation.

## Recovery bounds

Each pass is limited to 50 messages per channel, messages from the last 30 minutes, 20 channels, 100 messages total, and 20 seconds. Capped and unavailable outcomes are logged. Recovery state is local and gitignored; it reduces reconnect loss but does not guarantee exactly-once delivery across process crashes.

## Verification

- Focused Discord suites: 52 pass, 0 fail
- Full suite: 13,467 pass, 32 skip, 0 fail
- `bun run typecheck`
- `bun run lint` — 0 errors
- `bun run format:check`

Closes #1412