### PR TITLE
cron: re-arm timers after suspension

### DIFF
--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -10,8 +10,10 @@ function createFakeClock(start = new Date('2026-01-01T00:00:00Z').getTime()): Sc
   fireNext: () => void
   handleCount: () => number
   setNow: (next: number) => void
+  suspend: (ms: number) => void
 } {
   let now = start
+  let monotonicNow = start
   const timers: Array<{ fireAt: number; cb: () => void; cancelled: boolean }> = []
   let nextHandle = 1
   const handles = new Map<number, (typeof timers)[number]>()
@@ -19,7 +21,7 @@ function createFakeClock(start = new Date('2026-01-01T00:00:00Z').getTime()): Sc
   return {
     now: () => now,
     setTimeout: (cb, ms) => {
-      const timer = { fireAt: now + Math.max(0, ms), cb, cancelled: false }
+      const timer = { fireAt: monotonicNow + Math.max(0, ms), cb, cancelled: false }
       const handle = nextHandle++
       timers.push(timer)
       handles.set(handle, timer)
@@ -30,16 +32,20 @@ function createFakeClock(start = new Date('2026-01-01T00:00:00Z').getTime()): Sc
       if (timer) timer.cancelled = true
     },
     advance: async (ms) => {
-      const target = now + ms
+      const target = monotonicNow + ms
       for (;;) {
         const due = timers.filter((t) => !t.cancelled && t.fireAt <= target).sort((a, b) => a.fireAt - b.fireAt)[0]
         if (!due) break
-        now = due.fireAt
+        now += due.fireAt - monotonicNow
+        monotonicNow = due.fireAt
         due.cancelled = true
         due.cb()
-        await new Promise((r) => setImmediate(r))
+        const { promise, resolve } = Promise.withResolvers<void>()
+        setImmediate(resolve)
+        await promise
       }
-      now = target
+      now += target - monotonicNow
+      monotonicNow = target
     },
     fireNext: () => {
       const next = timers.filter((t) => !t.cancelled).sort((a, b) => a.fireAt - b.fireAt)[0]
@@ -50,6 +56,9 @@ function createFakeClock(start = new Date('2026-01-01T00:00:00Z').getTime()): Sc
     handleCount: () => Array.from(handles.values()).filter((t) => !t.cancelled).length,
     setNow: (next) => {
       now = next
+    },
+    suspend: (ms) => {
+      now += ms
     },
   }
 }
@@ -210,55 +219,71 @@ describe('createScheduler', () => {
     scheduler.stop()
   })
 
-  test('does not fire a long-delay job when Node clamps an oversized timer', async () => {
-    const clock = createFakeClock()
-    const nodeMaxTimeoutMs = 2 ** 31 - 1
-    const nodeLikeClock: SchedulerClock & Pick<typeof clock, 'advance'> = {
-      ...clock,
-      setTimeout: (cb, ms) => clock.setTimeout(cb, ms > nodeMaxTimeoutMs ? 1 : ms),
-    }
-    const recorder = createFireRecorder()
-    const dueAt = new Date('2026-02-01T00:00:00Z').toISOString()
-    const scheduler = createScheduler({
-      jobs: [{ id: 'long-delay', at: dueAt, kind: 'prompt', prompt: 'run', enabled: true }],
-      onFire: recorder.onFire,
-      clock: nodeLikeClock,
-      logger: silentLogger,
-    })
-
-    scheduler.start()
-    await nodeLikeClock.advance(nodeMaxTimeoutMs)
-
-    expect(recorder.fires).toHaveLength(0)
-
-    await nodeLikeClock.advance(new Date(dueAt).getTime() - nodeLikeClock.now())
-
-    expect(recorder.firesByJob.get('long-delay')).toHaveLength(1)
-
-    scheduler.stop()
-  })
-
-  test('retains a long-delay occurrence across a backward clock adjustment', async () => {
+  test('does not fire a future occurrence during bounded re-arms', async () => {
     const clock = createFakeClock()
     const recorder = createFireRecorder()
-    const nodeMaxTimeoutMs = 2 ** 31 - 1
+    const dueAt = new Date('2026-01-01T00:03:00Z').toISOString()
     const scheduler = createScheduler({
-      jobs: [promptJob('monthly', '0 0 1 * *')],
+      jobs: [{ id: 'future', at: dueAt, kind: 'prompt', prompt: 'run', enabled: true }],
       onFire: recorder.onFire,
       clock,
       logger: silentLogger,
     })
 
     scheduler.start()
-    clock.setNow(new Date('2025-12-15T00:00:00Z').getTime())
-    clock.fireNext()
-    await clock.advance(nodeMaxTimeoutMs)
+    await clock.advance(3 * 60 * 1000 - 1)
 
     expect(recorder.fires).toHaveLength(0)
 
-    await clock.advance(new Date('2026-02-01T00:00:00Z').getTime() - clock.now())
+    await clock.advance(1)
 
-    expect(recorder.firesByJob.get('monthly')).toHaveLength(1)
+    expect(recorder.firesByJob.get('future')).toHaveLength(1)
+
+    scheduler.stop()
+  })
+
+  test('converges on a captured occurrence after a suspended timer', async () => {
+    const start = new Date('2026-01-01T00:00:00Z').getTime()
+    const clock = createFakeClock(start)
+    const firedAt: number[] = []
+    const dueAt = start + 5 * 60 * 1000
+    const scheduler = createScheduler({
+      jobs: [{ id: 'suspended', at: new Date(dueAt).toISOString(), kind: 'prompt', prompt: 'run', enabled: true }],
+      onFire: () => firedAt.push(clock.now()),
+      clock,
+      logger: silentLogger,
+    })
+
+    scheduler.start()
+    clock.suspend(2 * 60 * 1000)
+    await clock.advance(5 * 60 * 1000)
+
+    expect(firedAt).toEqual([dueAt])
+
+    scheduler.stop()
+  })
+
+  test('retains a captured occurrence across a backward clock adjustment', async () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const dueAt = new Date('2026-01-01T00:03:00Z').toISOString()
+    const scheduler = createScheduler({
+      jobs: [{ id: 'backward', at: dueAt, kind: 'prompt', prompt: 'run', enabled: true }],
+      onFire: recorder.onFire,
+      clock,
+      logger: silentLogger,
+    })
+
+    scheduler.start()
+    clock.setNow(new Date('2025-12-31T23:59:00Z').getTime())
+    clock.fireNext()
+    await clock.advance(3 * 60 * 1000)
+
+    expect(recorder.fires).toHaveLength(0)
+
+    await clock.advance(60 * 1000)
+
+    expect(recorder.firesByJob.get('backward')).toHaveLength(1)
 
     scheduler.stop()
   })

--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -263,6 +263,30 @@ describe('createScheduler', () => {
     scheduler.stop()
   })
 
+  test('fires within one minute of a suspension that lands past the occurrence', async () => {
+    const clock = createFakeClock()
+    const recorder = createFireRecorder()
+    const dueAt = new Date('2026-01-01T00:10:00Z').toISOString()
+    const scheduler = createScheduler({
+      jobs: [{ id: 'resume-bound', at: dueAt, kind: 'prompt', prompt: 'run', enabled: true }],
+      onFire: recorder.onFire,
+      clock,
+      logger: silentLogger,
+    })
+
+    scheduler.start()
+    clock.suspend(15 * 60 * 1000)
+    await clock.advance(60 * 1000 - 1)
+
+    expect(recorder.fires).toHaveLength(0)
+
+    await clock.advance(1)
+
+    expect(recorder.firesByJob.get('resume-bound')).toHaveLength(1)
+
+    scheduler.stop()
+  })
+
   test('retains a captured occurrence across a backward clock adjustment', async () => {
     const clock = createFakeClock()
     const recorder = createFireRecorder()

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -58,9 +58,17 @@ const consoleLogger: SchedulerLogger = {
   error: (m) => console.error(m),
 }
 
-// Node clamps delays greater than this to 1ms. Re-arm long waits instead of
-// allowing an early callback to dispatch a future occurrence.
-const maxTimeoutMs = 2 ** 31 - 1
+// Timers count down against a monotonic clock, while cron occurrences are wall-clock
+// instants. A machine or VM suspension advances the latter but not the former, so a
+// single day-long timer would resume still holding almost its full delay and fire late
+// by the suspension. There is no portable in-process resume callback to correct that;
+// periodically re-checking the wall clock is the only reliable mechanism.
+//
+// One minute bounds resumed-host convergence while keeping the idle cost modest: each
+// enabled job wakes once per minute (30 jobs are 30 wake-ups/minute, or 43,200/day).
+// An intermediate wake-up only re-arms the immutable occurrence below; it never fires
+// early, because the callback dispatches only after the wall clock reaches nextFire.
+const maxArmMs = 60 * 1000
 
 export function createScheduler({
   jobs,
@@ -119,7 +127,7 @@ export function createScheduler({
         fire(live)
         scheduleNext(id)
       },
-      Math.min(delay, maxTimeoutMs),
+      Math.min(delay, maxArmMs),
     )
     handles.set(id, handle)
   }


### PR DESCRIPTION
## Background

Cron occurrences are wall-clock instants, but a process timer counts down against a monotonic clock. On one macOS host running a container VM, every daily cron job fired exactly 42 minutes late on one date, matching that host's overnight sleep window. Jobs whose useful wall-clock window was narrower than the drift produced nothing useful, so the failure was silent rather than loud.

PR #1416 established the machinery this change relies on in two steps. `bdce215f` introduced long-delay clamping and re-arming; `8f20ce0d` then extracted `arm(id, nextFire)` so intermediate callbacks retain an immutable captured occurrence instead of calling `scheduleNext(id)` and deriving a new one. That second step makes a one-minute cap safe: frequent intermediate wake-ups continue to target the same occurrence, including after a backward wall-clock adjustment.

## Summary

- Bound each scheduler timer arm to one minute.
- Keep re-arming toward the same captured occurrence until wall time reaches it; intermediate wake-ups never dispatch early.
- Extend the fake clock with separate wall and monotonic time so tests can model a suspension accurately.
- Add regression coverage for suspended timers, no-early dispatch, and backward wall-clock adjustments.

### Why this resolves the failure

There is no portable in-process resume callback for a suspended host or VM. Polling the wall clock is the available correction mechanism. A one-minute arm means a resumed runtime re-checks the remaining delay within one minute rather than retaining a full day-long arm; it then either re-arms the immutable occurrence or fires only after that occurrence's wall-clock instant.

The cost is one timer wake-up per enabled job per minute. For 30 enabled jobs, that is 30 wake-ups per minute, or 43,200 wake-ups per day.

## Alternatives considered

- **A shared heartbeat that re-arms every job:** rejected because it centralizes independent job timing in another scheduler and wakes all enabled jobs even when only one needs checking; the existing per-job handle lifecycle already gives `stop()` and `replaceJobs()` precise cancellation.
- **Comparing expected and actual elapsed time to detect wall-clock drift:** rejected because it still needs a wake-up to observe the difference, adds clock-baseline state, and cannot correct a process that remains suspended.
- **A configurable cadence:** rejected because this is a correctness bound, not an operator policy surface. A fixed, conservative cadence avoids schema/config/reload semantics and prevents a configuration from reintroducing unbounded drift.
- **Keeping `2 ** 31 - 1` and reacting to an explicit resume signal:** rejected because there is no portable in-process resume signal across hosts and VMs; any fallback would still need bounded polling.
- **OS-level suspend inhibition outside the process:** rejected because cron must remain correct when the host or VM is suspended for reasons the process cannot control.

One minute is deliberately between the nearby extremes. One or ten seconds multiply idle wake-ups without materially improving useful post-resume convergence; five minutes leaves a narrow-window job up to five minutes late. At 30 enabled jobs, the chosen bound remains 30 wake-ups per minute, or 43,200 per day.

## What this does NOT do

- Does not add suspend detection, persistence, a background worker, or a new configuration surface.
- Does not change cron parsing, time zones, missed-tick behavior, overlap behavior, count semantics, or `until` handling.
- Does not dispatch a future occurrence during an intermediate cadence wake-up.

## Review notes

The former Node overflow clamp is subsumed by the one-minute arm bound, so there is only one operative timer limit. The captured `nextFire` remains immutable across re-arms, preserving the #1416 invariant through both forward and backward wall-clock changes.

## Related prior art

Cron non-fires have historically been difficult to attribute: #1161 fixed an expired `until` that rejected an entire cron file and silently stopped every job, including plugin crons; #723 fixed the same whole-file failure mode for a past `at`; and #1402 was opened for a suspected in-flight wedge before its author retracted it after host logs showed cron had fired normally. This change does not address those defects, but bounded wall-clock re-checks remove suspension drift from the candidate explanations when a job next appears not to have run.

## Verification

- `bun test --parallel src/cron/` — 196 pass, 0 fail.
- `bun run typecheck` — passed.
- `bun run lint` — passed with 70 pre-existing warnings and 0 errors.
- `bun run format:check` — passed.
- Full upstream gate after the commit: `bun run check` — passed; `bun run test` — 13,540 pass, 32 skip, 0 fail.
- Temporarily restored the old `2 ** 31 - 1` arm bound and ran `bun test --parallel src/cron/scheduler.test.ts --test-name-pattern 'converges on a captured occurrence after a suspended timer'` — failed as expected: `expect(received).toEqual(expected)`, expected `[1767225900000]`, received `[1767226020000]`.
