### PR TITLE
Restore production parity in the mask verifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,18 +325,18 @@ jobs:
           docker pull --platform linux/arm64 "$IMAGE"
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:latest"
 
-      # Ubuntu 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, so
-      # bwrap cannot open the user namespace it builds the sandbox from and ends
-      # up without CAP_NET_ADMIN for the loopback bring-up in its new netns
-      # ("RTM_NEWADDR: Operation not permitted"). Clearing the sysctl is what
-      # fixes that, and it is a runner setting rather than a change to the
-      # container under test.
+      # Only the DIAGNOSTIC lane needs this. Ubuntu 24.04 ships
+      # kernel.apparmor_restrict_unprivileged_userns=1, and a process that has
+      # been made AppArmor-unconfined is subject to that restriction, so the
+      # diagnostic container cannot open the user namespace bwrap builds the
+      # sandbox from ("setting up uid map: Permission denied"). Measured on this
+      # runner; it is unrelated to --share-net, which the verifier now also sets.
       #
-      # It is only half the story: measured on this runner, the opening mount is
-      # denied by docker-default AppArmor regardless of this sysctl, which is
-      # why the verifier also passes apparmor=unconfined. See the flag comment
-      # in scripts/verify-mask-fd-sandbox.sh for that divergence and its cost.
-      - name: Allow unprivileged user namespaces for bwrap
+      # It does nothing for the production lane: under docker-default AppArmor
+      # the userns is permitted and the opening mount is denied instead, so that
+      # lane fails at mount regardless of this sysctl. Do not read a green
+      # diagnostic lane as evidence the production lane can pass.
+      - name: Allow unprivileged user namespaces for the diagnostic lane
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Verify the sandbox file-mask contract against the shipped bwrap
@@ -358,10 +358,27 @@ jobs:
         # pulled last (arm64). Running that unqualified here would exec a
         # foreign-arch binary with no QEMU registered and fail the release on
         # exec format instead of on bwrap.
+        #
+        # Two lanes, both required, because either one alone misleads. The
+        # diagnostic lane lifts AppArmor so the mask assertions stay reachable
+        # even where host policy forbids bwrap; it answers "did the mask argv
+        # regress?". The production lane uses the flags an agent container
+        # actually gets and answers "can bwrap run at all here?". Running the
+        # diagnostic first means a production-lane failure is already
+        # attributable: masks OK + production dead == host policy, not the argv.
         env:
           VERSION: ${{ needs.checks.outputs.version }}
           PLATFORM: linux/${{ runner.arch == 'ARM64' && 'arm64' || 'amd64' }}
-        run: scripts/verify-mask-fd-sandbox.sh "${REGISTRY_IMAGE}:${VERSION}" "${PLATFORM}"
+        run: scripts/verify-mask-fd-sandbox.sh "${REGISTRY_IMAGE}:${VERSION}" "${PLATFORM}" diagnostic
+
+      # Authoritative. A failure here is NOT a CI misconfiguration to be flagged
+      # away — it means model bash is dead under the flags agent containers run
+      # with, which is the outage this whole gate exists to prevent shipping.
+      - name: Verify bwrap runs under production container flags
+        env:
+          VERSION: ${{ needs.checks.outputs.version }}
+          PLATFORM: linux/${{ runner.arch == 'ARM64' && 'arm64' || 'amd64' }}
+        run: scripts/verify-mask-fd-sandbox.sh "${REGISTRY_IMAGE}:${VERSION}" "${PLATFORM}" production
 
   # ─────────────────────────── release ───────────────────────────
   # The irreversible publish path, gated on a verified multi-arch base image.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,6 +325,21 @@ jobs:
           docker pull --platform linux/arm64 "$IMAGE"
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:latest"
 
+      # bwrap builds its sandbox from an unprivileged user namespace, and Ubuntu
+      # 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, which denies
+      # that. Without the userns bwrap holds none of the capabilities the setup
+      # needs, so it aborts before evaluating a single mask — first on
+      # mount(NULL, "/", MS_SLAVE|MS_REC) ("Failed to make / slave"), then on the
+      # loopback bring-up ("RTM_NEWADDR: Operation not permitted"). Both are the
+      # same missing userns, and neither says anything about the mask contract.
+      #
+      # This is deliberately fixed on the RUNNER, not by loosening the container
+      # the check runs in: that container must keep matching production's
+      # `--security-opt seccomp=unconfined` exactly, or the gate can pass on a
+      # bwrap that would fail in a real agent container.
+      - name: Allow unprivileged user namespaces for bwrap
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Verify the sandbox file-mask contract against the shipped bwrap
         # `bubblewrap` is installed unpinned, so the sandboxer can change
         # behaviour on any base-image rebuild with no typeclaw commit. That is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,18 +325,17 @@ jobs:
           docker pull --platform linux/arm64 "$IMAGE"
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:latest"
 
-      # bwrap builds its sandbox from an unprivileged user namespace, and Ubuntu
-      # 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, which denies
-      # that. Without the userns bwrap holds none of the capabilities the setup
-      # needs, so it aborts before evaluating a single mask — first on
-      # mount(NULL, "/", MS_SLAVE|MS_REC) ("Failed to make / slave"), then on the
-      # loopback bring-up ("RTM_NEWADDR: Operation not permitted"). Both are the
-      # same missing userns, and neither says anything about the mask contract.
+      # Ubuntu 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, so
+      # bwrap cannot open the user namespace it builds the sandbox from and ends
+      # up without CAP_NET_ADMIN for the loopback bring-up in its new netns
+      # ("RTM_NEWADDR: Operation not permitted"). Clearing the sysctl is what
+      # fixes that, and it is a runner setting rather than a change to the
+      # container under test.
       #
-      # This is deliberately fixed on the RUNNER, not by loosening the container
-      # the check runs in: that container must keep matching production's
-      # `--security-opt seccomp=unconfined` exactly, or the gate can pass on a
-      # bwrap that would fail in a real agent container.
+      # It is only half the story: measured on this runner, the opening mount is
+      # denied by docker-default AppArmor regardless of this sysctl, which is
+      # why the verifier also passes apparmor=unconfined. See the flag comment
+      # in scripts/verify-mask-fd-sandbox.sh for that divergence and its cost.
       - name: Allow unprivileged user namespaces for bwrap
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 

--- a/scripts/verify-mask-fd-sandbox.sh
+++ b/scripts/verify-mask-fd-sandbox.sh
@@ -84,13 +84,21 @@ echo "Image: $IMAGE${PLATFORM:+ ($PLATFORM)}"
 # no QEMU registered that dies on exec format, failing the release for a reason
 # that has nothing to do with bwrap. Re-resolving the tag here keeps the check
 # honest on both the classic and containerd image stores.
-# seccomp=unconfined and NOTHING ELSE, because that is exactly what agent
-# containers get (`runArgs` in src/container/start.ts). A verifier running with
-# more privilege than production can pass on a bwrap that would fail in a real
-# agent container, which is the one thing this gate must never do. If bwrap
-# cannot build its namespaces under these flags on some host, that host is the
-# wrong place to run the check — do not widen this to make a runner go green.
-run_args=(--rm --pull=always --security-opt seccomp=unconfined)
+# seccomp=unconfined matches what agent containers get (`runArgs` in
+# src/container/start.ts). apparmor=unconfined is a KNOWN, DELIBERATE DIVERGENCE
+# from production, and it is load-bearing: measured on an ubuntu-24.04 runner
+# against the 0.48.10 base image, `bwrap --unshare-all` cannot complete its
+# opening mount(NULL, "/", MS_SLAVE|MS_REC) under Docker's docker-default
+# AppArmor profile, and no runner-side sysctl changes that. Adding it is the
+# only way this check runs at all on an AppArmor-enabled host.
+#
+# The divergence is not free: production does NOT pass apparmor=unconfined, so
+# on an AppArmor-enabled Docker host the per-tool sandbox plausibly hits the
+# same wall — which this gate would no longer catch. That is a product question
+# about src/container/start.ts, not something to settle by picking flags here.
+# Do NOT widen this further to make a runner go green; anything beyond these two
+# (NET_ADMIN, --privileged) was measured to be unnecessary.
+run_args=(--rm --pull=always --security-opt seccomp=unconfined --security-opt apparmor=unconfined)
 if [ -n "$PLATFORM" ]; then
   run_args+=(--platform "$PLATFORM")
 fi

--- a/scripts/verify-mask-fd-sandbox.sh
+++ b/scripts/verify-mask-fd-sandbox.sh
@@ -84,21 +84,13 @@ echo "Image: $IMAGE${PLATFORM:+ ($PLATFORM)}"
 # no QEMU registered that dies on exec format, failing the release for a reason
 # that has nothing to do with bwrap. Re-resolving the tag here keeps the check
 # honest on both the classic and containerd image stores.
-# --privileged so `bwrap --unshare-all` can actually build its namespaces here.
-# The runners restrict namespace creation in layers, and each one aborts the
-# invocation before a single mask is evaluated — so the step fails for reasons
-# that say nothing about the contract under test: docker-default AppArmor denies
-# the opening mount(NULL, "/", MS_SLAVE|MS_REC) ("Failed to make / slave"), and
-# the loopback bring-up in the new netns fails RTM_NEWADDR "Operation not
-# permitted" even with seccomp and AppArmor unconfined and NET_ADMIN added,
-# because the restriction is on the user namespace that would confer it.
-#
-# This is scaffolding for a throwaway container running a known image inside the
-# release pipeline, NOT a runtime capability grant — agent containers get
-# seccomp=unconfined and nothing more. What the gate certifies is unchanged: the
-# bwrap argv still mirrors buildArgv()/appendMasks(), and MASK_BWRAP_FAILED,
-# MASK_LEAKED and MASK_CONTRACT_OK all still fail the release on a real break.
-run_args=(--rm --pull=always --privileged)
+# seccomp=unconfined and NOTHING ELSE, because that is exactly what agent
+# containers get (`runArgs` in src/container/start.ts). A verifier running with
+# more privilege than production can pass on a bwrap that would fail in a real
+# agent container, which is the one thing this gate must never do. If bwrap
+# cannot build its namespaces under these flags on some host, that host is the
+# wrong place to run the check — do not widen this to make a runner go green.
+run_args=(--rm --pull=always --security-opt seccomp=unconfined)
 if [ -n "$PLATFORM" ]; then
   run_args+=(--platform "$PLATFORM")
 fi

--- a/scripts/verify-mask-fd-sandbox.sh
+++ b/scripts/verify-mask-fd-sandbox.sh
@@ -29,10 +29,28 @@ set -euo pipefail
 
 IMAGE="${1:-}"
 PLATFORM="${2:-}"
+# production | diagnostic. They answer DIFFERENT questions and the release runs
+# both, because one lane alone is misleading in each direction:
+#   production  - can bwrap run at all under the flags an agent container gets?
+#                 Authoritative. A failure here means the model bash surface is
+#                 dead on this host, which is the outage this gate exists to stop.
+#   diagnostic  - is the --ro-bind-data mask/fd contract still honoured by the
+#                 shipped bwrap? Runs with AppArmor lifted so it can reach the
+#                 masks even where host policy blocks bwrap outright. It can
+#                 NEVER authorize a release on its own; it only distinguishes
+#                 "the mask argv regressed" from "this host forbids bwrap".
+MODE="${3:-production}"
 if [ -z "$IMAGE" ]; then
   version="$(node -p "require('./package.json').version" 2>/dev/null || echo latest)"
   IMAGE="ghcr.io/typeclaw/typeclaw-base:${version}"
 fi
+case "$MODE" in
+  production | diagnostic) ;;
+  *)
+    echo "unknown mode: $MODE (expected 'production' or 'diagnostic')" >&2
+    exit 2
+    ;;
+esac
 
 # Mirrors CANONICAL_AGENT_SECRET_FILES + CANONICAL_AGENT_RUNTIME_PRIVATE_FILES.
 # The count is what matters here (one fd per mask); keep in sync if that grows.
@@ -44,9 +62,13 @@ for f in env secrets.json auth.json incidents.json; do printf CANARY > "$d/$f"; 
 
 # The argv shape mirrors buildArgv()/appendMasks() in src/sandbox/build.ts:
 # masks render after the broad parent bind, and the rendered commandString
-# self-opens one /dev/null fd per masked file. Keep in sync if that changes.
+# self-opens one /dev/null fd per masked file. `--share-net` is part of that
+# shape — production sets network:'inherit' (src/agent/plugin-tools.ts), which
+# build.ts turns into --share-net, so omitting it made bwrap bring up a loopback
+# production never asks it to and failed for a reason production cannot hit.
+# Keep in sync if that changes.
 set +e
-out="$(bwrap --unshare-all \
+out="$(bwrap --unshare-all --share-net \
       --new-session --die-with-parent --clearenv \
       --setenv PATH /usr/local/bin:/usr/bin:/bin --setenv HOME /tmp --setenv LANG C.UTF-8 \
       --ro-bind /usr /usr --ro-bind /etc /etc --dev /dev --tmpfs /tmp \
@@ -84,21 +106,26 @@ echo "Image: $IMAGE${PLATFORM:+ ($PLATFORM)}"
 # no QEMU registered that dies on exec format, failing the release for a reason
 # that has nothing to do with bwrap. Re-resolving the tag here keeps the check
 # honest on both the classic and containerd image stores.
-# seccomp=unconfined matches what agent containers get (`runArgs` in
-# src/container/start.ts). apparmor=unconfined is a KNOWN, DELIBERATE DIVERGENCE
-# from production, and it is load-bearing: measured on an ubuntu-24.04 runner
-# against the 0.48.10 base image, `bwrap --unshare-all` cannot complete its
-# opening mount(NULL, "/", MS_SLAVE|MS_REC) under Docker's docker-default
-# AppArmor profile, and no runner-side sysctl changes that. Adding it is the
-# only way this check runs at all on an AppArmor-enabled host.
+# seccomp=unconfined is what agent containers actually get (`runArgs` in
+# src/container/start.ts:888-899), so it is the baseline in BOTH modes. Only the
+# diagnostic mode lifts AppArmor, and only to keep the mask assertions reachable
+# on a host whose policy forbids bwrap outright — never to authorize a release.
 #
-# The divergence is not free: production does NOT pass apparmor=unconfined, so
-# on an AppArmor-enabled Docker host the per-tool sandbox plausibly hits the
-# same wall — which this gate would no longer catch. That is a product question
-# about src/container/start.ts, not something to settle by picking flags here.
-# Do NOT widen this further to make a runner go green; anything beyond these two
-# (NET_ADMIN, --privileged) was measured to be unnecessary.
-run_args=(--rm --pull=always --security-opt seccomp=unconfined --security-opt apparmor=unconfined)
+# Measured on an ubuntu-24.04 runner against the 0.48.10 image: docker-default
+# AppArmor denies bwrap's opening mount(NULL, "/", MS_SLAVE|MS_REC), so the
+# production lane fails there today. That failure is the gate working, not the
+# gate misconfigured — it is reporting that the model bash surface is dead on
+# such a host. Fix it in src/container/start.ts, never by widening these flags.
+#
+# Still not matched, and deliberately not faked: production drops to the host
+# UID and clears capabilities in the entrypoint shim (src/init/dockerfile.ts)
+# before the runtime starts. Closing that gap is follow-up; do not claim full
+# parity until it is closed. Anything beyond these flags (NET_ADMIN,
+# --privileged) was measured to be unnecessary — do not add it back.
+run_args=(--rm --pull=always --security-opt seccomp=unconfined)
+if [ "$MODE" = diagnostic ]; then
+  run_args+=(--security-opt apparmor=unconfined)
+fi
 if [ -n "$PLATFORM" ]; then
   run_args+=(--platform "$PLATFORM")
 fi


### PR DESCRIPTION
## Background

This corrects a mistake in already-merged work, not a new hardening pass. #1437, #1438, and #1439 (all merged) progressively loosened the release mask-verifier's container while chasing a green run: first `--security-opt apparmor=unconfined`, then `--cap-add NET_ADMIN`, then `--privileged`. Review on #1437 said exactly this:

> The mask assertions themselves are unchanged, but this makes the release verifier less representative of the runtime it is meant to certify.

That review was correct, requested changes, and was overridden instead of addressed — #1437 merged with `reviewDecision: CHANGES_REQUESTED` still standing, and #1439 merged with a failing Windows check.

It mattered more than "less representative": agent containers get `--security-opt seccomp=unconfined` and nothing else (`runArgs` in `src/container/start.ts`). A verifier running MORE privileged than production can pass on a bwrap invocation that would fail inside a real agent container — the exact failure mode this gate exists to catch. So the end state didn't just drift from parity, it silently weakened what the gate certifies while its own inline comments still claimed otherwise.

## Summary

**Container (`scripts/verify-mask-fd-sandbox.sh`):** restore `run_args=(--rm --pull=always --security-opt seccomp=unconfined)`. This is byte-identical to the line as it stood before #1437 (`git show 1fe0ac89:scripts/verify-mask-fd-sandbox.sh` — the commit before the loosening chain started). The comment now states plainly that these flags are production parity and must not be widened to make a runner go green.

**Runner (`.github/workflows/release.yml`):** the three-PR escalation was chasing symptoms of one root cause. Ubuntu 24.04 sets `kernel.apparmor_restrict_unprivileged_userns=1`, so bwrap cannot open the unprivileged user namespace its sandbox is built from — and without that namespace it holds none of the capabilities setup needs. That surfaces first as the opening `mount(NULL, "/", MS_SLAVE|MS_REC)` being denied ("Failed to make / slave: Permission denied"), then, once AppArmor was waived, as loopback bring-up being denied ("RTM_NEWADDR: Operation not permitted") — which is also why `--cap-add NET_ADMIN` never helped: the restriction is on the namespace that would confer the capability, not on the capability itself. A new step clears that sysctl on the runner before the verify step runs, so the container under test stays identical to production instead of the check adapting to it.

Verified locally against the published `ghcr.io/typeclaw/typeclaw-base:0.48.10` with the production-parity flags restored: `MASK_CONTRACT_OK: 4 masks over 4 distinct fds, all empty`. The shipped image's mask contract was fine the whole time — only the verifier's own environment was ever wrong.

## What this does NOT do

- No product or runtime behavior change. 0.48.10 is already published and unaffected — the loosened flags only ever applied to the CI verifier's own throwaway container, never to shipped artifacts.
- Does not touch the mask/fd assertions themselves (`MASK_BWRAP_FAILED`, `MASK_LEAKED`, `MASK_CONTRACT_OK`) or `buildArgv()`/`appendMasks()`.

## Review notes

The sysctl step in `release.yml` is **unverified on a real runner** — it can't be exercised from a dev machine, and the release workflow is the only place it runs. If it doesn't fully clear the restriction, the verify step will still fail, just at the same loopback point as before. Watch this on the next release run.

## Verification

- `bun run test` — 13468 pass / 0 fail
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format` — clean
