### PR TITLE
Broker git clone flags and fix gh in shell reserved-word position

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -311,7 +311,25 @@ describe('analyzeGhCommand', () => {
   it('blocks a repo-targeting subcommand with no repo specified', () => {
     const result = analyzeGhCommand('gh pr view 12')
     expect(result.kind).toBe('block')
-    if (result.kind === 'block') expect(result.reason).toContain('-R')
+    if (result.kind === 'block') {
+      expect(result.code).toBe('missing-repo')
+      expect(result.reason).toContain('owner/repo')
+    }
+  })
+
+  it('does not blame a multi-owner App when the repo is simply undeterminable', () => {
+    const result = analyzeGhCommand('gh repo list acme --limit 100')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') {
+      expect(result.code).toBe('missing-repo')
+      expect(result.reason).not.toContain('multiple owners')
+    }
+  })
+
+  it('still blames multiple owners when the command really spans owners', () => {
+    const result = analyzeGhCommand('gh api /repos/acme/widgets/compare/main...attacker:branch')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.reason).toContain('more than one owner')
   })
 
   it('blocks gh pr create without a repo', () => {
@@ -1030,6 +1048,58 @@ describe('canInjectPatIntoPassThroughGh', () => {
   it('rejects shell-active backslashes outside single quotes', () => {
     expect(canInjectPatIntoPassThroughGh('gh api /user \\--input /proc/self/environ')).toBe(false)
     expect(canInjectPatIntoPassThroughGh('gh api /user --jq "gsub(\\"\\n\\"; \\"\\")"')).toBe(false)
+  })
+})
+
+describe('gh in a shell reserved-word command position', () => {
+  // The incident shape. The invariant is that it BLOCKS at all: it previously
+  // reached pass-through and ran bare `gh`, which emitted gh's stock "run
+  // `gh auth login`" advice — guidance the agent cannot act on and which names
+  // nothing about TypeClaw. The specific code varies ( `[ ... ]` test brackets
+  // trip the pathname-expansion gate before the composition gate).
+  it('blocks a repo-targeting gh inside `if ...; then ... fi` instead of passing it through', () => {
+    const result = analyzeGhCommand(
+      'mkdir -p /tmp/repos && if [ ! -d /tmp/repos/acme/widgets/.git ]; then ' +
+        'gh repo view acme/widgets --json defaultBranchRef; fi',
+    )
+    expect(result.kind).toBe('block')
+  })
+
+  it('reports a bracket-free `then` compound as a composition block', () => {
+    const result = analyzeGhCommand('if true; then gh label list -R acme/widgets; fi')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.code).toBe('composition')
+  })
+
+  it('blocks a repo-targeting gh after `do` and after `else`', () => {
+    for (const command of [
+      'for r in a; do gh label list -R acme/widgets; done',
+      'if false; then true; else gh label list -R acme/widgets; fi',
+    ]) {
+      const result = analyzeGhCommand(command)
+      expect(result.kind).toBe('block')
+      if (result.kind === 'block') expect(result.code).toBe('composition')
+    }
+  })
+
+  it('does NOT treat `then`/`do` as a boundary when they are ordinary arguments', () => {
+    expect(analyzeGhCommand('echo then gh').kind).toBe('pass-through')
+    expect(analyzeGhCommand('echo do gh').kind).toBe('pass-through')
+  })
+
+  it('does NOT treat a quoted `then gh` string as an invocation', () => {
+    expect(analyzeGhCommand('echo "; then gh label list"').kind).toBe('pass-through')
+  })
+
+  it('keeps a standalone bare gh injectable (the reserved-word rule must not over-block)', () => {
+    expect(analyzeGhCommand('gh label list -R acme/widgets')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
+
+  it('leaves a shell construct with no gh invocation alone', () => {
+    expect(analyzeGhCommand('if [ -d /tmp/x ]; then rg pattern /tmp/x; fi').kind).toBe('pass-through')
   })
 })
 

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -21,11 +21,15 @@ export type GhCommandDecision =
   // (REST, non-`api` subcommands) leave the command unchanged and omit it.
   | { kind: 'inject'; repoSlug: string; rewrittenCommand?: string }
 
+// Reached whenever no EFFECTIVE DESTINATION repo can be determined — which is not
+// the same as "argv has no slug": `gh label clone owner/repo` names a literal SOURCE
+// slug and still lands here because the destination is what a token would be scoped
+// to. The message must not assert a multi-owner App (MULTI_OWNER_REASON below covers
+// that, and a single-owner App hitting this text reports a cause that is simply false).
 const MISSING_REPO_REASON =
-  'This GitHub App spans multiple owners, so `gh` has no single correct token. ' +
-  'Re-run as a single bare command with a LITERAL repo: `gh <cmd> -R owner/repo` ' +
-  '(or `gh api /repos/owner/repo/...`) so the right installation token can be injected. ' +
-  'The repo must be a concrete `owner/repo` slug, not a shell variable.'
+  'TypeClaw could not determine the effective destination repository for this `gh` command, ' +
+  'so it cannot mint a scoped installation token. Re-run as a single bare command that names a ' +
+  'LITERAL `owner/repo` slug TypeClaw can read from argv — not a shell variable.'
 
 const NON_LITERAL_REPO_REASON =
   'The `-R/--repo` value is not a literal `owner/repo` slug TypeClaw can verify. ' +
@@ -1484,12 +1488,22 @@ function findGhInvocations(tokens: readonly string[]): number[] {
   return starts
 }
 
+// bash treats `then`/`else`/`do` as reserved words ONLY in command position, and each
+// opens a fresh command position after it. Recognizing them is what makes
+// `if ...; then gh ...; fi` reach the composition gate — without it findGhInvocations
+// sees no invocation at all and the whole command silently passes through
+// unauthenticated, which is neither the documented policy nor a usable failure.
+// The recursion is what keeps `echo then gh` from registering: there, `then` is a
+// plain argument (not preceded by a boundary), so it opens nothing.
+const RESERVED_COMMAND_OPENERS = new Set(['then', 'else', 'do'])
+
 function isCommandBoundaryBefore(tokens: readonly string[], index: number): boolean {
   let cursor = index - 1
   while (cursor >= 0) {
     const prev = tokens[cursor]
     if (prev === undefined) return false
     if (prev === '&&' || prev === '||' || prev === '|' || prev === ';' || prev === '\n') return true
+    if (RESERVED_COMMAND_OPENERS.has(prev)) return isCommandBoundaryBefore(tokens, cursor)
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(prev)) {
       cursor -= 1
       continue

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -127,6 +127,62 @@ describe('analyzeGitCommand — pass-through', () => {
   })
 })
 
+describe('analyzeGitCommand — clone flags', () => {
+  // A shallow, branch-limited clone is the ordinary shape for code analysis on a
+  // large repo. Without a credential it fails on a private repo with git's opaque
+  // "could not read Username", which names neither the policy nor a way forward.
+  test.each([
+    'git clone --depth 1 https://github.com/acme/widgets.git /tmp/w',
+    'git clone --depth=1 https://github.com/acme/widgets.git',
+    'git clone -b main --depth 1 https://github.com/acme/widgets.git /tmp/w',
+    'git clone --single-branch --no-tags --depth 1 https://github.com/acme/widgets.git /tmp/w',
+    'git clone --filter=blob:none https://github.com/acme/widgets.git /tmp/w',
+    'git clone -q --no-checkout https://github.com/acme/widgets.git /tmp/w',
+  ])('mints for an inert clone flag: %s', async (command) => {
+    expect(await analyze(command)).toMatchObject({ kind: 'inject', repoSlug: 'acme/widgets', access: 'read' })
+  })
+
+  // Each of these can redirect the fetch to another repo/host, execute a command, or
+  // read/write an arbitrary path while a scoped token is live. They must never mint.
+  test.each([
+    'git clone --recurse-submodules https://github.com/acme/widgets.git /tmp/w',
+    'git clone -c url.https://evil/.insteadOf=https://github.com/ https://github.com/acme/widgets.git /tmp/w',
+    'git clone --upload-pack=/bin/sh https://github.com/acme/widgets.git /tmp/w',
+    'git clone --separate-git-dir=/tmp/evil https://github.com/acme/widgets.git /tmp/w',
+    'git clone --template=/tmp/t https://github.com/acme/widgets.git /tmp/w',
+    'git clone --reference /tmp/other https://github.com/acme/widgets.git /tmp/w',
+  ])('refuses to mint for a redirecting or path-touching clone flag: %s', async (command) => {
+    expect((await analyze(command)).kind).toBe('pass-through')
+  })
+
+  test.each([
+    'git clone --depth 1 https://github.com/acme/widgets.git /tmp/w && rg reward /tmp/w',
+    'git clone --depth 1 -b main https://github.com/acme/widgets.git /tmp/w && ls /tmp/w',
+    'git clone --single-branch --no-tags --depth 1 https://github.com/acme/widgets.git /tmp/w && grep -rn x /tmp/w',
+  ])('mints for clone-then-inspect with inert flags: %s', async (command) => {
+    const decision = await analyze(command)
+    expect(decision).toMatchObject({ kind: 'inject', repoSlug: 'acme/widgets', access: 'read' })
+  })
+
+  test('rebuilds the clone-then-inspect head canonically with every token quoted', async () => {
+    const decision = await analyze('git clone --depth 1 https://github.com/acme/widgets.git /tmp/w && rg reward /tmp/w')
+    expect(decision.kind).toBe('inject')
+    if (decision.kind !== 'inject') return
+    expect(decision.rewrittenCommand?.split(' && ')[0]).toBe(
+      "/usr/bin/git clone '--depth' '1' 'https://github.com/acme/widgets.git' '/tmp/w'",
+    )
+  })
+
+  test.each([
+    "git clone --depth '1;evil' https://github.com/acme/widgets.git /tmp/w && ls /tmp/w",
+    'git clone --upload-pack=/bin/sh https://github.com/acme/widgets.git /tmp/w && ls /tmp/w',
+    'git clone -c core.sshCommand=evil https://github.com/acme/widgets.git /tmp/w && ls /tmp/w',
+    'git clone --recurse-submodules https://github.com/acme/widgets.git /tmp/w && ls /tmp/w',
+  ])('refuses clone-then-inspect for an unsafe flag or value: %s', async (command) => {
+    expect((await analyze(command)).kind).not.toBe('inject')
+  })
+})
+
 describe('analyzeGitCommand — inject (explicit url)', () => {
   test('clone https', async () => {
     expect(await analyze('git clone https://github.com/acme/widgets.git')).toEqual({
@@ -1001,9 +1057,20 @@ describe('analyzeGitCommand — clone-then-inspect (sanitized re-exec)', () => {
     expect((await analyze(cmd, ghRemote)).kind).not.toBe('inject')
   })
 
-  test('a strict-grammar head with flags is not rewritten (no-flags grammar avoids clone --config)', async () => {
+  // The head grammar admits flags only from the inert allowlist. `--config`/`-c` is
+  // the threat the original no-flags rule existed to stop (it can set url.insteadOf
+  // or core.sshCommand while the token is live) and stays refused; a blanket no-flags
+  // rule also refused `--depth`, which broke shallow clone for code analysis.
+  test.each([
+    'git clone --config core.sshCommand=evil https://github.com/acme/widgets.git /tmp/x && ls',
+    'git clone -c url.https://evil/.insteadOf=https://github.com/ https://github.com/acme/widgets.git /tmp/x && ls',
+  ])('a clone --config head is still never rewritten: %s', async (cmd) => {
+    expect((await analyze(cmd, ghRemote)).kind).not.toBe('inject')
+  })
+
+  test('an inert flag IS accepted by the strict head grammar', async () => {
     const result = await analyze('git clone --depth 1 https://github.com/acme/widgets.git /tmp/x && ls', ghRemote)
-    expect(result.kind).not.toBe('inject')
+    expect(result).toMatchObject({ kind: 'inject', repoSlug: 'acme/widgets', access: 'read' })
   })
 
   test('a url with embedded credentials/port is not accepted by the strict head grammar', async () => {

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -298,8 +298,56 @@ function parseMintableTarget(subcommand: RemoteSubcommand, args: readonly string
   if (subcommand === 'push') return parseMintablePush(args)
   if (subcommand === 'fetch') return parseMintableFetch(args)
   if (subcommand === 'pull') return parseSimpleRemote(args, false)
-  if (subcommand === 'clone') return parseExplicitUrl(args, 2)
+  if (subcommand === 'clone') return parseCloneTarget(args)
   return parseExplicitUrl(args, Number.POSITIVE_INFINITY)
+}
+
+// Value-less clone flags that cannot redirect the fetch to another repo/host, run a
+// command, or read/write a path outside the destination. Deliberately EXCLUDES
+// --recurse-submodules (fetches other repos with the token live), --upload-pack and
+// -c/--config (command execution / url.insteadOf rewriting), and --template,
+// --reference, --separate-git-dir (arbitrary path read/write).
+const SAFE_CLONE_FLAGS = new Set([
+  '-q',
+  '--quiet',
+  '--progress',
+  '-n',
+  '--no-checkout',
+  '--single-branch',
+  '--no-single-branch',
+  '--no-tags',
+  '--bare',
+  '--sparse',
+])
+
+// Clone flags that consume the NEXT argv word as their value.
+const SAFE_CLONE_VALUE_FLAGS = new Set(['--depth', '-b', '--branch'])
+
+// `--flag=value` forms whose value is inert (a count, ref, date, or filter spec).
+const SAFE_CLONE_INLINE_PREFIXES = ['--depth=', '--branch=', '--filter=', '--shallow-since=', '--shallow-exclude=']
+
+// git clone's URL is a POSITIONAL, so the previous fixed-index parse rejected every
+// flagged clone — `--depth 1`, the most common shape in code-analysis workflows, got
+// no credential and failed on a private repo with git's opaque "could not read
+// Username". Skipping a conservative flag allowlist finds the same positional while
+// any unrecognized flag still falls through to no-credential (fails safe).
+function parseCloneTarget(args: readonly string[]): TargetSpec | null {
+  const positionals: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (SAFE_CLONE_FLAGS.has(arg)) continue
+    if (SAFE_CLONE_VALUE_FLAGS.has(arg)) {
+      const value = args[++i]
+      if (value === undefined || !isOptionValue(value)) return null
+      continue
+    }
+    if (SAFE_CLONE_INLINE_PREFIXES.some((prefix) => arg.startsWith(prefix))) continue
+    if (!isOptionValue(arg)) return null
+    positionals.push(arg)
+  }
+  if (positionals.length === 0 || positionals.length > 2) return null
+  const url = positionals[0] as string
+  return looksLikeUrl(url) ? { kind: 'single', value: url, forPush: false } : null
 }
 
 function parseMintablePush(args: readonly string[]): TargetSpec | null {
@@ -798,7 +846,10 @@ function analyzeCloneThenInspect(command: string): GitCommandDecision | null {
   const parsed = parseStrictCloneHead(split.head)
   if (parsed === null) return isNonGithubCloneHead(split.head) ? { kind: 'pass-through' } : null
 
-  const canonicalHead = `/usr/bin/git clone ${posixSingleQuote(parsed.url)} ${posixSingleQuote(parsed.destination)}`
+  const flagPart = parsed.flags.map(posixSingleQuote).join(' ')
+  const canonicalHead =
+    `/usr/bin/git clone ${flagPart === '' ? '' : `${flagPart} `}` +
+    `${posixSingleQuote(parsed.url)} ${posixSingleQuote(parsed.destination)}`
   return {
     kind: 'inject',
     repoSlug: parsed.repoSlug,
@@ -811,19 +862,53 @@ function tailContainsGitInvocation(tail: string): boolean {
   return extractEvidenceGitSegments(tail).length > 0
 }
 
-type StrictCloneHead = { repoSlug: string; url: string; destination: string }
+type StrictCloneHead = { repoSlug: string; url: string; destination: string; flags: string[] }
 
-const STRICT_CLONE_HEAD_RE =
-  /^[ \t]*git[ \t]+clone[ \t]+(https:\/\/github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+?)(?:\.git)?)[ \t]+([A-Za-z0-9._/-]+)[ \t]*$/
+const STRICT_CLONE_URL_RE = /^(https:\/\/github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+?)(?:\.git)?)$/
+const STRICT_CLONE_DESTINATION_RE = /^[A-Za-z0-9._/-]+$/
+const SAFE_CLONE_FLAG_VALUE_RE = /^[A-Za-z0-9._:@/-]+$/
 
+// The executed head is REBUILT from these parts rather than passed through, so the
+// grammar stays tiny even though it now admits flags: every accepted token comes from
+// the SAFE_CLONE_* allowlists, every value is charset-constrained, and each is
+// re-emitted single-quoted. Without this a plain `git clone --depth 1 <url> <dir> &&
+// <inspect>` — the natural code-analysis command — blocks outright.
 function parseStrictCloneHead(head: string): StrictCloneHead | null {
-  const match = STRICT_CLONE_HEAD_RE.exec(head)
+  const words = tokenizeStandalone(head)
+  if (words === null || words[0] !== 'git' || words[1] !== 'clone') return null
+
+  const flags: string[] = []
+  const positionals: string[] = []
+  for (let i = 2; i < words.length; i++) {
+    const word = words[i] as string
+    if (SAFE_CLONE_FLAGS.has(word)) {
+      flags.push(word)
+      continue
+    }
+    if (SAFE_CLONE_VALUE_FLAGS.has(word)) {
+      const value = words[++i]
+      if (value === undefined || !SAFE_CLONE_FLAG_VALUE_RE.test(value)) return null
+      flags.push(word, value)
+      continue
+    }
+    const prefix = SAFE_CLONE_INLINE_PREFIXES.find((candidate) => word.startsWith(candidate))
+    if (prefix !== undefined) {
+      if (!SAFE_CLONE_FLAG_VALUE_RE.test(word.slice(prefix.length))) return null
+      flags.push(word)
+      continue
+    }
+    if (word.startsWith('-')) return null
+    positionals.push(word)
+  }
+
+  if (positionals.length !== 2) return null
+  const [rawUrl, destination] = positionals as [string, string]
+  const match = STRICT_CLONE_URL_RE.exec(rawUrl)
   if (match === null) return null
-  const url = match[1] as string
   const repoSlug = match[2] as string
-  const destination = match[3] as string
+  if (!STRICT_CLONE_DESTINATION_RE.test(destination)) return null
   if (destination.startsWith('-') || repoSlug.startsWith('/') || repoSlug.endsWith('/')) return null
-  return { repoSlug, url, destination }
+  return { repoSlug, url: match[1] as string, destination, flags }
 }
 
 function isNonGithubCloneHead(head: string): boolean {

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -350,6 +350,43 @@ describe('github-cli-auth plugin', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
+  test('block guidance is command-aware: suggests a runnable rewrite per gh subcommand', async () => {
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(async () => ({ kind: 'token', token: 'ghs_minted' }), true)
+
+    const reasonFor = async (command: string): Promise<string> => {
+      const result = await hook(bashEvent(command), hookCtx)
+      expect(result).toMatchObject({ block: true })
+      return (result as { reason: string }).reason
+    }
+
+    // `gh repo view` takes a positional slug and errors on `-R`; suggesting `-R`
+    // here is what previously cost the agent a turn on "unknown shorthand flag".
+    const repoView = await reasonFor('gh repo view')
+    expect(repoView).toContain('gh repo view owner/repo')
+    expect(repoView).not.toContain('-R')
+
+    expect(await reasonFor('gh api /repos/acme/widgets/tarball --output /tmp/w.tgz')).toContain(
+      'gh api /repos/owner/repo/...',
+    )
+    expect(await reasonFor('gh repo list acme')).toContain('targets an owner rather than one repository')
+  })
+
+  test('source-read denials name the brokered git clone instead of leaving the agent stuck', async () => {
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(async () => ({ kind: 'token', token: 'ghs_minted' }), true)
+
+    for (const command of [
+      'gh repo clone acme/widgets /tmp/widgets',
+      "gh search code 'reward' --repo acme/widgets",
+      'gh api /repos/acme/widgets/tarball --output /tmp/w.tgz',
+    ]) {
+      const result = await hook(bashEvent(command), hookCtx)
+      expect(result).toMatchObject({ block: true })
+      expect((result as { reason: string }).reason).toContain('git clone --depth 1 https://github.com/')
+    }
+  })
+
   test('App auth: blocks when the bridge is unavailable', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const hook = await hookFor(unavailableResolver)

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -42,6 +42,35 @@ import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, dismissalMutationSucceeded, noteReviewCommand } from './review-recorder'
 import { classifyGhToken, shouldMintAppToken } from './token-class'
 
+const REPO_LIST_RE = /\bgh\s+repo\s+list\b/
+const GH_API_RE = /\bgh\s+api\b/
+const GH_REPO_VIEW_RE = /\bgh\s+repo\s+view\b/
+
+// `gh api` rejects `-R`, and `gh repo view` takes a positional slug — so the
+// blanket "-R owner/repo" advice is unrunnable for exactly the commands an agent
+// reaches for when exploring an unfamiliar repo. A denial that suggests a command
+// which cannot parse burns a turn and teaches the agent the repo is unreachable.
+function ghRewriteExample(command: string, slug: string): string {
+  if (GH_API_RE.test(command)) return `\`gh api /repos/${slug}/...\``
+  if (GH_REPO_VIEW_RE.test(command)) return `\`gh repo view ${slug}\``
+  return `\`gh <cmd> -R ${slug}\``
+}
+
+// The shapes an agent reaches for when it wants to READ SOURCE. None is brokerable:
+// `repo clone` is absent from SAFE_GH_OPERATIONS, and archive/search endpoints can
+// write or exfiltrate. Brokered `git clone` IS supported for any allowlisted repo, so
+// name it — otherwise the agent concludes the source is unreachable and says so.
+const SOURCE_READ_RE = /\bgh\s+repo\s+clone\b|\bgh\s+search\s+code\b|\/(?:tarball|zipball|contents)\b/
+
+function sourceReadRecovery(command: string, slug: string): string {
+  if (!SOURCE_READ_RE.test(command)) return ''
+  return (
+    ` To read this repository's source, clone it as its own standalone command:` +
+    ` \`git clone --depth 1 https://github.com/${slug}.git <dir>\` — TypeClaw brokers that clone for any` +
+    ' repo in `channels.github.repos[]`. Inspect the working copy with a separate command afterwards.'
+  )
+}
+
 export default definePlugin({
   plugin: async (ctx) => {
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
@@ -224,15 +253,25 @@ export default definePlugin({
     // exact single-bare rewrite so the agent recovers in one step instead of
     // guessing. Composition blocks get a split-the-script instruction. The
     // returned text is appended to the block reason (synchronous, always seen).
-    const buildGhBlockGuidance = (code: string, fallbackRepo: string | undefined): string => {
+    const buildGhBlockGuidance = (code: string, fallbackRepo: string | undefined, command: string): string => {
       const slug = fallbackRepo ?? 'owner/repo'
+      const example = ghRewriteExample(command, slug)
+      const sourceRead = sourceReadRecovery(command, slug)
       if (code === 'composition') {
         return (
-          ` Run each gh as its own single bare command, e.g. \`gh label edit <name> -R ${slug} --name ...\` —` +
-          ' not inside a function, `if`/`then`, `&&`, `;`, or `$(...)`.'
+          ` Run each gh as its own single bare command, e.g. ${example} —` +
+          ' not inside a function, `if`/`then`, `&&`, `;`, or `$(...)`.' +
+          sourceRead
         )
       }
-      return ` For example: \`gh <cmd> -R ${slug}\` as a single bare command.`
+      if (REPO_LIST_RE.test(command)) {
+        return (
+          ' `gh repo list` targets an owner rather than one repository, so there is no per-repo' +
+          ` rewrite that can mint a token. Name a concrete repo instead, e.g. \`gh repo view ${slug}\`.` +
+          sourceRead
+        )
+      }
+      return ` For example: ${example} as a single bare command.` + sourceRead
     }
 
     // 'fall-through' means "not a repo-targeting gh command" so the caller can
@@ -273,7 +312,7 @@ export default definePlugin({
           reason:
             decision.code === 'credential-display'
               ? decision.reason
-              : decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo),
+              : decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo, command),
         }
       }
 


### PR DESCRIPTION
## Background

An agent asked to answer a question from the source of a private repo it was fully authorized for — the repo was listed in `channels.github.repos[]` and GitHub App auth was healthy (`gh repo view <slug> --json defaultBranchRef` returned data) — could not read any of it, and said so in a customer-facing channel. Every route it tried failed for a different reason:

- `gh repo list <owner>` blocked while claiming the App "spans multiple owners," when it spans one.
- `gh repo clone <slug> <dir> -- --depth 1` produced no block and no token, so bare `gh` emitted its stock "run `gh auth login`" advice.
- `gh api /repos/.../tarball --output` blocked as not credential-safe.
- `gh repo view -R <slug>` failed with `unknown shorthand flag: 'R'` because the agent followed the block message's own suggested rewrite verbatim.
- `gh search code --repo <slug>` blocked.

Root cause: `git clone`'s URL is a positional, but `parseExplicitUrl` located it at a fixed index and rejected the command outright if any argv word was a flag. The clone-then-inspect head grammar refused flags for the same reason. So the brokered clone only ever minted for the barest `git clone <url> <dir>` — a shallow, branch-limited clone (the ordinary way to read a large repo) got no credential and failed with git's opaque "could not read Username for 'https://github.com'".

## Summary

### Broker `git clone` with an allowlist of inert flags

`parseCloneTarget`/`parseStrictCloneHead` (`git-command.ts`) now skip a conservative flag allowlist to find the URL/destination positionals, and re-emit accepted flags single-quoted into the canonically rebuilt head. The allowlist deliberately omits `--recurse-submodules`, `-c`/`--config`, `--upload-pack`, `--template`, `--reference`, and `--separate-git-dir` — anything that could redirect the fetch to another repo/host, run a command, or touch a path outside the destination. Flag values are charset-constrained, so `--depth '1;evil'` is refused. An unrecognized flag still mints nothing, so this only widens the authorized set and keeps failing safe.

This supersedes the previous no-flags head grammar, whose own test named `clone --config` as the threat it existed to stop. That test is kept, not deleted — it's retargeted at `--config`/`-c` specifically instead of a blanket flag refusal.

### Recognize `gh` in a shell reserved-word command position

`isCommandBoundaryBefore` (`gh-command.ts`) treated only operators and env assignments as opening a command position, so `if ...; then gh ...; fi` produced no invocation at all — `analyzeGhCommand` returned pass-through and the command ran as bare, unauthenticated `gh`, even though the existing composition guidance already promised that shape was disallowed. `then`/`else`/`do` now open a command position, gated recursively on the reserved word itself sitting at a boundary — bash's own rule, and what keeps `echo then gh` from registering as an invocation.

Also corrects `MISSING_REPO_REASON`, which asserted the App spans multiple owners. That message fires whenever no effective destination repo can be determined, including on a single-owner App, so it was reporting a cause that was simply untrue.

### Make blocked-`gh` guidance command-aware

`gh api` rejects `-R` and `gh repo view` takes a positional slug, so the previous blanket "`-R owner/repo`" suggestion could not parse for exactly the commands an agent reaches for on an unfamiliar repo. `buildGhBlockGuidance` (`index.ts`) now picks the example from the command shape, and source-read shapes (`gh repo clone`, `gh search code`, archive endpoints) — which have no brokered path in any form — now name the supported alternative: a standalone `git clone --depth 1`.

## What this does NOT do

- Does not widen the git broker to submodules, custom config, or arbitrary path flags — those stay refused.
- Does not add a brokered path for `gh repo clone`, `gh search code`, or the archive endpoints; the guidance points at the existing `git clone` broker instead.
- Does not change any other gh/git composition or credential-safety rule.

## Review notes

The load-bearing invariant in the clone broker is that every accepted token comes from `SAFE_CLONE_FLAGS`/`SAFE_CLONE_VALUE_FLAGS`/`SAFE_CLONE_INLINE_PREFIXES`, every value is charset-constrained, and the rebuilt head re-quotes each token rather than passing the original string through. Verify `--config`/`-c`, `--upload-pack`, `--recurse-submodules`, `--template`, `--reference`, and `--separate-git-dir` all still refuse to mint in both standalone and clone-then-inspect form.

For the reserved-word fix, verify the recursion bottoms out correctly: `echo then gh` and a quoted `"; then gh ..."` must still pass through untouched, while `if`/`do`/`else` immediately before `gh` at a real boundary must block.

## Verification

- `bun run test` — 13468 pass, 0 fail
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean