### PR TITLE
Tolerate an already-registered Windows dev link

### DIFF
--- a/src/init/windows-dev-link.test.ts
+++ b/src/init/windows-dev-link.test.ts
@@ -96,4 +96,57 @@ describe('linkWindowsDevTypeclaw', () => {
       await rm(globalDir, { recursive: true, force: true })
     }
   })
+
+  test('tolerates a bun link failure when the checkout is already linked globally', async () => {
+    const { checkout, env, cleanup } = await fakeBunLink()
+    try {
+      const result = await linkWindowsDevTypeclaw(checkout, {
+        platform: 'win32',
+        env,
+        runBunLink: async () => {
+          throw new Error('bun link failed: EEXIST: File exists (symlink())')
+        },
+      })
+
+      expect(result).toBe(realpathSync(checkout))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('rethrows a bun link failure when the global link points at another checkout', async () => {
+    const { env, cleanup } = await fakeBunLink()
+    const other = await mkdtemp(join(tmpdir(), 'tc-checkout-other-'))
+    try {
+      await expect(
+        linkWindowsDevTypeclaw(other, {
+          platform: 'win32',
+          env,
+          runBunLink: async () => {
+            throw new Error('bun link failed: EEXIST: File exists (symlink())')
+          },
+        }),
+      ).rejects.toThrow('EEXIST')
+    } finally {
+      await rm(other, { recursive: true, force: true })
+      await cleanup()
+    }
+  })
+
+  test('rethrows a bun link failure when nothing is linked globally', async () => {
+    const globalDir = await mkdtemp(join(tmpdir(), 'tc-bun-global-unlinked-'))
+    try {
+      await expect(
+        linkWindowsDevTypeclaw('/repo/typeclaw', {
+          platform: 'win32',
+          env: { BUN_INSTALL_GLOBAL_DIR: globalDir },
+          runBunLink: async () => {
+            throw new Error('bun link failed: permission denied')
+          },
+        }),
+      ).rejects.toThrow('permission denied')
+    } finally {
+      await rm(globalDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/init/windows-dev-link.ts
+++ b/src/init/windows-dev-link.ts
@@ -47,9 +47,41 @@ export async function linkWindowsDevTypeclaw(
 ): Promise<string | null> {
   const platform = options.platform ?? process.platform
   if (!isWindows(platform)) return null
+  const env = options.env ?? process.env
   const runLink = options.runBunLink ?? defaultRunBunLink
-  await runLink(typeclawRoot)
-  return resolveBunLinkedPackage(TYPECLAW_DEP, options.env ?? process.env) ?? typeclawRoot
+  try {
+    await runLink(typeclawRoot)
+  } catch (error) {
+    // `bun link` is not idempotent on Windows. It deletes any existing
+    // <globalDir>/node_modules/<name> entry and then creates the junction, but
+    // the delete is best-effort (its error is discarded) and the pair is not
+    // atomic — so a junction that resists deletion, or a second `bun link`
+    // racing the first, dies on EEXIST. Re-running `typeclaw init` from a dev
+    // checkout then aborts on a step that had nothing left to do. Swallow the
+    // failure ONLY when the end state we wanted is already true: the global
+    // entry resolves to THIS checkout. An entry pointing at a different
+    // checkout, or no entry at all, still propagates, so a link that genuinely
+    // failed is never mistaken for a success.
+    if (!isLinkedTo(typeclawRoot, env)) throw error
+  }
+  return resolveBunLinkedPackage(TYPECLAW_DEP, env) ?? typeclawRoot
+}
+
+function isLinkedTo(typeclawRoot: string, env: NodeJS.ProcessEnv): boolean {
+  const linked = resolveBunLinkedPackage(TYPECLAW_DEP, env)
+  if (linked === null) return false
+  // Both sides are realpath'd so a junction target compares equal to the
+  // checkout path we were handed, and case-folded because Windows paths are
+  // case-insensitive while the two resolutions need not agree on casing.
+  return linked.toLowerCase() === canonicalize(typeclawRoot).toLowerCase()
+}
+
+function canonicalize(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return path
+  }
 }
 
 async function defaultRunBunLink(cwd: string): Promise<void> {


### PR DESCRIPTION
## Background

The `windows checks (typecheck / lint / format / test)` lane on CI has been failing on `main`, but it's marked `continue-on-error: true`, so the overall run still reports green (run 33827205399: `ci` and `flake-guard` passed, `windows` failed) and the failure went unnoticed.

The one failing test was `runInit > produces an initialized agent folder (config, secrets, markdown, git repo)` (`src/init/index.test.ts`), with:

```
error: bun link failed in D:\a\typeclaw\typeclaw: error: failed to create junction to node_modules in global dir due to error EEXIST: File exists (symlink())
```

raised from `defaultRunBunLink` (`src/init/windows-dev-link.ts`) via `linkWindowsDevTypeclaw` -> `maybeLinkWindowsDevTypeclaw` (`src/init/index.ts`) -> `runInit`.

Per Bun's own source (`src/runtime/cli/link_command.rs`), `bun link` is not idempotent on Windows: it first does a best-effort delete of the existing `<globalDir>/node_modules/<name>` entry whose error is discarded, then creates the junction. The delete+create pair is not atomic and neither path checks whether the existing target already matches, so the call dies with EEXIST whenever the junction resists deletion or a second `bun link` races the first between delete and create — the exact failure oven-sh/bun#12917 tracks (still open). On CI this fires because `bun test --parallel` distributes hundreds of test files across workers, and several `src/init` tests reach the same global link concurrently; whichever loses the race aborts.

This isn't only a test artifact — a developer on a native-Windows dev checkout who simply re-runs `typeclaw init` hits the identical abort, on a scaffold step that had nothing left to do.

## Summary

`linkWindowsDevTypeclaw` (`src/init/windows-dev-link.ts`) now wraps the `bun link` call and swallows the failure only when the end state we wanted is already true: the global entry realpath-resolves to this same checkout. Anything else — an entry pointing elsewhere, or none at all — still throws, so a link that genuinely failed is never mistaken for success. Both sides of the comparison are realpath'd (so a junction target compares equal to the checkout path) and case-folded (Windows paths are case-insensitive and the two resolutions need not agree on casing).

This deliberately isn't a blanket `catch {}` — the tolerance is scoped to a verified desired-outcome check, matching this repo's guard-authoring rule that a tolerance must name the failure it swallows and the case that still fails closed.

Three tests added in `src/init/windows-dev-link.test.ts`:
- tolerates a bun link failure when the checkout is already linked globally (the new behavior — fails on `main`)
- rethrows a bun link failure when the global link points at another checkout (tolerance doesn't over-reach)
- rethrows a bun link failure when nothing is linked globally (a genuine failure still propagates)

## What this does NOT do

- Does not add a retry, lock, or serialization around `bun link` — the fix accepts the race can still happen and makes losing it survivable instead of preventing it.
- Does not patch or vendor Bun; the workaround lives entirely on the caller side.
- Does not touch the POSIX `file:`-based dev-link path — this is Windows-only, gated by `isWindows(platform)`.

## Review notes

- `isLinkedTo`'s realpath + case-fold comparison is the load-bearing check — it's what keeps this from silently swallowing an entry that points at a different checkout.
- Can't be proven on macOS/Linux locally; the real EEXIST only reproduces on a native-Windows runner. The added tests simulate it via an injected throwing `runBunLink` with `platform: 'win32'`. Final proof is this PR's own `windows` lane going green.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (70 pre-existing warnings, untouched)
- `bun run format:check` — all files correctly formatted
- `bun run test` — 13527 pass, 32 skip, 0 fail across 612 files
