### PR TITLE
Run the mask verifier privileged

### DIFF
--- a/scripts/verify-mask-fd-sandbox.sh
+++ b/scripts/verify-mask-fd-sandbox.sh
@@ -84,23 +84,21 @@ echo "Image: $IMAGE${PLATFORM:+ ($PLATFORM)}"
 # no QEMU registered that dies on exec format, failing the release for a reason
 # that has nothing to do with bwrap. Re-resolving the tag here keeps the check
 # honest on both the classic and containerd image stores.
-# apparmor=unconfined alongside seccomp: bwrap's first act is
-# `mount(NULL, "/", MS_SLAVE|MS_REC)`, which Docker's docker-default AppArmor
-# profile denies on an AppArmor-enabled host (the GitHub Ubuntu runners), failing
-# with "Failed to make / slave: Permission denied" before any mask is evaluated.
-# seccomp=unconfined does not cover AppArmor. Agent containers already run
-# unconfined so bwrap can create namespaces, so this matches the runtime the gate
-# is meant to certify rather than relaxing it — the mask assertions are unchanged.
-# NET_ADMIN because --unshare-all creates a network namespace and bwrap then
-# brings up its loopback; where the runner denies the unprivileged user namespace
-# that would otherwise confer it, that RTM_NEWADDR fails "Operation not
-# permitted". This grants the verifier container what the rendered command needs
-# to run at all. The bwrap argv is untouched, so the mirrored shape still stands.
-run_args=(
-  --rm --pull=always
-  --security-opt seccomp=unconfined --security-opt apparmor=unconfined
-  --cap-add NET_ADMIN
-)
+# --privileged so `bwrap --unshare-all` can actually build its namespaces here.
+# The runners restrict namespace creation in layers, and each one aborts the
+# invocation before a single mask is evaluated — so the step fails for reasons
+# that say nothing about the contract under test: docker-default AppArmor denies
+# the opening mount(NULL, "/", MS_SLAVE|MS_REC) ("Failed to make / slave"), and
+# the loopback bring-up in the new netns fails RTM_NEWADDR "Operation not
+# permitted" even with seccomp and AppArmor unconfined and NET_ADMIN added,
+# because the restriction is on the user namespace that would confer it.
+#
+# This is scaffolding for a throwaway container running a known image inside the
+# release pipeline, NOT a runtime capability grant — agent containers get
+# seccomp=unconfined and nothing more. What the gate certifies is unchanged: the
+# bwrap argv still mirrors buildArgv()/appendMasks(), and MASK_BWRAP_FAILED,
+# MASK_LEAKED and MASK_CONTRACT_OK all still fail the release on a real break.
+run_args=(--rm --pull=always --privileged)
 if [ -n "$PLATFORM" ]; then
   run_args+=(--platform "$PLATFORM")
 fi


### PR DESCRIPTION
## Background

Direct continuation of #1437 (merged) and #1438 (merged), both fixing the same "Verify the sandbox file-mask contract against the shipped bwrap" release step. That gate landed after the 0.48.9 tag, so 0.48.10 is the first release to execute it — and it has still never passed in a real run.

Chain so far: #1437 added `--security-opt apparmor=unconfined` after AppArmor denied bwrap's opening `mount(NULL, "/", MS_SLAVE|MS_REC)` ("Failed to make / slave: Permission denied"). #1438 added `--cap-add NET_ADMIN` after the check got one step further and failed bringing up loopback in bwrap's new network namespace. But the release run at the merged #1438 SHA — with `NET_ADMIN` already in place — failed with the identical loopback error:

```
bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
```

`NET_ADMIN` sits in the container's bounding set but was never effective: the runner's restriction is on the user namespace that would confer it, not on the capability itself. Adding capabilities one at a time cannot fix a namespace-creation restriction.

## Summary

Replace the accumulated flags (`seccomp=unconfined`, `apparmor=unconfined`, `--cap-add NET_ADMIN`) with a single `--privileged`, and stop chasing individual namespace permissions release by release.

This is scaffolding for a throwaway container that runs a known image inside the release pipeline — not a runtime capability grant. Agent containers still get `seccomp=unconfined` and nothing more; nothing about the product's sandbox posture changes. What the gate certifies is untouched: the bwrap argv still mirrors `buildArgv()`/`appendMasks()` in `src/sandbox/build.ts`, and `MASK_BWRAP_FAILED`, `MASK_LEAKED`, and `MASK_CONTRACT_OK` all still fire, so a genuine contract break still fails the release.

## What this does NOT do

- Does not change any mask assertion or the fd/mask contract being verified.
- Does not touch the shipped base image, `buildArgv()`/`appendMasks()`, or any runtime capability grant — `--privileged` is scoped to the verifier's own throwaway container.
- Does not add a third permission flag to chase; it replaces the two prior attempts instead of stacking on top of them.

## Review notes

The two cheaper alternatives were tried and empirically failed, in order: AppArmor + seccomp unconfined got past the opening mount but not loopback; adding `NET_ADMIN` on top of that still hit the identical `RTM_NEWADDR: Operation not permitted` at the merged #1438 SHA. `--privileged` is the next narrowest fix that doesn't require enumerating every namespace permission the runner restricts one at a time. Verify `MASK_BWRAP_FAILED`, `MASK_LEAKED`, and `MASK_CONTRACT_OK` are unchanged — this is a `run_args` collapse plus a rewritten comment, nothing in the mask logic itself.

## Verification

- Ran the verifier locally against the already-pushed `ghcr.io/typeclaw/typeclaw-base:0.48.10` image: `MASK_CONTRACT_OK: 4 masks over 4 distinct fds, all empty` — unchanged before and after all three attempts, confirming the shipped image's mask contract was always fine and only the verifier's own environment was wrong.
- `bun run test` — 13468 pass / 0 fail
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
