### PR TITLE
Let the mask verifier bring up loopback

### DIFF
--- a/scripts/verify-mask-fd-sandbox.sh
+++ b/scripts/verify-mask-fd-sandbox.sh
@@ -91,7 +91,16 @@ echo "Image: $IMAGE${PLATFORM:+ ($PLATFORM)}"
 # seccomp=unconfined does not cover AppArmor. Agent containers already run
 # unconfined so bwrap can create namespaces, so this matches the runtime the gate
 # is meant to certify rather than relaxing it — the mask assertions are unchanged.
-run_args=(--rm --pull=always --security-opt seccomp=unconfined --security-opt apparmor=unconfined)
+# NET_ADMIN because --unshare-all creates a network namespace and bwrap then
+# brings up its loopback; where the runner denies the unprivileged user namespace
+# that would otherwise confer it, that RTM_NEWADDR fails "Operation not
+# permitted". This grants the verifier container what the rendered command needs
+# to run at all. The bwrap argv is untouched, so the mirrored shape still stands.
+run_args=(
+  --rm --pull=always
+  --security-opt seccomp=unconfined --security-opt apparmor=unconfined
+  --cap-add NET_ADMIN
+)
 if [ -n "$PLATFORM" ]; then
   run_args+=(--platform "$PLATFORM")
 fi


### PR DESCRIPTION
## Background

This is a direct follow-up to #1437, which is merged. That PR fixed the Release workflow's "Verify the sandbox file-mask contract against the shipped bwrap" step failing on every run with `bwrap: Failed to make / slave: Permission denied` — Docker's docker-default AppArmor profile was denying bwrap's opening mount, so `--security-opt apparmor=unconfined` was added. The gate landed after the 0.48.9 tag, so 0.48.10 is the first release to ever execute it, and it still has never passed in a real release.

With the mount unblocked, the gate got one step further and died differently:

```
bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
```

`--unshare-all` creates a network namespace, and bwrap then brings up its loopback interface inside that namespace. Where the runner denies the unprivileged user namespace that would otherwise confer `CAP_NET_ADMIN`, that netlink call is refused and the whole bwrap invocation aborts before a single mask is evaluated — so again the failure says nothing about the mask contract itself.

## Summary

Add `--cap-add NET_ADMIN` to the verifier's `docker run` invocation, next to the existing seccomp/AppArmor overrides, with a comment explaining why.

This grants a capability to the throwaway container the check runs in — it does not change what's being certified. The bwrap argv is untouched and still mirrors `buildArgv()`/`appendMasks()` in `src/sandbox/build.ts`, which is the whole point of the gate. The assertions are unchanged: `MASK_BWRAP_FAILED`, `MASK_LEAKED`, and `MASK_CONTRACT_OK` all still fire, and a genuine contract break still fails the release.

Worth being explicit for reviewers: typeclaw drops `NET_ADMIN` in the actual agent runtime. This is verifier scaffolding needed to get bwrap's own namespace setup to run at all, not a runtime capability grant.

## What this does NOT do

- Does not change the bwrap argv or the mask/fd contract being verified.
- Does not touch the shipped base image or any runtime capability grant — `NET_ADMIN` here is scoped to the verifier's own Docker sandbox flags.

## Review notes

Verify `MASK_BWRAP_FAILED`, `MASK_LEAKED`, and `MASK_CONTRACT_OK` are unchanged in the diff — this is one added capability flag plus an explanatory comment, nothing in the mask logic itself.

## Verification

- Re-ran the verifier against the already-pushed `ghcr.io/typeclaw/typeclaw-base:0.48.10` image both before and after this change: `MASK_CONTRACT_OK: 4 masks over 4 distinct fds, all empty` — confirming the shipped image's mask contract was always fine and only the verifier's environment was wrong.
- `bun run test` — 13468 pass / 0 fail
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean