### PR TITLE
memory: exclude vector cache from snapshots

### DIFF
--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -1463,6 +1463,37 @@ describe('commitMemorySnapshot', () => {
     expect(await porcelainStatus(agentDir)).toBe('')
   })
 
+  test('force-adds ignored memory artifacts but excludes the rebuildable vector cache', async () => {
+    await initRepo(agentDir)
+    await writeFile(streamFile('2026-04-27'), 'fragment\n')
+    const vectorDir = join(agentDir, 'memory', '.vectors')
+    await mkdir(vectorDir, { recursive: true })
+    await writeFile(join(vectorDir, 'index.db'), 'sqlite cache')
+    await writeFile(join(vectorDir, 'index.db-wal'), 'wal sidecar')
+    await writeFile(join(vectorDir, 'index.db-shm'), 'shm sidecar')
+
+    await commitMemorySnapshot(agentDir)
+
+    expect(await trackedFiles(agentDir)).toEqual(['memory/streams/2026-04-27.jsonl'])
+    expect(await skipWorktreeFiles(agentDir)).toEqual(['memory/streams/2026-04-27.jsonl'])
+    expect(await porcelainStatus(agentDir)).toBe('')
+  })
+
+  test('does not commit a snapshot when only the rebuildable vector cache exists', async () => {
+    await initRepo(agentDir)
+    const vectorDir = join(agentDir, 'memory', '.vectors')
+    await mkdir(vectorDir, { recursive: true })
+    await writeFile(join(vectorDir, 'index.db'), 'sqlite cache')
+    await writeFile(join(vectorDir, 'index.db-wal'), 'wal sidecar')
+    await writeFile(join(vectorDir, 'index.db-shm'), 'shm sidecar')
+
+    await commitMemorySnapshot(agentDir)
+
+    expect(await trackedFiles(agentDir)).toEqual([])
+    expect(await lastCommitSubject(agentDir)).toBe('init')
+    expect(await porcelainStatus(agentDir)).toBe('')
+  })
+
   test('subsequent edits to tracked memory files do not appear in git status', async () => {
     await initRepo(agentDir)
     await writeFile(join(agentDir, 'MEMORY.md'), '# Memory\n')

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { z } from 'zod'
 
@@ -33,6 +33,7 @@ import { loadAllReferences, type Reference } from './references/load-references'
 import { captureShardSnapshot, restoreShardSnapshot } from './shard-snapshot'
 import type { StreamEvent } from './stream-events'
 import { readEvents, writeEventsAtomic } from './stream-io'
+import { VECTOR_INDEX_REL_PATH } from './vector/doctor'
 import { embed, EMBEDDING_MODEL_ID } from './vector/embedder'
 import type { EmbedFn } from './vector/hybrid'
 import { topicPassage } from './vector/passages'
@@ -734,7 +735,17 @@ function isEnoent(err: unknown): boolean {
   return typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT'
 }
 
-const SNAPSHOT_PATHS = ['memory/'] as const
+// The vector index is generated, rebuildable cache state, not durable memory.
+// Keep force-adding the broad memory/ root so new durable artifact types are
+// snapshotted automatically, while Git's exclusion pathspec keeps the SQLite
+// DB and its WAL/SHM sidecars out of history.
+const EXCLUDE_PATHSPEC_PREFIX = ':(exclude)'
+const VECTOR_INDEX_DIRECTORY_REL_PATH = dirname(VECTOR_INDEX_REL_PATH)
+const SNAPSHOT_PATHS = ['memory/', `${EXCLUDE_PATHSPEC_PREFIX}${VECTOR_INDEX_DIRECTORY_REL_PATH}/`] as const
+
+function isSnapshotExclusionPathspec(pathspec: string): boolean {
+  return pathspec.startsWith(EXCLUDE_PATHSPEC_PREFIX)
+}
 
 async function ensureMemoryFiles(agentDir: string): Promise<void> {
   const memoryDir = join(agentDir, 'memory')
@@ -767,10 +778,14 @@ async function commitMemorySnapshotUnlocked(cwd: string): Promise<void> {
 
   await clearSkipWorktree(bun, cwd, repo)
 
-  // `git add -- foo bar/` fails with exit 128 if any pathspec matches no
-  // path on disk. Filter to existing paths before passing them in.
-  const presentPaths = SNAPSHOT_PATHS.filter((p) => existsSync(join(cwd, p)))
-  if (presentPaths.length === 0) {
+  // `git add -- foo bar/` fails with exit 128 if any ordinary pathspec matches
+  // no path on disk. Keep exclusion pathspecs: they are Git syntax rather than
+  // filesystem paths, and must accompany the broad memory/ root everywhere it
+  // flows. Still return early when no ordinary root is present, so an exclusion
+  // by itself never reaches `git add`.
+  const presentPaths = SNAPSHOT_PATHS.filter((p) => isSnapshotExclusionPathspec(p) || existsSync(join(cwd, p)))
+  const hasPresentSnapshotRoot = presentPaths.some((p) => !isSnapshotExclusionPathspec(p))
+  if (!hasPresentSnapshotRoot) {
     await applySkipWorktree(bun, cwd, repo)
     return
   }


### PR DESCRIPTION
## Background

`commitMemorySnapshot` force-adds `memory/` because durable memory artifacts are intentionally gitignored during normal operation. That broad path also force-added `memory/.vectors/`, including the SQLite index and its WAL/SHM sidecars, even when an operator chose to ignore that cache.

Merged PR #800 described the vector database as covered by the existing memory snapshot. Merged PR #809 classifies that same index as generated runtime state: its doctor fix reports no changed paths and removes corrupt state so startup can rebuild it. Those positions conflict. This change follows #809's rebuildable-state classification.

This is also established snapshot-path practice rather than a novel narrowing: commit `26282acf` removed `MEMORY.md` from `SNAPSHOT_PATHS` when it stopped being durable snapshot content, leaving the broad `memory/` root. This change keeps that root and removes only another non-durable member from its capture.

## Summary

- Exclude `memory/.vectors/` from memory snapshot pathspecs while continuing to force-add the broad `memory/` root.
- Derive the excluded directory from `VECTOR_INDEX_REL_PATH`, the existing index-file source of truth.
- Keep the exclusion through staging, staged-file enumeration, and skip-worktree bookkeeping.
- Add regression coverage for ignored durable memory artifacts, vector DB/WAL/SHM exclusion, and the vector-cache-only no-commit case.

### Why this resolves the failure

The snapshot still force-adds all current and future durable artifacts below `memory/`, including artifacts an operator intentionally gitignored. Git's `:(exclude)` pathspec removes only the derived vector-cache subtree from that broad capture, so the generated SQLite index and its sidecars no longer churn or bloat history.

An allowlist of known durable subdirectories was deliberately rejected: it would silently omit any new memory artifact a future release adds. The broad root plus one derived-cache exclusion preserves forward compatibility without giving the rebuildable cache a second path definition.

## What this does NOT do

- It does not change vector indexing, retrieval, dreaming, or doctor behavior.
- It does not add configuration or alter an operator's general git-ignore policy.
- It does not relocate the existing `memory/.vectors/` on-disk location or remove vector-index files already present in existing agent-folder history.

## Review notes

The `presentPaths` existence filter retains exclusion pathspecs because they are Git syntax rather than filesystem paths. It still returns early unless an ordinary root is present, preventing an exclusion-only `git add` invocation. The same pathspec list scopes `git add -f`, `git diff --cached --name-only`, and tracked-file lookup, so the exclusion governs staging, commit enumeration, and skip-worktree bookkeeping together.

That placement follows merged PR #1424 (`backup: reconcile vanished untracked snapshot paths`): explicit pathspecs are the concurrency boundary. That PR rejected `git add -A` and a fresh status read because either could acquire paths created after the original snapshot, and rejected filtering every absent path because tracked deletions and rename sources are correctly absent on disk. Here, a post-hoc unstage or status re-read would similarly make the snapshot's staged set depend on a second operation; placing the exclusion in the original pathspec list keeps every consumer aligned and preserves the existing protection against exit-128 failures when ordinary pathspecs match nothing.

This exclusion is complete, not partial. The backup runner's only two `git add -f` call sites receive paths selected from `git status --porcelain --untracked-files=all`; its force prefixes are only `sessions/` and `todo/`, and it separately excludes runtime-owned `memory/` paths from ordinary staging. Gitignored `memory/.vectors/` never appears in that status output. Dreaming is therefore the only path that force-adds the cache by a directory pathspec.

Alternatives considered:

- **An operator-configured snapshot-path surface:** rejected because the durable/rebuildable classification is runtime ownership, not a per-agent preference; it would add schema and policy surface without repairing the unsafe default.
- **Move `.vectors/` outside `memory/`:** arguably the cleanest eventual layout, but it breaks an existing on-disk location and requires migration. `VECTOR_INDEX_REL_PATH` currently has four usage sites in `vector/doctor.ts` (plus its declaration), so this would be a broader vector-module change than this targeted snapshot fix.
- **Stage broadly, then unstage the cache:** rejected because the exclusion would not constrain every snapshot-path consumer and would introduce a second index mutation after staging.
- **Drop `-f` and defer entirely to `.gitignore`:** rejected because it would stop snapshotting the durable memory artifacts the runtime intentionally force-adds.

## Verification

- `bun test --parallel src/bundled-plugins/memory/dreaming.test.ts` — 95 pass, 0 fail.
- Temporarily restored the prior `SNAPSHOT_PATHS = ['memory/']` behavior and ran the new regression: it failed because `memory/.vectors/index.db`, `memory/.vectors/index.db-shm`, and `memory/.vectors/index.db-wal` were tracked. Restored the fix afterward.
- `bun run typecheck` — passed.
- `bun run lint` — passed with 70 pre-existing warnings and 0 errors.
- `bun run format:check` — passed.
- `bun test --parallel src/bundled-plugins/memory/` — 943 pass, 0 fail.
- Full upstream gate after the commit: `bun run check` — passed; `bun run test` — 13,541 pass, 32 skip, 0 fail.
