### PR TITLE
Fix mask verifier failing under AppArmor

### DIFF
--- a/scripts/verify-mask-fd-sandbox.sh
+++ b/scripts/verify-mask-fd-sandbox.sh
@@ -84,7 +84,14 @@ echo "Image: $IMAGE${PLATFORM:+ ($PLATFORM)}"
 # no QEMU registered that dies on exec format, failing the release for a reason
 # that has nothing to do with bwrap. Re-resolving the tag here keeps the check
 # honest on both the classic and containerd image stores.
-run_args=(--rm --pull=always --security-opt seccomp=unconfined)
+# apparmor=unconfined alongside seccomp: bwrap's first act is
+# `mount(NULL, "/", MS_SLAVE|MS_REC)`, which Docker's docker-default AppArmor
+# profile denies on an AppArmor-enabled host (the GitHub Ubuntu runners), failing
+# with "Failed to make / slave: Permission denied" before any mask is evaluated.
+# seccomp=unconfined does not cover AppArmor. Agent containers already run
+# unconfined so bwrap can create namespaces, so this matches the runtime the gate
+# is meant to certify rather than relaxing it — the mask assertions are unchanged.
+run_args=(--rm --pull=always --security-opt seccomp=unconfined --security-opt apparmor=unconfined)
 if [ -n "$PLATFORM" ]; then
   run_args+=(--platform "$PLATFORM")
 fi


### PR DESCRIPTION
## Background

The Release workflow's "Verify the sandbox file-mask contract against the shipped bwrap" step fails on every run, blocking npm publish entirely:

```
bwrap: bubblewrap 0.12.0
MASK_BWRAP_FAILED rc=1
bwrap: Failed to make / slave: Permission denied
```

It failed twice identically on re-run — not a flake. The gate landed after the 0.48.9 tag, so 0.48.10 is the first release to ever execute it, and it has never passed in a real release.

bwrap's opening action is mount(NULL, "/", MS_SLAVE|MS_REC). Docker's docker-default AppArmor profile denies that on an AppArmor-enabled host, which the GitHub Ubuntu runners are. --security-opt seccomp=unconfined was already set, but seccomp does not cover AppArmor. The failure happens before any mask is evaluated, so it says nothing about the mask contract itself — running the same script locally on macOS (no AppArmor) against the already-pushed ghcr.io/typeclaw/typeclaw-base:0.48.10 image prints MASK_CONTRACT_OK: 4 masks over 4 distinct fds, all empty. The shipped image and its bwrap mask contract are fine; only the verifier's own environment was wrong.

## Summary

Add `--security-opt apparmor=unconfined` next to the existing `seccomp=unconfined` in `scripts/verify-mask-fd-sandbox.sh`, with a comment explaining why.

This restores fidelity to the runtime being certified — it does not remove hardening. Agent containers already run unconfined precisely so bwrap can create namespaces; running the verifier the same way matches that runtime instead of relaxing a check. The assertions themselves are untouched — MASK_BWRAP_FAILED, MASK_LEAKED, and MASK_CONTRACT_OK all still fire, and a real contract break still fails the release.

## What this does NOT do

- Does not change any mask assertion or the fd/mask contract being verified.
- Does not touch the shipped base image or its bwrap invocation — only the verifier's own Docker sandbox flags.

## Review notes

The failure and the fix are both in Docker's confinement of the verifier container, not in bwrap or the shipped image. Verify MASK_BWRAP_FAILED, MASK_LEAKED, and MASK_CONTRACT_OK are unchanged in the diff — this is a one-flag addition plus an explanatory comment.

## Verification

- Re-ran the verifier against the pushed ghcr.io/typeclaw/typeclaw-base:0.48.10 image: MASK_CONTRACT_OK.
- `bun run test` — 13468 pass / 0 fail
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
